### PR TITLE
Feat:  parallel processing of `processSequence` execution

### DIFF
--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
@@ -59,7 +59,7 @@ public:
 
     static bool processSequence_(
       InjectionHandler* injection,
-      const std::vector<RawDataProcessor*>& raw_data_processing_methods_I,
+      const std::vector<RawDataProcessor*>* raw_data_processing_methods_I,
       const Filenames* filenames,
       const bool verbose_I = false);
 


### PR DESCRIPTION
### Synopsis
Added parallel execution support for `processSequence` using the `threads` library

### Changes
- static method for calling the asynchronous execution of the main `processSequence` method
- use of `std::packaged_task` and `std::future` to execute asynchronously

### TODO
- further investigate memory leaks
- add an option for using multiple cores