### PR TITLE
Feat/aut700 - Advanced plotting

### DIFF
--- a/src/examples/source/GUI.cpp
+++ b/src/examples/source/GUI.cpp
@@ -101,12 +101,14 @@ int main(int argc, char **argv)
   bool show_chromatogram_legend = true;
   float chromatogram_slider_min = 0.0f;
   float chromatogram_slider_max = 0.0f;
+  bool chromatogram_compact_view = true;
 
   // Spectra display option
   bool spectra_initialized = false;
   bool show_spectra_legend = true;
   float spectra_slider_min = 0.0f;
   float spectra_slider_max = 0.0f;
+  bool spectra_compact_view = true;
 
   // Popup modals
   bool popup_about_ = false;
@@ -967,7 +969,7 @@ int main(int argc, char **argv)
             session_handler_.chrom_x_axis_title, session_handler_.chrom_y_axis_title,
             session_handler_.chrom_time_range.first, session_handler_.chrom_time_range.second, session_handler_.chrom_intensity_min, session_handler_.chrom_intensity_max,
             win_size_and_pos.bottom_and_top_window_x_size_, win_size_and_pos.top_window_y_size_,
-            "Chromatograms Main Window", show_chromatogram_legend, chromatogram_slider_min, chromatogram_slider_max);
+            "Chromatograms Main Window", show_chromatogram_legend, chromatogram_slider_min, chromatogram_slider_max, chromatogram_compact_view);
           plot2d.draw();
           ImGui::EndTabItem();
         }
@@ -1000,7 +1002,7 @@ int main(int argc, char **argv)
             session_handler_.spec_x_axis_title, session_handler_.spec_y_axis_title,
             session_handler_.spec_mz_range.first, session_handler_.spec_mz_range.second, session_handler_.spec_intensity_min, session_handler_.spec_intensity_max,
             win_size_and_pos.bottom_and_top_window_x_size_, win_size_and_pos.top_window_y_size_, 
-            "Spectra Main Window", show_spectra_legend, spectra_slider_min, spectra_slider_max);
+            "Spectra Main Window", show_spectra_legend, spectra_slider_min, spectra_slider_max, spectra_compact_view);
           plot2d.draw();
           ImGui::EndTabItem();
         }

--- a/src/examples/source/GUI.cpp
+++ b/src/examples/source/GUI.cpp
@@ -96,6 +96,18 @@ int main(int argc, char **argv)
   bool show_feature_heatmap_plot = false; // injection vs. feature for a particular metavalue
   bool show_calibrators_line_plot = false; // peak area/height ratio vs. concentration ratio
 
+  // Chromatogram display option
+  bool chromatogram_initialized = false;
+  bool show_chromatogram_legend = true;
+  float chromatogram_slider_min = 0.0f;
+  float chromatogram_slider_max = 0.0f;
+
+  // Spectra display option
+  bool spectra_initialized = false;
+  bool show_spectra_legend = true;
+  float spectra_slider_min = 0.0f;
+  float spectra_slider_max = 0.0f;
+
   // Popup modals
   bool popup_about_ = false;
   bool popup_run_workflow_ = false;
