### PR TITLE
[feat/aut169] Add getID, getName and getDescription to SequenceProcessor

### DIFF
--- a/src/smartpeak/include/SmartPeak/core/ApplicationProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/ApplicationProcessor.h
@@ -25,20 +25,24 @@
 
 #include <SmartPeak/core/ApplicationHandler.h>
 #include <SmartPeak/core/Filenames.h>
+#include <SmartPeak/iface/IProcessorDescription.h>
 #include <SmartPeak/io/InputDataValidation.h>
 #include <string>
 #include <vector>
 
 namespace SmartPeak
 {
-  struct ApplicationProcessor {
+  struct ApplicationProcessor : IProcessorDescription {
     ApplicationProcessor(const ApplicationProcessor& other) = delete;
     ApplicationProcessor& operator=(const ApplicationProcessor& other) = delete;
     virtual ~ApplicationProcessor() = default;
 
     // Each of the derived classes implement the following virtual methods
     virtual bool process() = 0;
-    virtual const std::string getName() const = 0;
+
+    /* IProcessorDescription */
+    int getID() const override { return -1; }
+    std::string getDescription() const override { return ""; }
 
     ApplicationHandler& application_handler_;
 
@@ -57,7 +61,7 @@ namespace SmartPeak
     bool process() override;
     std::string name_;
     ApplicationHandler::Command cmd_; 
-    const std::string getName() const override { return "CreateCommand"; };
+    std::string getName() const override { return "CreateCommand"; };
   };
 
   struct BuildCommandsFromNames : ApplicationProcessor {
@@ -65,7 +69,7 @@ namespace SmartPeak
     bool process() override;
     std::vector<std::string> names_;
     std::vector<ApplicationHandler::Command> commands_;
-    const std::string getName() const override { return "BuildCommandsFromNames"; };
+    std::string getName() const override { return "BuildCommandsFromNames"; };
   };
 
   struct FilePickerProcessor : ApplicationProcessor {
@@ -76,7 +80,7 @@ namespace SmartPeak
   struct LoadSessionFromSequence : FilePickerProcessor {
     LoadSessionFromSequence(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSessionFromSequence"; };
+    std::string getName() const override { return "LoadSessionFromSequence"; };
   private:
     bool buildStaticFilenames();
     void updateFilenames(Filenames& f, const std::string& pathname);
@@ -89,152 +93,152 @@ namespace SmartPeak
   struct LoadSequenceParameters : FilePickerProcessor {
     LoadSequenceParameters(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceParameters"; };
+    std::string getName() const override { return "LoadSequenceParameters"; };
   };
 
   struct LoadSequenceTransitions : FilePickerProcessor {
     LoadSequenceTransitions(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceTransitions"; };
+    std::string getName() const override { return "LoadSequenceTransitions"; };
   };
 
   struct LoadSequenceValidationData : FilePickerProcessor {
     LoadSequenceValidationData(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceValidationData"; };
+    std::string getName() const override { return "LoadSequenceValidationData"; };
   };
 
   struct LoadSequenceSegmentQuantitationMethods : FilePickerProcessor {
     LoadSequenceSegmentQuantitationMethods(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentQuantitationMethods"; };
+    std::string getName() const override { return "LoadSequenceSegmentQuantitationMethods"; };
   };
 
   struct LoadSequenceSegmentStandardsConcentrations : FilePickerProcessor {
     LoadSequenceSegmentStandardsConcentrations(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentStandardsConcentrations"; };
+    std::string getName() const override { return "LoadSequenceSegmentStandardsConcentrations"; };
   };
 
   struct LoadSequenceSegmentFeatureFilterComponents : FilePickerProcessor {
     LoadSequenceSegmentFeatureFilterComponents(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureFilterComponents"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureFilterComponents"; };
   };
 
   struct LoadSequenceSegmentFeatureFilterComponentGroups : FilePickerProcessor {
     LoadSequenceSegmentFeatureFilterComponentGroups(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureFilterComponentGroups"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureFilterComponentGroups"; };
   };
 
   struct LoadSequenceSegmentFeatureQCComponents : FilePickerProcessor {
     LoadSequenceSegmentFeatureQCComponents(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureQCComponents"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureQCComponents"; };
   };
 
   struct LoadSequenceSegmentFeatureQCComponentGroups : FilePickerProcessor {
     LoadSequenceSegmentFeatureQCComponentGroups(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureQCComponentGroups"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureQCComponentGroups"; };
   };
 
   struct LoadSequenceSegmentFeatureRSDFilterComponents : FilePickerProcessor {
     LoadSequenceSegmentFeatureRSDFilterComponents(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureRSDFilterComponents"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureRSDFilterComponents"; };
   };
 
   struct LoadSequenceSegmentFeatureRSDFilterComponentGroups : FilePickerProcessor {
     LoadSequenceSegmentFeatureRSDFilterComponentGroups(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureRSDFilterComponentGroups"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureRSDFilterComponentGroups"; };
   };
 
   struct LoadSequenceSegmentFeatureRSDQCComponents : FilePickerProcessor {
     LoadSequenceSegmentFeatureRSDQCComponents(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureRSDQCComponents"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureRSDQCComponents"; };
   };
 
   struct LoadSequenceSegmentFeatureRSDQCComponentGroups : FilePickerProcessor {
     LoadSequenceSegmentFeatureRSDQCComponentGroups(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureRSDQCComponentGroups"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureRSDQCComponentGroups"; };
   };
 
   struct LoadSequenceSegmentFeatureBackgroundFilterComponents : FilePickerProcessor {
     LoadSequenceSegmentFeatureBackgroundFilterComponents(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureBackgroundFilterComponents"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureBackgroundFilterComponents"; };
   };
 
   struct LoadSequenceSegmentFeatureBackgroundFilterComponentGroups : FilePickerProcessor {
     LoadSequenceSegmentFeatureBackgroundFilterComponentGroups(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureBackgroundFilterComponentGroups"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureBackgroundFilterComponentGroups"; };
   };
 
   struct LoadSequenceSegmentFeatureBackgroundQCComponents : FilePickerProcessor {
     LoadSequenceSegmentFeatureBackgroundQCComponents(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureBackgroundQCComponents"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureBackgroundQCComponents"; };
   };
 
   struct LoadSequenceSegmentFeatureBackgroundQCComponentGroups : FilePickerProcessor {
     LoadSequenceSegmentFeatureBackgroundQCComponentGroups(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceSegmentFeatureBackgroundQCComponentGroups"; };
+    std::string getName() const override { return "LoadSequenceSegmentFeatureBackgroundQCComponentGroups"; };
   };
 
   struct StoreSequenceFileAnalyst : ApplicationProcessor {
     StoreSequenceFileAnalyst(ApplicationHandler& application_handler) : ApplicationProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "StoreSequenceFileAnalyst"; };
+    std::string getName() const override { return "StoreSequenceFileAnalyst"; };
   };
 
   struct StoreSequenceFileMasshunter : ApplicationProcessor {
     StoreSequenceFileMasshunter(ApplicationHandler& application_handler) : ApplicationProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "StoreSequenceFileMasshunter"; };
+    std::string getName() const override { return "StoreSequenceFileMasshunter"; };
   };
 
   struct StoreSequenceFileXcalibur : ApplicationProcessor {
     StoreSequenceFileXcalibur(ApplicationHandler& application_handler) : ApplicationProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "StoreSequenceFileXcalibur"; };
+    std::string getName() const override { return "StoreSequenceFileXcalibur"; };
   };
 
   struct SetRawDataPathname : FilePickerProcessor {
     SetRawDataPathname(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "SetRawDataPathname"; };
+    std::string getName() const override { return "SetRawDataPathname"; };
   };
 
   struct SetInputFeaturesPathname : FilePickerProcessor {
     SetInputFeaturesPathname(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "SetInputFeaturesPathname"; };
+    std::string getName() const override { return "SetInputFeaturesPathname"; };
   };
 
   struct SetOutputFeaturesPathname : FilePickerProcessor {
     SetOutputFeaturesPathname(ApplicationHandler& application_handler) : FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "SetOutputFeaturesPathname"; };
+    std::string getName() const override { return "SetOutputFeaturesPathname"; };
   };
 
   struct LoadSequenceWorkflow : FilePickerProcessor {
     LoadSequenceWorkflow(ApplicationHandler& application_handler) : 
       FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "LoadSequenceWorkflow"; };
+    std::string getName() const override { return "LoadSequenceWorkflow"; };
   };
 
   struct StoreSequenceWorkflow : FilePickerProcessor {
     StoreSequenceWorkflow(ApplicationHandler& application_handler) :
       FilePickerProcessor(application_handler) {}
     bool process() override;
-    const std::string getName() const override { return "StoreSequenceWorkflow"; };
+    std::string getName() const override { return "StoreSequenceWorkflow"; };
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
@@ -36,6 +36,7 @@
 #include <SmartPeak/core/MetaDataHandler.h>
 #include <SmartPeak/core/RawDataHandler.h>
 #include <SmartPeak/core/Parameters.h>
+#include <SmartPeak/iface/IProcessorDescription.h>
 
 #include <map>
 #include <vector>
@@ -44,15 +45,11 @@
 
 namespace SmartPeak
 {
-  struct RawDataProcessor
+  struct RawDataProcessor : IProcessorDescription
   {
     RawDataProcessor(const RawDataProcessor& other) = delete;
     RawDataProcessor& operator=(const RawDataProcessor& other) = delete;
     virtual ~RawDataProcessor() = default;
-
-    virtual int getID() const = 0; /// get the raw data processor struct ID
-    virtual std::string getName() const = 0; /// get the raw data processor struct name
-    virtual std::string getDescription() const = 0; /// get the raw data processor struct description
 
     /** Interface to all raw data processing methods.
 

--- a/src/smartpeak/include/SmartPeak/core/SampleGroupProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SampleGroupProcessor.h
@@ -29,10 +29,11 @@
 #include <SmartPeak/core/SequenceHandler.h>
 #include <SmartPeak/core/SampleGroupHandler.h>
 #include <SmartPeak/core/Parameters.h>
+#include <SmartPeak/iface/IProcessorDescription.h>
 
 namespace SmartPeak
 {
-  struct SampleGroupProcessor
+  struct SampleGroupProcessor : IProcessorDescription
   {
     SampleGroupProcessor(const SampleGroupProcessor& other) = delete;
     SampleGroupProcessor& operator=(const SampleGroupProcessor& other) = delete;

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
@@ -28,6 +28,7 @@
 #include <SmartPeak/core/SequenceHandler.h>
 #include <SmartPeak/core/SequenceSegmentProcessor.h>
 #include <SmartPeak/core/SampleGroupProcessor.h>
+#include <SmartPeak/iface/IProcessorDescription.h>
 #include <map>
 #include <memory> // shared_ptr
 #include <set>
@@ -99,7 +100,7 @@ namespace SmartPeak
     const std::vector<std::shared_ptr<RawDataProcessor>>& methods
   );
 
-  struct SequenceProcessor {
+  struct SequenceProcessor : IProcessorDescription {
     SequenceProcessor(SequenceHandler& sh) : sequenceHandler_IO(&sh) {}
     virtual ~SequenceProcessor() = default;
 
@@ -119,6 +120,11 @@ namespace SmartPeak
     CreateSequence() = default;
     CreateSequence(SequenceHandler& sh) : SequenceProcessor(sh) {}
     void process() const override;
+
+    /* IProcessorDescription */
+    int getID() const override { return -1; }
+    std::string getName() const override { return "CREATE_SEQUENCE"; }
+    std::string getDescription() const override { return "Create a new sequence from file or wizard"; }
   };
 
   /**
@@ -133,6 +139,11 @@ namespace SmartPeak
     ProcessSequence(SequenceHandler& sh) : SequenceProcessor(sh) {}
     static ParameterSet getParameterSchema();
     void process() const override;
+
+    /* IProcessorDescription */
+    int getID() const override { return -1; }
+    std::string getName() const override { return "PROCESS_SEQUENCE"; }
+    std::string getDescription() const override { return "Apply a processing workflow to all injections in a sequence"; }
   };
 
   /**
@@ -146,6 +157,11 @@ namespace SmartPeak
     ProcessSequenceSegments() = default;
     ProcessSequenceSegments(SequenceHandler& sh) : SequenceProcessor(sh) {}
     void process() const override;
+
+    /* IProcessorDescription */
+    int getID() const override { return -1; }
+    std::string getName() const override { return "PROCESS_SEQUENCE_SEGMENTS"; }
+    std::string getDescription() const override { return "Apply a processing workflow to all injections in a sequence segment"; }
   };
 
   /**
@@ -159,6 +175,11 @@ namespace SmartPeak
     ProcessSampleGroups() = default;
     ProcessSampleGroups(SequenceHandler& sh) : SequenceProcessor(sh) {}
     void process() const override;
+
+    /* IProcessorDescription */
+    int getID() const override { return -1; }
+    std::string getName() const override { return "PROCESS_SAMPLE_GROUPS"; }
+    std::string getDescription() const override { return "Apply a processing workflow to all injections in a sample group"; }
   };
 
   struct LoadWorkflow : SequenceProcessor {
@@ -166,6 +187,11 @@ namespace SmartPeak
     LoadWorkflow(SequenceHandler & sh) : SequenceProcessor(sh) {}
     void process() const override;
     std::string filename_;
+
+    /* IProcessorDescription */
+    int getID() const override { return -1; }
+    std::string getName() const override { return "LOAD_WORKFLOW"; }
+    std::string getDescription() const override { return "Load a workflow from file"; }
   };
 
   struct StoreWorkflow : SequenceProcessor {
@@ -173,6 +199,11 @@ namespace SmartPeak
     StoreWorkflow(SequenceHandler& sh) : SequenceProcessor(sh) {}
     void process() const override;
     std::string filename_;
+
+    /* IProcessorDescription */
+    int getID() const override { return -1; }
+    std::string getName() const override { return "STORE_WORKFLOW"; }
+    std::string getDescription() const override { return "Store a workflow to file"; }
   };
 
 }

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
@@ -28,11 +28,12 @@
 #include <SmartPeak/core/SampleType.h>
 #include <SmartPeak/core/SequenceHandler.h>
 #include <SmartPeak/core/SequenceSegmentHandler.h>
+#include <SmartPeak/iface/IProcessorDescription.h>
 #include <SmartPeak/core/Parameters.h>
 
 namespace SmartPeak
 {
-  struct SequenceSegmentProcessor
+  struct SequenceSegmentProcessor : IProcessorDescription
   {
     SequenceSegmentProcessor(const SequenceSegmentProcessor& other) = delete;
     SequenceSegmentProcessor& operator=(const SequenceSegmentProcessor& other) = delete;
@@ -83,9 +84,9 @@ namespace SmartPeak
 
   struct CalculateCalibration : SequenceSegmentProcessor
   {
-    int getID() const { return 15; }
-    std::string getName() const { return "CALCULATE_CALIBRATION"; }
-    std::string getDescription() const { return "Determine the optimal relationship between known sample concentration and measured intensity."; }
+    int getID() const override { return 15; }
+    std::string getName() const override { return "CALCULATE_CALIBRATION"; }
+    std::string getDescription() const override { return "Determine the optimal relationship between known sample concentration and measured intensity."; }
 
     virtual ParameterSet getParameterSchema() const override;
 
@@ -102,9 +103,9 @@ namespace SmartPeak
 
   struct LoadStandardsConcentrations : SequenceSegmentProcessor
   {
-    int getID() const { return -1; }
-    std::string getName() const { return "LOAD_STANDARDS_CONCENTRATIONS"; }
-    std::string getDescription() const { return "Load the standards concentrations file that gives the relationship between injection, component, and known concentration from disk."; }
+    int getID() const override { return -1; }
+    std::string getName() const override { return "LOAD_STANDARDS_CONCENTRATIONS"; }
+    std::string getDescription() const override { return "Load the standards concentrations file that gives the relationship between injection, component, and known concentration from disk."; }
 
     virtual ParameterSet getParameterSchema() const override;
 
@@ -121,9 +122,9 @@ namespace SmartPeak
 
   struct LoadQuantitationMethods : SequenceSegmentProcessor
   {
-    int getID() const { return 17; }
-    std::string getName() const { return "LOAD_QUANTITATION_METHODS"; }
-    std::string getDescription() const { return "Load each transitions calibration model defined in quantitationMethods from disk."; }
+    int getID() const override { return 17; }
+    std::string getName() const override { return "LOAD_QUANTITATION_METHODS"; }
+    std::string getDescription() const override { return "Load each transitions calibration model defined in quantitationMethods from disk."; }
 
     virtual ParameterSet getParameterSchema() const override;
 
@@ -140,9 +141,9 @@ namespace SmartPeak
 
   struct StoreQuantitationMethods : SequenceSegmentProcessor
   {
-    int getID() const { return 16; }
-    std::string getName() const { return "STORE_QUANTITATION_METHODS"; }
-    std::string getDescription() const { return "Write each transitions calibration model to disk for later use."; }
+    int getID() const override { return 16; }
+    std::string getName() const override { return "STORE_QUANTITATION_METHODS"; }
+    std::string getDescription() const override { return "Write each transitions calibration model to disk for later use."; }
 
     virtual ParameterSet getParameterSchema() const override;
 
@@ -375,9 +376,9 @@ namespace SmartPeak
 
   struct EstimateFeatureFilterValues : SequenceSegmentProcessor
   {
-    int getID() const { return -1; }
-    std::string getName() const { return "ESTIMATE_FEATURE_FILTER_VALUES"; }
-    std::string getDescription() const { return "Estimate default FeatureQC parameter values for the feature filters from Standard and QC samples."; }
+    int getID() const override { return -1; }
+    std::string getName() const override { return "ESTIMATE_FEATURE_FILTER_VALUES"; }
+    std::string getDescription() const override { return "Estimate default FeatureQC parameter values for the feature filters from Standard and QC samples."; }
 
     virtual ParameterSet getParameterSchema() const override;
 
@@ -396,9 +397,9 @@ namespace SmartPeak
 
   struct EstimateFeatureQCValues : SequenceSegmentProcessor
   {
-    int getID() const { return -1; }
-    std::string getName() const { return "ESTIMATE_FEATURE_QC_VALUES"; }
-    std::string getDescription() const { return "Estimate default FeatureQC parameter values for the feature QCs from Standard and QC samples."; }
+    int getID() const override { return -1; }
+    std::string getName() const override { return "ESTIMATE_FEATURE_QC_VALUES"; }
+    std::string getDescription() const override { return "Estimate default FeatureQC parameter values for the feature QCs from Standard and QC samples."; }
 
     virtual ParameterSet getParameterSchema() const override;
 
@@ -417,9 +418,9 @@ namespace SmartPeak
 
   struct TransferLOQToFeatureFilters : SequenceSegmentProcessor
   {
-    int getID() const { return -1; }
-    std::string getName() const { return "TRANSFER_LOQ_TO_FEATURE_FILTERS"; }
-    std::string getDescription() const { return "Transfer the upper (u)/lower (l) limits of quantitation (LOQ) values from the quantitation methods to the calculated concentration bounds of the feature filters."; }
+    int getID() const override { return -1; }
+    std::string getName() const override { return "TRANSFER_LOQ_TO_FEATURE_FILTERS"; }
+    std::string getDescription() const override { return "Transfer the upper (u)/lower (l) limits of quantitation (LOQ) values from the quantitation methods to the calculated concentration bounds of the feature filters."; }
 
     virtual ParameterSet getParameterSchema() const override;
 
@@ -436,9 +437,9 @@ namespace SmartPeak
 
   struct TransferLOQToFeatureQCs : SequenceSegmentProcessor
   {
-    int getID() const { return -1; }
-    std::string getName() const { return "TRANSFER_LOQ_TO_FEATURE_QCS"; }
-    std::string getDescription() const { return "Transfer the upper (u)/lower (l) limits of quantitation (LOQ) values from the quantitation methods to the calculated concentration bounds of the feature filters."; }
+    int getID() const override { return -1; }
+    std::string getName() const override { return "TRANSFER_LOQ_TO_FEATURE_QCS"; }
+    std::string getDescription() const override { return "Transfer the upper (u)/lower (l) limits of quantitation (LOQ) values from the quantitation methods to the calculated concentration bounds of the feature filters."; }
 
     virtual ParameterSet getParameterSchema() const override;
 
@@ -455,9 +456,9 @@ namespace SmartPeak
 
   struct EstimateFeatureRSDs : SequenceSegmentProcessor
   {
-    int getID() const { return -1; }
-    std::string getName() const { return "ESTIMATE_FEATURE_RSDS"; }
-    std::string getDescription() const { return "Estimate the %RSD for component and component group feature filter attributes from pooled QC samples."; }
+    int getID() const override { return -1; }
+    std::string getName() const override { return "ESTIMATE_FEATURE_RSDS"; }
+    std::string getDescription() const override { return "Estimate the %RSD for component and component group feature filter attributes from pooled QC samples."; }
 
     virtual ParameterSet getParameterSchema() const override;
 
@@ -476,9 +477,9 @@ namespace SmartPeak
 
   struct EstimateFeatureBackgroundInterferences : SequenceSegmentProcessor
   {
-    int getID() const { return -1; }
-    std::string getName() const { return "ESTIMATE_FEATURE_BACKGROUND_INTERFERENCES"; }
-    std::string getDescription() const { return "Estimate the %BackgroundInterferences for component and component group feature filter ion intensity attributes from Blank samples."; }
+    int getID() const override { return -1; }
+    std::string getName() const override { return "ESTIMATE_FEATURE_BACKGROUND_INTERFERENCES"; }
+    std::string getDescription() const override { return "Estimate the %BackgroundInterferences for component and component group feature filter ion intensity attributes from Blank samples."; }
 
     virtual ParameterSet getParameterSchema() const override;
 

--- a/src/smartpeak/include/SmartPeak/iface/IProcessorDescription.h
+++ b/src/smartpeak/include/SmartPeak/iface/IProcessorDescription.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <memory>
+
+namespace SmartPeak 
+{
+  struct IProcessorDescription 
+  {
+    /**
+      Get the processor struct ID
+    */
+    virtual int getID() const = 0;
+
+    /**
+      Get the processor struct name
+    */
+    virtual std::string getName() const = 0;
+
+    /**
+      Get the processor struct description
+    */
+    virtual std::string getDescription() const = 0;
+
+    virtual ~IProcessorDescription() = default;
+  };
+}

--- a/src/smartpeak/include/SmartPeak/iface/sources.cmake
+++ b/src/smartpeak/include/SmartPeak/iface/sources.cmake
@@ -1,0 +1,18 @@
+### the directory name
+set(directory include/SmartPeak/iface)
+
+### list all header files of the directory here
+set(sources_list_h
+  IProcessorDescription.h
+)
+
+### add path to the filenames
+set(sources_h)
+foreach(i ${sources_list_h})
+  list(APPEND sources_h ${directory}/${i})
+endforeach(i)
+
+### source group definition
+source_group("Header Files\\SmartPeak\\iface" FILES ${sources_h})
+
+set(SmartPeak_sources_h ${SmartPeak_sources_h} ${sources_h})

--- a/src/smartpeak/includes.cmake
+++ b/src/smartpeak/includes.cmake
@@ -10,6 +10,7 @@ set(SmartPeak_sources_h  CACHE INTERNAL "This variable should hold all SmartPeak
 
 ## ATTENTION: The order of includes should be similar to the inclusion hierarchy
 include(include/SmartPeak/core/sources.cmake)
+include(include/SmartPeak/iface/sources.cmake)
 include(include/SmartPeak/algorithm/sources.cmake)
 include(include/SmartPeak/io/sources.cmake)
 include(include/SmartPeak/pipelines/sources.cmake)

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -184,6 +184,15 @@ BOOST_AUTO_TEST_CASE(createSequence)
   BOOST_CHECK_EQUAL(sequenceHandler.getSequence().size(), 0);
 }
 
+BOOST_AUTO_TEST_CASE(gettersCreateSequence)
+{
+  SequenceHandler sequenceHandler;
+  CreateSequence cs(sequenceHandler);
+
+  BOOST_CHECK_EQUAL(cs.getID(), -1);
+  BOOST_CHECK_EQUAL(cs.getName(), "CREATE_SEQUENCE");
+}
+
 BOOST_AUTO_TEST_CASE(processSequence)
 {
   SequenceHandler sequenceHandler;
@@ -260,6 +269,15 @@ BOOST_AUTO_TEST_CASE(processSequence)
   }
 }
 
+BOOST_AUTO_TEST_CASE(gettersProcessSequence)
+{
+  SequenceHandler sequenceHandler;
+  ProcessSequence cs(sequenceHandler);
+
+  BOOST_CHECK_EQUAL(cs.getID(), -1);
+  BOOST_CHECK_EQUAL(cs.getName(), "PROCESS_SEQUENCE");
+}
+
 BOOST_AUTO_TEST_CASE(processSequenceSegments)
 {
   SequenceHandler sequenceHandler;
@@ -331,6 +349,15 @@ BOOST_AUTO_TEST_CASE(processSequenceSegments)
   BOOST_CHECK_CLOSE(static_cast<double>(AQMs[2].getULOQ()), 0.8, 1e-6);
 
   // TODO: Selected sequence segment names
+}
+
+BOOST_AUTO_TEST_CASE(gettersProcessSequenceSegments)
+{
+  SequenceHandler sequenceHandler;
+  ProcessSequenceSegments cs(sequenceHandler);
+
+  BOOST_CHECK_EQUAL(cs.getID(), -1);
+  BOOST_CHECK_EQUAL(cs.getName(), "PROCESS_SEQUENCE_SEGMENTS");
 }
 
 BOOST_AUTO_TEST_CASE(processSampleGroups)
@@ -456,6 +483,15 @@ BOOST_AUTO_TEST_CASE(LoadWorkflow1)
   {
     BOOST_CHECK_EQUAL(expected_command_names[i], commands[i]);
   }
+}
+
+BOOST_AUTO_TEST_CASE(gettersProcessSampleGroups)
+{
+  SequenceHandler sequenceHandler;
+  ProcessSampleGroups cs(sequenceHandler);
+
+  BOOST_CHECK_EQUAL(cs.getID(), -1);
+  BOOST_CHECK_EQUAL(cs.getName(), "PROCESS_SAMPLE_GROUPS");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
✅ Add `IProcessorDescription` interface,
✅ Implement `IProcessorDescription` interface in `SequenceProcessor` classes,
✅ Add unit tests for relevant `SequenceProcessor`'s getters.

📌 Disclaimer:
- Assigned IDs are now set to `-1`, this probably needs an update,
- Descriptions might be not descriptive enough - I copied class docs to the string,
- Since I created `IProcessorDescription` interface, I can also update other Processor classes with this interface (out of the scope of this ticket)
- Maybe location of `IProcessorDescription` can be under new directory `interface` or `iface`:
![image](https://user-images.githubusercontent.com/6596930/105694170-e7e33d00-5f00-11eb-8616-49ef364f41eb.png)
