### PR TITLE
[fix/aut816] Fixed chromatogram and spectra range reset 

### DIFF
--- a/src/smartpeak/source/ui/ChromatogramPlotWidget.cpp
+++ b/src/smartpeak/source/ui/ChromatogramPlotWidget.cpp
@@ -19,20 +19,26 @@ namespace SmartPeak
         component_names.insert(selected_transitions(i));
     }
 
-    if (refresh_needed_)
+    if ((refresh_needed_) || // data changed
+       ((input_component_names_ != component_names) || (input_sample_names_ != sample_names))) // user select different items
     {
-      // get the whole graph area
-      current_range_ = std::make_pair(0, 1800);
-      session_handler_.getChromatogramScatterPlot(sequence_handler_, chrom_, current_range_, sample_names, component_names);
-      current_range_ = slider_min_max_ = input_range_ = std::make_pair(chrom_.x_min_, chrom_.x_max_);
+      // we may recompute the RT window, get the whole graph area
+      session_handler_.getChromatogramScatterPlot(sequence_handler_, chrom_, std::make_pair(0, 1800), sample_names, component_names);
+      if ((std::abs(slider_min_max_.first - chrom_.x_min_) > std::numeric_limits<double>::epsilon()) ||
+          (std::abs(slider_min_max_.second - chrom_.x_max_) > std::numeric_limits<double>::epsilon()))
+      {
+        // min max changed, reset the sliders and current range
+        current_range_ = slider_min_max_ = std::make_pair(chrom_.x_min_, chrom_.x_max_);
+      }
+      input_range_ = std::make_pair(chrom_.x_min_, chrom_.x_max_);
+      input_sample_names_ = sample_names;
+      input_component_names_ = component_names;
       refresh_needed_ = false;
     }
-    if ((input_range_ != current_range_) || (input_component_names_ != component_names) || (input_sample_names_ != sample_names))
+    else if (input_range_ != current_range_) // user zoom in/out
     {
       session_handler_.getChromatogramScatterPlot(sequence_handler_, chrom_, current_range_, sample_names, component_names);
       input_range_ = current_range_;
-      input_sample_names_ = sample_names;
-      input_component_names_ = component_names;
     }
   };
 

--- a/src/smartpeak/source/ui/SpectraPlotWidget.cpp
+++ b/src/smartpeak/source/ui/SpectraPlotWidget.cpp
@@ -27,21 +27,27 @@ namespace SmartPeak
         component_group_names.insert(selected_transition_groups(i));
     }
 
-    if (refresh_needed_)
+    if ((refresh_needed_) || // data changed
+       ((input_sample_names_ != sample_names) || (input_scan_names_ != scan_names) || (input_component_group_names_ != component_group_names))) // user select different items
     {
       // get the whole graph area
-      current_range_ = std::make_pair(0, 2000);
-      session_handler_.getSpectrumScatterPlot(sequence_handler_, chrom_, current_range_, sample_names, scan_names, component_group_names);
-      current_range_ = slider_min_max_ = input_range_ = std::make_pair(chrom_.x_min_, chrom_.x_max_);
-      refresh_needed_ = false;
-    }
-    if ((input_range_ != current_range_) || (input_scan_names_ != scan_names) || (input_sample_names_ != sample_names) || (input_component_group_names_ != component_group_names))
-    {
-      session_handler_.getSpectrumScatterPlot(sequence_handler_, chrom_, current_range_, sample_names, scan_names,component_group_names);
-      input_range_ = current_range_;
+      session_handler_.getSpectrumScatterPlot(sequence_handler_, chrom_, std::make_pair(0, 2000), sample_names, scan_names, component_group_names);
+      if ((std::abs(slider_min_max_.first - chrom_.x_min_) > std::numeric_limits<double>::epsilon()) ||
+          (std::abs(slider_min_max_.second - chrom_.x_max_) > std::numeric_limits<double>::epsilon()))
+      {
+        // min max changed, reset the sliders and current range
+        current_range_ = slider_min_max_ = std::make_pair(chrom_.x_min_, chrom_.x_max_);
+      }
+      input_range_ = std::make_pair(chrom_.x_min_, chrom_.x_max_);
       input_sample_names_ = sample_names;
       input_scan_names_ = scan_names;
       input_component_group_names_ = component_group_names;
+      refresh_needed_ = false;
+    }
+    else if (input_range_ != current_range_) // user zoom in/out
+    {
+      session_handler_.getSpectrumScatterPlot(sequence_handler_, chrom_, current_range_, sample_names, scan_names,component_group_names);
+      input_range_ = current_range_;
     }
   };
 


### PR DESCRIPTION
Fixed chromatogram and spectra range reset when selecting different component.

in this fix, he check if the user has selected different component. if so, recompute the window range.

Then if the window range has changed, we reset the sliders and the actual display range of the window (to expand or to shrink according to the new range).

If the range hasn't changed, we do not reset the displayed window range. This allow the user to zoom on a specific range and show hide a component to that range without to have to zoom in again.
