### PR TITLE
Add test for ApplicationProcessor classes

### DIFF
--- a/src/smartpeak/include/SmartPeak/core/ApplicationProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/ApplicationProcessor.h
@@ -50,6 +50,12 @@ namespace SmartPeak
   namespace ApplicationProcessors {
     ParameterSet getParameterSchema();
     void processCommands(ApplicationHandler& application_handler, std::vector<ApplicationHandler::Command> commands, const std::set<std::string>& injection_names, const std::set<std::string>& sequence_segment_names, const std::set<std::string>& sample_group_names);
+    void processCommands(
+        ApplicationHandler& application_handler, 
+        std::vector<ApplicationHandler::Command> commands, 
+        const std::set<std::string>& injection_names, 
+        const std::set<std::string>& sequence_segment_names, 
+        const std::set<std::string>& sample_group_names);
   }
 
   struct CreateCommand : ApplicationProcessor {

--- a/src/tests/class_tests/smartpeak/source/ApplicationProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/ApplicationProcessor_test.cpp
@@ -25,15 +25,108 @@
 
 #define BOOST_TEST_MODULE ApplicationProcessor test suite
 #include <boost/test/included/unit_test.hpp>
+#include <boost/filesystem.hpp>
 #include <SmartPeak/core/ApplicationProcessor.h>
+#include <SmartPeak/core/SequenceProcessor.h>
+#include <SmartPeak/core/Filenames.h>
 #include <boost/filesystem.hpp>
 
 using namespace SmartPeak;
 using namespace std;
+namespace fs = boost::filesystem;
 
-BOOST_AUTO_TEST_SUITE(applicationprocessor)
+struct ApplicationProcessorFixture 
+{
+  /* ctor/dtor */
+  ApplicationProcessorFixture() 
+  {
+    datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
+    auto workflow = fs::path{ datapath_ } / fs::path{ "workflow_csv_files" };
 
-BOOST_AUTO_TEST_CASE(buildcommandsfromids)
+    filenames_ = Filenames::getDefaultStaticFilenames(workflow.string());
+    filenames_.referenceData_csv_i = (fs::path{ datapath_ } / fs::path{ "MRMFeatureValidator_referenceData_1.csv" }).string();
+
+    // Injections sequence:
+    std::vector<InjectionHandler> seq;
+    {
+      seq.push_back(InjectionHandler{});
+      seq.push_back(InjectionHandler{});
+    }
+    ah_.sequenceHandler_.setSequence(seq);
+    // Sequence segments:
+    std::vector<SequenceSegmentHandler> seq_seg;
+    {
+      seq_seg.push_back(SequenceSegmentHandler{});
+      seq_seg.push_back(SequenceSegmentHandler{});
+    }
+    ah_.sequenceHandler_.setSequenceSegments(seq_seg);
+    // Sample groups:
+    std::vector<SampleGroupHandler> sample_groups;
+    {
+      sample_groups.push_back(SampleGroupHandler{});
+      sample_groups.push_back(SampleGroupHandler{});
+    }
+    ah_.sequenceHandler_.setSampleGroups(sample_groups);
+  }
+
+  ~ApplicationProcessorFixture() {}
+
+public:
+  ApplicationHandler ah_;
+  std::string datapath_;
+  Filenames filenames_;
+};
+
+BOOST_FIXTURE_TEST_SUITE(ApplicationProcessor, ApplicationProcessorFixture)
+
+/* CreateCommand */
+BOOST_AUTO_TEST_CASE(CreateCommand_GetName)
+{
+  CreateCommand cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "CreateCommand");
+}
+
+BOOST_AUTO_TEST_CASE(CreateCommand_ProcessFailsOnEmptyCommand)
+{
+  CreateCommand cmd{ ah_ };
+  cmd.name_ = "";
+  auto created = cmd.process();
+  BOOST_CHECK(!created);
+}
+
+BOOST_AUTO_TEST_CASE(CreateCommand_ProcessFailsOnWrongCommandName)
+{
+  CreateCommand cmd{ ah_ };
+  cmd.name_ = "BAD_COMMAND_NAME";
+  auto created = cmd.process();
+  BOOST_CHECK(!created);
+}
+
+BOOST_AUTO_TEST_CASE(CreateCommand_ProcessSucceedsOnValidCommandName)
+{
+  CreateCommand cmd{ ah_ };
+  // Raw data method
+  {
+    cmd.name_ = "LOAD_RAW_DATA";
+    auto created = cmd.process();
+    BOOST_CHECK(created);
+  }
+  // Sequence Segment Method
+  {
+    cmd.name_ = "LOAD_FEATURE_QCS";
+    auto created = cmd.process();
+    BOOST_CHECK(created);
+  }
+  // Sample Group Method
+  {
+    cmd.name_ = "MERGE_INJECTIONS";
+    auto created = cmd.process();
+    BOOST_CHECK(created);
+  }
+}
+
+/* BuildCommandsFromNames */
+BOOST_AUTO_TEST_CASE(BuildCommandsFromNames_Process)
 {
   ApplicationHandler application_handler;
   BuildCommandsFromNames buildCommandsFromNames(application_handler);
@@ -61,186 +154,591 @@ BOOST_AUTO_TEST_CASE(buildcommandsfromids)
   BOOST_CHECK_EQUAL(buildCommandsFromNames.commands_.size(), 0);
 }
 
