### PR TITLE
[feat/aut834] Include/Pass version tag to SmartPeak code.

### DIFF
--- a/src/examples/source/GUI.cpp
+++ b/src/examples/source/GUI.cpp
@@ -158,6 +158,9 @@ int main(int argc, char** argv)
     .addAppender(&consoleAppender)
     .addAppender(&appender_);
 
+  // Log SmartPeak launch initiated:
+  LOG_INFO << "Start SmartPeak version " << Utilities::getSmartPeakVersion();
+
   if (error_msg.empty())
   {
     if (logdir_created) LOG_DEBUG << "Log directory created: " << logdirpath;
@@ -177,6 +180,8 @@ int main(int argc, char** argv)
   }
 
   // Setup window
+  auto smartpeak_window_title = static_cast<std::ostringstream&&>(
+    std::ostringstream() << "SmartPeak v" << Utilities::getSmartPeakVersion()).str();
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
   SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
@@ -185,7 +190,7 @@ int main(int argc, char** argv)
   SDL_DisplayMode current;
   SDL_GetCurrentDisplayMode(0, &current);
   SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
-  SDL_Window* window = SDL_CreateWindow("SmartPeak SDL2+OpenGL application", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
+  SDL_Window* window = SDL_CreateWindow(smartpeak_window_title.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
   SDL_GLContext gl_context = SDL_GL_CreateContext(window);
   SDL_GL_SetSwapInterval(1); // Enable vsync
 
@@ -385,8 +390,9 @@ int main(int argc, char** argv)
     }
     if (ImGui::BeginPopupModal("About modal", NULL, ImGuiWindowFlags_AlwaysAutoResize))
     {
+      // TODO: read text from file and print in the window
       ImGui::Text("About SmartPeak");
-      ImGui::Text("SmartPeak %s", "1.0"); //TODO: define version function
+      ImGui::Text("SmartPeak %s", Utilities::getSmartPeakVersion().c_str());
       ImGui::Separator();
       ImGui::Text("By the hardworking SmartPeak developers.");
       ImGui::Separator();

--- a/src/smartpeak/include/SmartPeak/core/Utilities.h
+++ b/src/smartpeak/include/SmartPeak/core/Utilities.h
@@ -323,5 +323,10 @@ public:
     * @returns The absolute path to log file and boolean flag whether the path to directory was created
     */
     static std::pair<std::string, bool> getLogFilepath(const std::string& filename);
+
+    /**
+    * @brief Returns the build version of SmartPeak package if available.
+    */
+    static std::string getSmartPeakVersion();
   };
 }

--- a/src/smartpeak/source/core/Utilities.cpp
+++ b/src/smartpeak/source/core/Utilities.cpp
@@ -24,6 +24,7 @@
 #include <SmartPeak/core/Utilities.h>
 #include <SmartPeak/core/CastValue.h>
 #include <SmartPeak/core/Parameters.h>
+#include <SmartPeak/smartpeak_package_version.h>
 #include <OpenMS/DATASTRUCTURES/Param.h>
 #include <algorithm>
 #include <iostream>
@@ -678,5 +679,15 @@ namespace SmartPeak
           HOME, LOCALAPPDATA or SMARTPEAK_LOGS env variable is set. For details refer to user documentation");
     }
     return std::make_pair(path, flag);
+  }
+
+  std::string Utilities::getSmartPeakVersion()
+  {
+#if defined(SMARTPEAK_PACKAGE_VERSION)
+    return static_cast<std::ostringstream&&>(std::ostringstream()
+      << SMARTPEAK_PACKAGE_VERSION).str();
+#else
+    return "Unknown";
+#endif
   }
 }


### PR DESCRIPTION
+ Modify CMakeLists.txt to cache version information.
+ Add `Utilities::getSmartPeakVersion()` static method.
+ Include version information in GUI.cpp.

📌 I think this method doesn't need test.