@@ -929,36 +941,66 @@ int main(int argc, char **argv)
         if (show_chromatogram_line_plot && ImGui::BeginTabItem("Chromatograms", &show_chromatogram_line_plot))
         {
           // Filter for the position
-          const ImGuiSliderFlags slider_flags = ImGuiSliderFlags_Logarithmic;
-          session_handler_.setMinimalDataAndFilters(application_handler_.sequenceHandler_);
-          ImGui::SliderFloat("min time (sec)", &session_handler_.chrom_time_range.first, 0.0f, session_handler_.chrom_time_range.second, "%.4f", slider_flags);
-          ImGui::SliderFloat("max time (sec)", &session_handler_.chrom_time_range.second, session_handler_.chrom_time_range.first, 2000.0f, "%.4f", slider_flags);
-
+          if (!workflow_is_done_)
+          {
+            chromatogram_initialized = false;
+          }
+          else // workflow_is_done_
+          {
+            if (!chromatogram_initialized)
+            {
+              session_handler_.setMinimalDataAndFilters(application_handler_.sequenceHandler_);
+              session_handler_.resetChromatogramRange();
+            }
+            exceeding_plot_points_ = !session_handler_.setChromatogramScatterPlot(application_handler_.sequenceHandler_);
+            if (!chromatogram_initialized)
+            {
+              // Get min and max for the sliders, adjust range to initial value
+              session_handler_.chrom_time_range.first = chromatogram_slider_min = session_handler_.chrom_time_min;
+              session_handler_.chrom_time_range.second = chromatogram_slider_max = session_handler_.chrom_time_max;
+              chromatogram_initialized = true;
+            }
+          }
           // The actual plot
-          exceeding_plot_points_ = !session_handler_.setChromatogramScatterPlot(application_handler_.sequenceHandler_);
           ChromatogramPlotWidget plot2d(session_handler_.chrom_time_raw_data, session_handler_.chrom_intensity_raw_data, session_handler_.chrom_series_raw_names,
             session_handler_.chrom_time_hull_data, session_handler_.chrom_intensity_hull_data, session_handler_.chrom_series_hull_names,
             session_handler_.chrom_x_axis_title, session_handler_.chrom_y_axis_title,
-            session_handler_.chrom_time_min, session_handler_.chrom_time_max, session_handler_.chrom_intensity_min, session_handler_.chrom_intensity_max,
-            win_size_and_pos.bottom_and_top_window_x_size_, win_size_and_pos.top_window_y_size_ - 20, "Chromatograms Main Window");
+            session_handler_.chrom_time_range.first, session_handler_.chrom_time_range.second, session_handler_.chrom_intensity_min, session_handler_.chrom_intensity_max,
+            win_size_and_pos.bottom_and_top_window_x_size_, win_size_and_pos.top_window_y_size_,
+            "Chromatograms Main Window", show_chromatogram_legend, chromatogram_slider_min, chromatogram_slider_max);
           plot2d.draw();
           ImGui::EndTabItem();
         }
         if (show_spectra_line_plot && ImGui::BeginTabItem("Spectra", &show_spectra_line_plot))
         {
           // Filter for the position
-          const ImGuiSliderFlags slider_flags = ImGuiSliderFlags_Logarithmic;
-          session_handler_.setMinimalDataAndFilters(application_handler_.sequenceHandler_);
-          ImGui::SliderFloat("min m/z (Da)", &session_handler_.spec_mz_range.first, 0.0f, session_handler_.spec_mz_range.second, "%.4f", slider_flags);
-          ImGui::SliderFloat("max m/z (Da)", &session_handler_.spec_mz_range.second, session_handler_.spec_mz_range.first, 2000.0f, "%.4f", slider_flags);
-
+          if (!workflow_is_done_)
+          {
+            spectra_initialized = false;
+          }
+          else // workflow_is_done_
+          {
+            if (!spectra_initialized)
+            {
+              session_handler_.setMinimalDataAndFilters(application_handler_.sequenceHandler_);
+              session_handler_.resetSpectrumRange();
+            }
+            exceeding_plot_points_ = !session_handler_.setSpectrumScatterPlot(application_handler_.sequenceHandler_);
+            if (!spectra_initialized)
+            {
+              // Get min and max for the sliders, adjust range to initial value
+              session_handler_.spec_mz_range.first =  spectra_slider_min = session_handler_.spec_mz_min;
+              session_handler_.spec_mz_range.second = spectra_slider_max = session_handler_.spec_mz_max;
+              spectra_initialized = true;
+            }
+          }
           // The actual plot
-          exceeding_plot_points_ = !session_handler_.setSpectrumScatterPlot(application_handler_.sequenceHandler_);
           ChromatogramPlotWidget plot2d(session_handler_.spec_mz_raw_data, session_handler_.spec_intensity_raw_data, session_handler_.spec_series_raw_names,
             session_handler_.spec_mz_hull_data, session_handler_.spec_intensity_hull_data, session_handler_.spec_series_hull_names,
             session_handler_.spec_x_axis_title, session_handler_.spec_y_axis_title,
-            session_handler_.spec_mz_min, session_handler_.spec_mz_max, session_handler_.spec_intensity_min, session_handler_.spec_intensity_max,
-            win_size_and_pos.bottom_and_top_window_x_size_, win_size_and_pos.top_window_y_size_ - 20, "Spectra Main Window");
+            session_handler_.spec_mz_range.first, session_handler_.spec_mz_range.second, session_handler_.spec_intensity_min, session_handler_.spec_intensity_max,
+            win_size_and_pos.bottom_and_top_window_x_size_, win_size_and_pos.top_window_y_size_, 
+            "Spectra Main Window", show_spectra_legend, spectra_slider_min, spectra_slider_max);
           plot2d.draw();
           ImGui::EndTabItem();
         }

--- a/src/smartpeak/include/SmartPeak/core/SessionHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/SessionHandler.h
@@ -69,6 +69,10 @@ namespace SmartPeak
     */
     bool setChromatogramScatterPlot(const SequenceHandler& sequence_handler);
     /*
+    @brief reset range to large enough value in order to parse the chromatogram entirely
+    */
+    void resetChromatogramRange();
+    /*
     @brief Sets the spectrum data
 
     @param[in] sequence_handler
@@ -76,6 +80,10 @@ namespace SmartPeak
     @returns true if all points were added and false if points were omitted due to performance
     */
     bool setSpectrumScatterPlot(const SequenceHandler& sequence_handler);
