### PR TITLE
style: simpler formatter for logging in the terminal

### DIFF
--- a/src/examples/source/CommandLine.cpp
+++ b/src/examples/source/CommandLine.cpp
@@ -1328,8 +1328,8 @@ public:
         ss << t.tm_year + 1900 << "-" << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mon + 1 << PLOG_NSTR("-") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_mday << PLOG_NSTR(" ");
         ss << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_hour << PLOG_NSTR(":") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_min << PLOG_NSTR(":") << std::setfill(PLOG_NSTR('0')) << std::setw(2) << t.tm_sec << PLOG_NSTR(" ");
         ss << std::setfill(PLOG_NSTR(' ')) << std::setw(5) << std::left << severityToString(record.getSeverity()) << PLOG_NSTR(" ");
-        ss << PLOG_NSTR("[") << record.getTid() << PLOG_NSTR("] ");
-        ss << record.getMessage() << PLOG_NSTR("\n");
+        // ss << PLOG_NSTR("[") << record.getTid() << PLOG_NSTR("] ");
+        ss << PLOG_NSTR("\n") << record.getMessage() << PLOG_NSTR("\n");
 
         return ss.str();
       }


### PR DESCRIPTION
Since I moved most of the `std::cout` to `LOG` macros, the terminal became harder to read.
Plog supports custom formatters, and I took inspiration from `TxtFormatter` to create `ConsoleFormatter`.

Preview: (please see more description after the dump of text)
```
➜  SmartPeak2_build bin/CommandLine
2019-05-02 13:24:40 NONE  [10738] 

Welcome to SmartPeak

Load an existing session from a sequence file
`File -> Load session from sequence`
`Edit -> Workflow ->"1 2"` then `Actions->Run workflow` to load the raw data and associated features

Get quick information about the current application state
`Actions -> Quick Info`

Check the integrity of loaded data
`Actions -> Check data integrity`

Run a workflow
`Edit -> Workflow -> your_commands_here`
`Actions -> Run workflow`

Save workflow results
`Edit -> Workflow`, input `9` to select `Store features`
`Actions -> Run workflow`

Report workflow results
`Actions -> Report`

See this introductory tutorial again
`Help -> Getting started`

2019-05-02 13:24:40 NONE  [10738] 

Main
[1] File
[2] Edit
[3] View
[4] Actions
[5] Help


> 1
2019-05-02 13:24:44 DEBUG [10738] Input line: 1
2019-05-02 13:24:44 NONE  [10738] 

Main > File
[1] New session
[2] Load session
[3] Load session from sequence
[4] Save session
[5] Import file
[6] Export file
[M] Main menu
[E] Exit


> 3
2019-05-02 13:24:49 DEBUG [10738] Input line: 3
2019-05-02 13:24:49 NONE  [10738] 

Set the sequence file pathname.

2019-05-02 13:24:49 NONE  [10738] 

Example:
> /home/pasdom/SmartPeak2/src/examples/data/HPLC_UV_Standards/sequence.csv


2019-05-02 13:24:49 NONE  [10738] 

Enter the absolute pathname:

> m
2019-05-02 13:24:59 DEBUG [10738] Input line: m
2019-05-02 13:24:59 ERROR [10738] 

The file does not exist. Try again.

>
```

Worth the merge, or do you prefer to keep `TxtFormatter`? Or change this to show different info?