### PR TITLE
[feat/aut177] Allow for resizing the GUI bottom, left and upper panes

### DIFF
--- a/src/examples/source/GUI.cpp
+++ b/src/examples/source/GUI.cpp
@@ -645,7 +645,6 @@ int main(int argc, char **argv)
       ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0);
       const ImGuiWindowFlags left_window_flags =
         ImGuiWindowFlags_NoTitleBar |
-        ImGuiWindowFlags_NoResize |
         ImGuiWindowFlags_NoMove |
         ImGuiWindowFlags_NoCollapse |
         ImGuiWindowFlags_NoFocusOnAppearing;
@@ -692,6 +691,8 @@ int main(int argc, char **argv)
         }
         ImGui::EndTabBar();
       }
+      win_size_and_pos.setLeftWindowXSize(ImGui::GetWindowWidth());
+      win_size_and_pos.setWindowSizesAndPositions(show_top_window_, show_bottom_window_, show_left_window_, show_right_window_);
       ImGui::End();
       ImGui::PopStyleVar();
     }
@@ -704,7 +705,6 @@ int main(int argc, char **argv)
       ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0);
       const ImGuiWindowFlags top_window_flags =
         ImGuiWindowFlags_NoTitleBar |
-        ImGuiWindowFlags_NoResize |
         ImGuiWindowFlags_NoMove |
         ImGuiWindowFlags_NoCollapse |
         ImGuiWindowFlags_NoFocusOnAppearing;
@@ -999,6 +999,9 @@ int main(int argc, char **argv)
         }
         ImGui::EndTabBar();
       }
+      win_size_and_pos.setTopWindowYSize(ImGui::GetWindowHeight());
+      win_size_and_pos.setLeftWindowXSize(ImGui::GetWindowPos().x);
+      win_size_and_pos.setWindowSizesAndPositions(show_top_window_, show_bottom_window_, show_left_window_, show_right_window_);
       ImGui::End();
       ImGui::PopStyleVar();
     }

--- a/src/smartpeak/include/SmartPeak/ui/WindowSizesAndPositions.h
+++ b/src/smartpeak/include/SmartPeak/ui/WindowSizesAndPositions.h
@@ -7,6 +7,9 @@ namespace SmartPeak
     void setWindowPercentages(const float& bottom_window_y_perc, const float& left_window_x_perc, const float& right_window_x_perc);
     void setWindowSizesAndPositions_(const float& bottom_window_y_perc, const float& left_window_x_perc, const float& right_window_x_perc);
     void setWindowSizesAndPositions(const bool& show_top_window, const bool& show_bottom_window, const bool& show_left_window, const bool& show_right_window);
+    void setLeftWindowXSize(const float& left_window_x_size);
+    void setTopWindowYSize(const float& top_window_y_size);
+
     // Absolute application size
     float main_menu_bar_y_size_ = 18.0f;
     float y_size_ = 0;

--- a/src/smartpeak/source/ui/WindowSizesAndPositions.cpp
+++ b/src/smartpeak/source/ui/WindowSizesAndPositions.cpp
@@ -12,6 +12,12 @@ namespace SmartPeak
     right_window_x_perc_ = right_window_x_perc;
     // TODO: check that the percentages equal 1
   }
+  void WindowSizesAndPositions::setLeftWindowXSize(const float& left_window_x_size) {
+    left_window_x_perc_ = left_window_x_size / x_size_;
+  }
+  void WindowSizesAndPositions::setTopWindowYSize(const float& top_window_y_size) {
+    bottom_window_y_perc_ = 1 - (top_window_y_size / y_size_);
+  }
   void WindowSizesAndPositions::setWindowSizesAndPositions_(const float& bottom_window_y_perc, const float& left_window_x_perc, const float& right_window_x_perc) {
     // Absolute sizes
     bottom_window_y_size_ = bottom_window_y_perc * y_size_;

--- a/src/tests/class_tests/smartpeak/source/WindowSizesAndPositions_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/WindowSizesAndPositions_test.cpp
@@ -52,6 +52,46 @@ BOOST_AUTO_TEST_CASE(setXAndYSizes)
   BOOST_CHECK_CLOSE(win_size_and_pos.x_size_, 10, 1e-3);
 }
 
+BOOST_AUTO_TEST_CASE(setLeftWindowXSize)
+{
+  WindowSizesAndPositions win_size_and_pos;
+  win_size_and_pos.setXAndYSizes(100, 100);
+  win_size_and_pos.setLeftWindowXSize(10);
+  win_size_and_pos.setWindowSizesAndPositions(true, true, true, false);
+  BOOST_CHECK_CLOSE(win_size_and_pos.bottom_window_y_size_, 20.5 , 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.top_window_y_size_, 61.5, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.bottom_and_top_window_x_size_, 90, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.left_and_right_window_y_size_, 82, 1e-3); //
+  BOOST_CHECK_CLOSE(win_size_and_pos.left_window_x_size_, 10, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.right_window_x_size_, 0, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.bottom_window_y_pos_, 79.5, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.top_window_y_pos_, 18, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.bottom_and_top_window_x_pos_, 10, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.left_and_right_window_y_pos_, 18, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.left_window_x_pos_, 0, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.right_window_x_pos_, 100, 1e-3);
+}
+
+BOOST_AUTO_TEST_CASE(setTopWindowYSize)
+{
+  WindowSizesAndPositions win_size_and_pos;
+  win_size_and_pos.setXAndYSizes(100, 100);
+  win_size_and_pos.setTopWindowYSize(10);
+  win_size_and_pos.setWindowSizesAndPositions(true, true, true, false);
+  BOOST_CHECK_CLOSE(win_size_and_pos.bottom_window_y_size_, 72, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.top_window_y_size_, 10, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.bottom_and_top_window_x_size_, 75, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.left_and_right_window_y_size_, 82, 1e-3); //
+  BOOST_CHECK_CLOSE(win_size_and_pos.left_window_x_size_, 25, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.right_window_x_size_, 0, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.bottom_window_y_pos_, 28, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.top_window_y_pos_, 18, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.bottom_and_top_window_x_pos_, 25, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.left_and_right_window_y_pos_, 18, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.left_window_x_pos_, 0, 1e-3);
+  BOOST_CHECK_CLOSE(win_size_and_pos.right_window_x_pos_, 100, 1e-3);
+}
+
 BOOST_AUTO_TEST_CASE(setWindowPercentages)
 {
   WindowSizesAndPositions win_size_and_pos;


### PR DESCRIPTION
With this modification, it's now possible to resize the left, the bottom and top panels.
I played a little bit with the limitations of imgui. 
The counterpart is some icons appear on the bottom right side of resizable windows, and there are some minor artefacts. Overall, it seems better than before.

To get a better result, the best would to modify imgui to have some flags allowing to resize only some side of the window (for example, left only). Or maybe another way to handle the windowing along with imgui, but it is out of scope for the moment, I think.

![image](https://user-images.githubusercontent.com/1705849/103783865-8898b800-5039-11eb-9158-8b57e0d7f109.png)
