### PR TITLE
Feat/aut294

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -319,6 +319,17 @@ The collection of examples is located at ``src/example/data`` directory of the S
 
 .. begin_gui
 
+Set logging path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Default locations of logs:
+
+- Windows: `C:\\Users\\<user>\\AppData\\Local\\SmartPeak`
+- Linux and MacOS: `~/.SmartPeak`
+
+User can change default location and specify directory where the logs are stored by setting `SMARTPEAK_LOGS` env variable. 
+If directory specified by the path doesn't exist, SmartPeak will create specified directories.
+
+
 Using GUI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/smartpeak/include/SmartPeak/core/Utilities.h
+++ b/src/smartpeak/include/SmartPeak/core/Utilities.h
@@ -309,5 +309,19 @@ public:
       @returns The numbers of elements found
     */
     static size_t directorySize(const std::string& pathname);
+
+    /**
+    * @brief Constructs an absolute filepath to an application logs.
+    * 
+    * Default locations of logs:
+    *   - Windows: C:\Users\<user>\AppData\Local\SmartPeak
+    *   - Linux and MacOS: ~/.SmartPeak
+    * User can change default location and specify directory where the logs are stored by
+    * setting SMARTPEAK_LOGS env variable. If directory specified by the path doesn't exist, the function will create one.
+    * 
+    * @param[in] filename Log filename
+    * @returns The absolute path to log file and boolean flag whether the path to directory was created
+    */
+    static std::pair<std::string, bool> getLogFilepath(const std::string& filename);
   };
 }


### PR DESCRIPTION
I propose new way to generate path to log files using env variables. Following list specifies the order which path is used:
- If SMARTPEAK_LOGS env variable is set (custom - works on any OS),
- If LOCALAPPDATA env variable is set (default on windows) - e.g.: `C:\Users\<user>\AppData\Local\SmartPeak\`
- If HOME env variable is set (default on linux and macos) - e.g.: `/home/<user>/.SmartPeak/`

📌 Disclaimer: The behavior has to be tested on MAC
I encourage reviewers to pull this PR and test logs themselves.

✅ Tested in Windows,
✅ Tested in Ubuntu

Here is example:
```
Windows (Default):
2021-01-13 15:41:03.871 NONE  [7976] [SDL_main@190] Log file at: C:\Users\krzyja\AppData\Local\SmartPeak\smartpeak_log_2021-01-13_15-40-33.csv
2021-01-13 15:41:17.802 DEBUG [7976] [SmartPeak::SessionHandler::setTransitionsTable@159] Making transitions_table_headers
2021-01-13 15:41:17.807 DEBUG [7976] [SmartPeak::SessionHandler::setTransitionExplorer@48] Making transition_explorer_checkbox_headers
...

Windows (Custom path):
2021-01-13 16:35:18.763 NONE  [4960] [SDL_main@190] Log file at: C:\Users\krzyja\Workspace\.logs\smartpeak_log_2021-01-13_16-35-18.csv
2021-01-13 16:35:19.129 DEBUG [4960] [SmartPeak::SessionHandler::setTransitionsTable@159] Making transitions_table_headers
2021-01-13 16:35:19.130 DEBUG [4960] [SmartPeak::SessionHandler::setTransitionExplorer@48] Making transition_explorer_checkbox_headers
...

Ubuntu (Default):
2021-01-13 07:31:55.075 NONE  [5438] [main@151] Log file at: /home/krzysztof/.SmartPeak/smartpeak_log_2021-01-13_07-31-55.csv
2021-01-13 07:31:56.023 DEBUG [5438] [SmartPeak::SessionHandler::setTransitionsTable@159] Making transitions_table_headers
2021-01-13 07:31:56.023 DEBUG [5438] [SmartPeak::SessionHandler::setTransitionExplorer@48] Making transition_explorer_checkbox_headers
...

Ubuntu (Custom path)
2021-01-13 07:34:09.947 NONE  [5606] [main@151] Log file at: /home/krzysztof/.logs/smartpeak_log_2021-01-13_07-34-09.csv
2021-01-13 07:34:10.825 DEBUG [5606] [SmartPeak::SessionHandler::setTransitionsTable@159] Making transitions_table_headers
2021-01-13 07:34:10.826 DEBUG [5606] [SmartPeak::SessionHandler::setTransitionExplorer@48] Making transition_explorer_checkbox_headers
...

```