+    /*
+    @brief reset range to large enough value in order to parse the spectrogram entirely
+    */
+    void resetSpectrumRange();
     void setFeatureLinePlot();
     void setFeatureHeatMap();
     /*
@@ -235,16 +243,20 @@ namespace SmartPeak
     std::vector<std::string> chrom_series_hull_names,chrom_series_raw_names;
     std::string chrom_x_axis_title;
     std::string chrom_y_axis_title;
-    float chrom_time_min, chrom_time_max, chrom_intensity_min, chrom_intensity_max;
-    std::pair<float, float> chrom_time_range = std::make_pair(0, 1800);
+    float chrom_time_min = 0.0f;
+    float chrom_time_max = 0.0f;
+    float chrom_intensity_min, chrom_intensity_max;
+    std::pair<float, float> chrom_time_range;
     // data for the spectrum scatter plot
     std::vector<std::vector<float>> spec_mz_hull_data, spec_intensity_hull_data;
     std::vector<std::vector<float>> spec_mz_raw_data, spec_intensity_raw_data;
     std::vector<std::string> spec_series_hull_names, spec_series_raw_names;
     std::string spec_x_axis_title;
     std::string spec_y_axis_title;
-    float spec_mz_min, spec_mz_max, spec_intensity_min, spec_intensity_max;
-    std::pair<float, float> spec_mz_range = std::make_pair(0, 2000);
+    float spec_mz_min = 0.0f;
+    float spec_mz_max = 0.0f;
+    float spec_intensity_min, spec_intensity_max;
+    std::pair<float, float> spec_mz_range;
     // data for the feature line plot
     Eigen::Tensor<float, 2> feat_sample_data, feat_value_data;
     Eigen::Tensor<std::string, 1> feat_line_series_names;

--- a/src/smartpeak/include/SmartPeak/ui/Widget.h
+++ b/src/smartpeak/include/SmartPeak/ui/Widget.h
@@ -181,13 +181,14 @@ namespace SmartPeak
       const std::vector<std::vector<float>>&x_data_area, const std::vector<std::vector<float>>&y_data_area, const std::vector<std::string>&series_names_area,
       const std::string& x_axis_title, const std::string& y_axis_title, float& x_min, float& x_max, const float& y_min, const float& y_max,
       const float& plot_width, const float& plot_height, const std::string& plot_title, bool& show_legend, 
-      float& range_min, float& range_max) :
+      float& range_min, float& range_max, bool& compact_view) :
       x_data_scatter_(x_data_scatter), y_data_scatter_(y_data_scatter), series_names_scatter_(series_names_scatter),
       x_data_area_(x_data_area), y_data_area_(y_data_area), series_names_area_(series_names_area),
       x_axis_title_(x_axis_title), y_axis_title_(y_axis_title),
       x_min_(x_min), x_max_(x_max), y_min_(y_min), y_max_(y_max), plot_width_(plot_width), plot_height_(plot_height), plot_title_(plot_title),
       show_legend_(show_legend), 
-      range_min_(range_min), range_max_(range_max) {};
+      range_min_(range_min), range_max_(range_max),
+      compact_view_(compact_view){};
     void draw() override;
     const std::vector<std::vector<float>>& x_data_scatter_;
     const std::vector<std::vector<float>>& y_data_scatter_;
@@ -207,6 +208,7 @@ namespace SmartPeak
     bool& show_legend_;
     const float& range_min_; // range for the sliders
     const float& range_max_;
+    bool& compact_view_;
   };
 
   /**

--- a/src/smartpeak/include/SmartPeak/ui/Widget.h
+++ b/src/smartpeak/include/SmartPeak/ui/Widget.h
@@ -179,12 +179,15 @@ namespace SmartPeak
   public:
     ChromatogramPlotWidget(const std::vector<std::vector<float>>&x_data_scatter, const std::vector<std::vector<float>>&y_data_scatter, const std::vector<std::string>&series_names_scatter,
       const std::vector<std::vector<float>>&x_data_area, const std::vector<std::vector<float>>&y_data_area, const std::vector<std::string>&series_names_area,
-      const std::string& x_axis_title, const std::string& y_axis_title, const float& x_min, const float& x_max, const float& y_min, const float& y_max,
-      const float& plot_width, const float& plot_height, const std::string& plot_title) :
+      const std::string& x_axis_title, const std::string& y_axis_title, float& x_min, float& x_max, const float& y_min, const float& y_max,
+      const float& plot_width, const float& plot_height, const std::string& plot_title, bool& show_legend, 
+      float& range_min, float& range_max) :
       x_data_scatter_(x_data_scatter), y_data_scatter_(y_data_scatter), series_names_scatter_(series_names_scatter),
       x_data_area_(x_data_area), y_data_area_(y_data_area), series_names_area_(series_names_area),
       x_axis_title_(x_axis_title), y_axis_title_(y_axis_title),
-      x_min_(x_min), x_max_(x_max), y_min_(y_min), y_max_(y_max), plot_width_(plot_width), plot_height_(plot_height), plot_title_(plot_title) {};
+      x_min_(x_min), x_max_(x_max), y_min_(y_min), y_max_(y_max), plot_width_(plot_width), plot_height_(plot_height), plot_title_(plot_title),
+      show_legend_(show_legend), 
+      range_min_(range_min), range_max_(range_max) {};
     void draw() override;
     const std::vector<std::vector<float>>& x_data_scatter_;
     const std::vector<std::vector<float>>& y_data_scatter_;
@@ -194,13 +197,16 @@ namespace SmartPeak
     const std::vector<std::string>& series_names_area_;
     const std::string& x_axis_title_;
     const std::string& y_axis_title_;
-    const float& x_min_;
-    const float& x_max_;
+    float& x_min_;
+    float& x_max_;
     const float& y_min_;
     const float& y_max_;
     const float& plot_width_;
     const float& plot_height_;
     const std::string plot_title_; // used as the ID of the plot as well so this should be unique across the different Widgets
+    bool& show_legend_;
+    const float& range_min_; // range for the sliders
+    const float& range_max_;
   };
 
   /**

--- a/src/smartpeak/source/core/SessionHandler.cpp
+++ b/src/smartpeak/source/core/SessionHandler.cpp
@@ -1609,6 +1609,10 @@ namespace SmartPeak
       }
     }
   }
+  void SessionHandler::resetChromatogramRange()
+  {
+    chrom_time_range = std::make_pair(0, 1800);
+  }
   bool SessionHandler::setChromatogramScatterPlot(const SequenceHandler & sequence_handler)
   {
     const int MAX_POINTS = 9000; // Maximum number of points before either performance drops considerable or IMGUI throws an error
@@ -1727,6 +1731,10 @@ namespace SmartPeak
     }
     if (n_points < MAX_POINTS) return true;
     else return false;
+  }
+  void SessionHandler::resetSpectrumRange()
+  {
+    spec_mz_range = std::make_pair(0, 2000);
   }
   bool SessionHandler::setSpectrumScatterPlot(const SequenceHandler& sequence_handler)
   {

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -655,6 +655,14 @@ BOOST_AUTO_TEST_CASE(setFeatureMatrix1)
   session_handler.setFeatureMatrix(testData.sequenceHandler);
 }
 
+BOOST_AUTO_TEST_CASE(resetChromatogramRange1)
+{
+  SessionHandler session_handler;
+  session_handler.resetChromatogramRange();
+  BOOST_CHECK_CLOSE(session_handler.chrom_time_range.first, 0.0, 1e-3);
+  BOOST_CHECK_CLOSE(session_handler.chrom_time_range.second, 1800.0, 1e-3);
+}
+
 BOOST_AUTO_TEST_CASE(setChromatogramScatterPlot1)
 {
   TestData testData;
@@ -662,6 +670,13 @@ BOOST_AUTO_TEST_CASE(setChromatogramScatterPlot1)
   session_handler.setChromatogramScatterPlot(testData.sequenceHandler);
 }
 
+BOOST_AUTO_TEST_CASE(resetSpectrumRange1)
+{
+  SessionHandler session_handler;
+  session_handler.resetSpectrumRange();
+  BOOST_CHECK_CLOSE(session_handler.spec_mz_range.first, 0.0, 1e-3);
+  BOOST_CHECK_CLOSE(session_handler.spec_mz_range.second, 2000.0, 1e-3);
+}
 
 BOOST_AUTO_TEST_CASE(setSpectrumScatterPlot1)
 {


### PR DESCRIPTION
- Fixed Sliders
- Disable/Enable legend
- Lines and scatter use the same colors (Compact View)
- More stability to display while running workflow (not fully tested)
- Sliders along with legend checkbox are now part of the chromatogram widget
- Legend is right in order

**compact view**
![image](https://user-images.githubusercontent.com/1705849/104018972-fe785d00-51ba-11eb-9c8e-618b75b7f799.png)

**non compact view**
![image](https://user-images.githubusercontent.com/1705849/104018929-eef91400-51ba-11eb-81e6-57e6fefddb16.png)

It may be worth noticing that with imGUI when you double right-click on the graph, you have some command items available, like hiding legend.

This code sticks with current architecture (only moved some parts in the widget, which I think is better).
however in general we would need to have the widgets as maintained instances that would avoid these statics, not created when we need to draw (and discard after that). It could be another task.

Another point is it would be very convenient to have a more detailed status of the workflow processing (started, not running, finished ...). For example, I had to play with some flags to know that the graph is ready to display. An event based system or at least a more detailed status would help. Maybe it will come when we will implement the workflow progress.