-BOOST_AUTO_TEST_CASE(CreateCommandGetName)
+BOOST_AUTO_TEST_CASE(BuildCommandsFromNames_GetName)
 {
-  ApplicationHandler application_handler;
-  CreateCommand application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "CreateCommand");
+  BuildCommandsFromNames cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "BuildCommandsFromNames");
 }
 
-BOOST_AUTO_TEST_CASE(BuildCommandsFromNamesGetName)
+/* LoadSessionFromSequence */
+BOOST_AUTO_TEST_CASE(LoadSessionFromSequence_GetName)
 {
-  ApplicationHandler application_handler;
-  BuildCommandsFromNames application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "BuildCommandsFromNames");
+  LoadSessionFromSequence cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSessionFromSequence");
 }
 
-BOOST_AUTO_TEST_CASE(LoadSessionFromSequenceGetName)
+BOOST_AUTO_TEST_CASE(LoadSessionFromSequence_ProcessSucceedsOnCorrectPath)
 {
-  ApplicationHandler application_handler;
-  LoadSessionFromSequence application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSessionFromSequence");
+  LoadSessionFromSequence cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.sequence_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceParametersGetName)
+/* LoadSequenceParameters */
+BOOST_AUTO_TEST_CASE(LoadSequenceParameters_GetName)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceParameters application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceParameters");
+  LoadSequenceParameters cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceParameters");
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceTransitionsGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceParameters_ProcessFailsOnEmptySequence)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceTransitions application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceTransitions");
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceParameters cmd{ ah };
+  BOOST_CHECK(!cmd.process());
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceValidationDataGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceParameters_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceValidationData application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceValidationData");
+  LoadSequenceParameters cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.parameters_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentQuantitationMethodsGetName)
+/* LoadSequenceTransitions */
+BOOST_AUTO_TEST_CASE(LoadSequenceTransitions_GetName)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentQuantitationMethods application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentQuantitationMethods");
+  LoadSequenceTransitions cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceTransitions");
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentStandardsConcentrationsGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceTransitions_ProcessFailsOnEmptySequence)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentStandardsConcentrations application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentStandardsConcentrations");
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceTransitions cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureFilterComponentsGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceTransitions_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureFilterComponents application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureFilterComponents");
+  LoadSequenceTransitions cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.traML_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureFilterComponentGroupsGetName)
+/* LoadSequenceValidationData */
+BOOST_AUTO_TEST_CASE(LoadSequenceValidationData_GetName)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureFilterComponentGroups application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureFilterComponentGroups");
+  LoadSequenceValidationData cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceValidationData");
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureQCComponentsGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceValidationData_ProcessFailsOnEmptySequence)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureQCComponents application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureQCComponents");
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceValidationData cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureQCComponentGroupsGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceValidationData_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureQCComponentGroups application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureQCComponentGroups");
+  LoadSequenceValidationData cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.referenceData_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDFilterComponentsGetName)
+/* LoadSequenceSegmentQuantitationMethods */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentQuantitationMethods_GetName)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureRSDFilterComponents application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureRSDFilterComponents");
+  LoadSequenceSegmentQuantitationMethods cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentQuantitationMethods");
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDFilterComponentGroupsGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentQuantitationMethods_ProcessFailsOnEmptySequence)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureRSDFilterComponentGroups application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureRSDFilterComponentGroups");
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentQuantitationMethods cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDQCComponentsGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentQuantitationMethods_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureRSDQCComponents application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureRSDQCComponents");
+  LoadSequenceSegmentQuantitationMethods cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.quantitationMethods_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDQCComponentGroupsGetName)
+/* LoadSequenceSegmentStandardsConcentrations */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentStandardsConcentrations_GetName)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureRSDQCComponentGroups application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureRSDQCComponentGroups");
+  LoadSequenceSegmentStandardsConcentrations cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentStandardsConcentrations");
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundFilterComponentsGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentStandardsConcentrations_ProcessFailsOnEmptySequence)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureBackgroundFilterComponents application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureBackgroundFilterComponents");
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentStandardsConcentrations cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundFilterComponentGroupsGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentStandardsConcentrations_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureBackgroundFilterComponentGroups application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureBackgroundFilterComponentGroups");
+  LoadSequenceSegmentStandardsConcentrations cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.standardsConcentrations_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundQCComponentsGetName)
+/* LoadSequenceSegmentFeatureFilterComponents */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureFilterComponents_GetName)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureBackgroundQCComponents application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureBackgroundQCComponents");
+  LoadSequenceSegmentFeatureFilterComponents cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureFilterComponents");
 }
 
-BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundQCComponentGroupsGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureFilterComponents_ProcessFailsOnEmptySequence)
 {
-  ApplicationHandler application_handler;
-  LoadSequenceSegmentFeatureBackgroundQCComponentGroups application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "LoadSequenceSegmentFeatureBackgroundQCComponentGroups");
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureFilterComponents cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
 }
 
-BOOST_AUTO_TEST_CASE(StoreSequenceFileAnalyst1)
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureFilterComponents_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
 {
-  ApplicationHandler application_handler;
-  StoreSequenceFileAnalyst application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "StoreSequenceFileAnalyst");
+  LoadSequenceSegmentFeatureFilterComponents cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureFilterComponents_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
 }
 
-BOOST_AUTO_TEST_CASE(StoreSequenceFileMasshunter1)
+/* LoadSequenceSegmentFeatureFilterComponentGroups */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureFilterComponentGroups_GetName)
 {
-  ApplicationHandler application_handler;
-  StoreSequenceFileMasshunter application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "StoreSequenceFileMasshunter");
+  LoadSequenceSegmentFeatureFilterComponentGroups cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureFilterComponentGroups");
 }
 
-BOOST_AUTO_TEST_CASE(StoreSequenceFileXcalibur1)
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureFilterComponentGroups_ProcessFailsOnEmptySequence)
 {
-  ApplicationHandler application_handler;
-  StoreSequenceFileXcalibur application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "StoreSequenceFileXcalibur");
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureFilterComponentGroups cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
 }
 
-BOOST_AUTO_TEST_CASE(SetRawDataPathnameGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureFilterComponentGroups_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
 {
-  ApplicationHandler application_handler;
-  SetRawDataPathname application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "SetRawDataPathname");
+  LoadSequenceSegmentFeatureFilterComponentGroups cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureFilterComponentGroups_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
 }
 
-BOOST_AUTO_TEST_CASE(SetInputFeaturesPathnameGetName)
+/* LoadSequenceSegmentFeatureQCComponents */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureQCComponents_GetName)
 {
-  ApplicationHandler application_handler;
-  SetInputFeaturesPathname application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "SetInputFeaturesPathname");
+  LoadSequenceSegmentFeatureQCComponents cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureQCComponents");
 }
 
