### PR TITLE
fix: precautionary clear of sequence handler

### DIFF
--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -37,6 +37,7 @@ namespace SmartPeak
       return;
     }
 
+    sequenceHandler.clear(); // start with an empty sequence handler
     const std::string s_sample_name {"sample_name"};
     const std::string s_sample_group_name {"sample_group_name"};
     const std::string s_sequence_segment_name {"sequence_segment_name"};


### PR DESCRIPTION
### changes
- added a call to sequenceHandler::clear prior to reading in a new sequence file