### PR TITLE
Fix: small updates to example test file names

### DIFF
--- a/src/examples/source/GCMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/GCMS_FullScan_Unknown_test.cpp
@@ -21,7 +21,7 @@ void test_main_GCMS_FullScan_Unknown()
 
   OpenMSFile::loadFeatureMap(
     rawDataHandler,
-    SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns/features/GCMS_FullScan.featureXML")
+    SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns/features/GCMS_FullScan_1_BatchName_1900-01-01_000000.featureXML")
   );
 
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();

--- a/src/examples/source/GCMS_SIM_Unknown_test.cpp
+++ b/src/examples/source/GCMS_SIM_Unknown_test.cpp
@@ -21,7 +21,7 @@ void test_main_GCMS_SIM_Unknown()
 
   OpenMSFile::loadFeatureMap(
     rawDataHandler,
-    SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns/features/GCMS_SIM.featureXML")
+    SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns/features/GCMS_SIM_1_BatchName_1900-01-01_000000.featureXML")
   );
 
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();

--- a/src/examples/source/HPLC_UV_Standards_test.cpp
+++ b/src/examples/source/HPLC_UV_Standards_test.cpp
@@ -21,7 +21,7 @@ void test_main_HPLC_UV_Standards()
 
   OpenMSFile::loadFeatureMap(
     rawDataHandler,
-    SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards/features/100ug_8_BatchName_1900-01-00_000000.featureXML")
+    SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards/features/100ug_8_BatchName_1900-01-01_000000.featureXML")
   );
 
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();

--- a/src/examples/source/HPLC_UV_Unknown_test.cpp
+++ b/src/examples/source/HPLC_UV_Unknown_test.cpp
@@ -21,7 +21,7 @@ void test_main_HPLC_UV_Unknown()
 
   OpenMSFile::loadFeatureMap(
     rawDataHandler,
-    SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns/features/20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2_1_BatchName_1900-01-00_000000.featureXML")
+    SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns/features/20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2_1_BatchName_1900-01-01_000000.featureXML")
   );
 
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();

--- a/src/examples/source/LCMS_MRM_QCs_test.cpp
+++ b/src/examples/source/LCMS_MRM_QCs_test.cpp
@@ -21,7 +21,7 @@ void test_main_LCMS_MRM_QCs()
 
   OpenMSFile::loadFeatureMap(
     rawDataHandler,
-    SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs/features/150601_0_BloodProject01_PLT_QC_Broth-1.featureXML")
+    SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs/features/150601_0_BloodProject01_PLT_QC_Broth-1_1_BatchName_1900-01-01_000000.featureXML")
   );
 
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();

--- a/src/examples/source/LCMS_MRM_Standards_test.cpp
+++ b/src/examples/source/LCMS_MRM_Standards_test.cpp
@@ -21,7 +21,7 @@ void test_main_LCMS_MRM_Standards()
 
   OpenMSFile::loadFeatureMap(
     rawDataHandler,
-    SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards/features/150516_CM1_Level1_1_BatchName_1900-01-00_000000.featureXML")
+    SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards/features/150516_CM1_Level1_1_BatchName_1900-01-01_000000.featureXML")
   );
 
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();

--- a/src/examples/source/LCMS_MRM_Unknown_test.cpp
+++ b/src/examples/source/LCMS_MRM_Unknown_test.cpp
@@ -21,7 +21,7 @@ void test_main_LCMS_MRM_Unknown()
 
   OpenMSFile::loadFeatureMap(
     rawDataHandler,
-    SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/features/170808_Jonathan_yeast_Sacc1_1x_1_BatchName_1900-01-00_000000.featureXML")
+    SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/features/170808_Jonathan_yeast_Sacc1_1x_1_BatchName_1900-01-01_000000.featureXML")
   );
 
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();


### PR DESCRIPTION
Updated the names of the example test files to account for the new default metadata `acquisition_date_and_time` attribute.