-BOOST_AUTO_TEST_CASE(SetOutputFeaturesPathnameGetName)
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureQCComponents_ProcessFailsOnEmptySequence)
 {
-  ApplicationHandler application_handler;
-  SetOutputFeaturesPathname application_processor(application_handler);
-  BOOST_CHECK_EQUAL(application_processor.getName(), "SetOutputFeaturesPathname");
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureQCComponents cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureQCComponents_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
+{
+  LoadSequenceSegmentFeatureQCComponents cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureQCComponents_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
+}
+
+/* LoadSequenceSegmentFeatureQCComponentGroups */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureQCComponentGroups_GetName)
+{
+  LoadSequenceSegmentFeatureQCComponentGroups cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureQCComponentGroups");
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureQCComponentGroups_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureQCComponentGroups cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureQCComponentGroups_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
+{
+  LoadSequenceSegmentFeatureQCComponentGroups cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureQCComponentGroups_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
+}
+
+/* LoadSequenceSegmentFeatureRSDFilterComponents */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDFilterComponents_GetName)
+{
+  LoadSequenceSegmentFeatureRSDFilterComponents cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureRSDFilterComponents");
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDFilterComponents_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureRSDFilterComponents cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDFilterComponents_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
+{
+  LoadSequenceSegmentFeatureRSDFilterComponents cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureRSDFilterComponents_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
+}
+
+/* LoadSequenceSegmentFeatureRSDFilterComponentGroups */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDFilterComponentGroups_GetName)
+{
+  LoadSequenceSegmentFeatureRSDFilterComponentGroups cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureRSDFilterComponentGroups");
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDFilterComponentGroups_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureRSDFilterComponentGroups cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDFilterComponentGroups_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
+{
+  LoadSequenceSegmentFeatureRSDFilterComponentGroups cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureRSDFilterComponentGroups_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
+}
+
+/* LoadSequenceSegmentFeatureRSDQCComponents */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDQCComponents_GetName)
+{
+  LoadSequenceSegmentFeatureRSDQCComponents cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureRSDQCComponents");
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDQCComponents_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureRSDQCComponents cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDQCComponents_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
+{
+  LoadSequenceSegmentFeatureRSDQCComponents cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureRSDQCComponents_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
+}
+
+/* LoadSequenceSegmentFeatureRSDQCComponentGroups */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDQCComponentGroups_GetName)
+{
+  LoadSequenceSegmentFeatureRSDQCComponentGroups cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureRSDQCComponentGroups");
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDQCComponentGroups_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureRSDQCComponentGroups cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureRSDQCComponentGroups_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
+{
+  LoadSequenceSegmentFeatureRSDQCComponentGroups cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureRSDQCComponentGroups_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
+}
+
+/* LoadSequenceSegmentFeatureBackgroundFilterComponents */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundFilterComponents_GetName)
+{
+  LoadSequenceSegmentFeatureBackgroundFilterComponents cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureBackgroundFilterComponents");
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundFilterComponents_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureBackgroundFilterComponents cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundFilterComponents_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
+{
+  LoadSequenceSegmentFeatureBackgroundFilterComponents cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureBackgroundFilterComponents_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
+}
+
+/* LoadSequenceSegmentFeatureBackgroundFilterComponentGroups */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundFilterComponentGroups_GetName)
+{
+  LoadSequenceSegmentFeatureBackgroundFilterComponentGroups cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureBackgroundFilterComponentGroups");
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundFilterComponentGroups_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureBackgroundFilterComponentGroups cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundFilterComponentGroups_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
+{
+  LoadSequenceSegmentFeatureBackgroundFilterComponentGroups cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureBackgroundFilterComponentGroups_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
+}
+
+/* LoadSequenceSegmentFeatureBackgroundQCComponents */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundQCComponents_GetName)
+{
+  LoadSequenceSegmentFeatureBackgroundQCComponents cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureBackgroundQCComponents");
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundQCComponents_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureBackgroundQCComponents cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundQCComponents_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
+{
+  LoadSequenceSegmentFeatureBackgroundQCComponents cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureBackgroundQCComponents_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
+}
+
+/* LoadSequenceSegmentFeatureBackgroundQCComponentGroups */
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundQCComponentGroups_GetName)
+{
+  LoadSequenceSegmentFeatureBackgroundQCComponentGroups cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "LoadSequenceSegmentFeatureBackgroundQCComponentGroups");
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundQCComponentGroups_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  LoadSequenceSegmentFeatureBackgroundQCComponentGroups cmd{ ah };
+  auto loaded = cmd.process();
+  BOOST_CHECK(!loaded);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSequenceSegmentFeatureBackgroundQCComponentGroups_ProcessSucceedsOnNonEmptySequenceAndCorrectPath)
+{
+  LoadSequenceSegmentFeatureBackgroundQCComponentGroups cmd{ ah_ };
+  {
+    cmd.pathname_ = filenames_.featureBackgroundQCComponentGroups_csv_i;
+  }
+  auto loaded = cmd.process();
+  BOOST_CHECK(loaded);
+}
+
+/* StoreSequenceFileAnalyst */
+BOOST_AUTO_TEST_CASE(StoreSequenceFileAnalyst_GetName)
+{
+  StoreSequenceFileAnalyst cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "StoreSequenceFileAnalyst");
+}
+
+BOOST_AUTO_TEST_CASE(StoreSequenceFileAnalyst_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  StoreSequenceFileAnalyst cmd{ ah };
+  auto store = cmd.process();
+  BOOST_CHECK(!store);
+}
+
+BOOST_AUTO_TEST_CASE(StoreSequenceFileAnalyst_ProcessSucceedsOnNonEmptySequence)
+{
+  StoreSequenceFileAnalyst cmd{ ah_ };
+  auto store = cmd.process();
+  BOOST_CHECK(store);
+}
+
+/* StoreSequenceFileMasshunter */
+BOOST_AUTO_TEST_CASE(StoreSequenceFileMasshunter_GetName)
+{
+  StoreSequenceFileMasshunter cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "StoreSequenceFileMasshunter");
+}
+
+BOOST_AUTO_TEST_CASE(StoreSequenceFileMasshunter_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  StoreSequenceFileMasshunter cmd{ ah };
+  auto store = cmd.process();
+  BOOST_CHECK(!store);
+}
+
+BOOST_AUTO_TEST_CASE(StoreSequenceFileMasshunter_ProcessSucceedsOnNonEmptySequence)
+{
+  StoreSequenceFileMasshunter cmd{ ah_ };
+  auto store = cmd.process();
+  BOOST_CHECK(store);
+}
+
+/* StoreSequenceFileXcalibur */
+BOOST_AUTO_TEST_CASE(StoreSequenceFileXcalibur_GetName)
+{
+  StoreSequenceFileXcalibur cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "StoreSequenceFileXcalibur");
+}
+
+BOOST_AUTO_TEST_CASE(StoreSequenceFileXcalibur_ProcessFailsOnEmptySequence)
+{
+  // Default ApplicationHandler has a default SequenceHnadler with empty sequence
+  ApplicationHandler ah;
+  StoreSequenceFileXcalibur cmd{ ah };
+  auto store = cmd.process();
+  BOOST_CHECK(!store);
+}
+
+BOOST_AUTO_TEST_CASE(StoreSequenceFileXcalibur_ProcessSucceedsOnNonEmptySequence)
+{
+  StoreSequenceFileXcalibur cmd{ ah_ };
+  auto store = cmd.process();
+  BOOST_CHECK(store);
+}
+
+/* SetRawDataPathname */
+BOOST_AUTO_TEST_CASE(SetRawDataPathname_GetName)
+{
+  SetRawDataPathname cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "SetRawDataPathname");
+}
+
+BOOST_AUTO_TEST_CASE(SetRawDataPathname_ProcessSetsPath)
+{
+  SetRawDataPathname cmd{ ah_ };
+  {
+    cmd.pathname_ = "path/to/directory";
+  }
+  auto set = cmd.process();
+  BOOST_CHECK(set);
+  BOOST_CHECK_EQUAL(ah_.mzML_dir_, cmd.pathname_);
+}
+
+/* SetInputFeaturesPathname */
+BOOST_AUTO_TEST_CASE(SetInputFeaturesPathname_GetName)
+{
+  SetInputFeaturesPathname cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "SetInputFeaturesPathname");
+}
+
+BOOST_AUTO_TEST_CASE(SetInputFeaturesPathname_ProcessSetsPath)
+{
+  SetInputFeaturesPathname cmd{ ah_ };
+  {
+    cmd.pathname_ = "path/to/directory";
+  }
+  auto set = cmd.process();
+  BOOST_CHECK(set);
+  BOOST_CHECK_EQUAL(ah_.features_in_dir_, cmd.pathname_);
+}
+
+/* SetOutputFeaturesPathname */
+BOOST_AUTO_TEST_CASE(SetOutputFeaturesPathname_GetName)
+{
+  SetOutputFeaturesPathname cmd{ ah_ };
+  BOOST_CHECK_EQUAL(cmd.getName(), "SetOutputFeaturesPathname");
+}
+
+BOOST_AUTO_TEST_CASE(SetOutputFeaturesPathname_ProcessSetsPath)
+{
+  SetOutputFeaturesPathname cmd{ ah_ };
+  {
+    cmd.pathname_ = "path/to/directory";
+  }
+  auto set = cmd.process();
+  BOOST_CHECK(set);
+  BOOST_CHECK_EQUAL(ah_.features_out_dir_, cmd.pathname_);
 }
 
 BOOST_AUTO_TEST_CASE(StoreSequenceWorkflow1)


### PR DESCRIPTION
The unit test for `ApplicationProcessor` classes:
- I observed that `FilePickerProcessor` classes succeed when a path associated with an object is empty or point to wrong file
   - Success when path is empty -> should fail (return `false`),
   - Success when path points to non-existing file -> should fail (return `false`),
   - Some classes throws an exception when path points to file which exists but have wrong structure -> perhaps the exception should be caught in `process()` and the method should return false
- The `ApplicationProcessors::processCommands()` is not tested. The only idea I have is to verify exception handling. The thing is that this procedure relies on `SequenceProcessor` classes, so this test would mostly test dependencies, not the actual procedure.

📌Please give me hints about `FilePickerProcessor`, at the moment implementation requires some fixes.
❗ Because we don't use mocking approach, I created a test fixture which creates default objects (`default-constructible`) as stubs. However, this way breaks rules of unit testing with regards to isolating dependencies, which in turn makes them class-level integration tests.
❗ Many test fails at this stage.