### PR TITLE
Not specifying some user parameters will not prevent processors to run

### DIFF
--- a/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
@@ -53,6 +53,8 @@ namespace SmartPeak
     RawDataProcessor& operator=(const RawDataProcessor& other) = delete;
     virtual ~RawDataProcessor() = default;
 
+    virtual ParameterSet getParameterSchema() const override { return ParameterSet(); };
+
     /** Interface to all raw data processing methods.
 
       @param[in,out] rawDataHandler_IO Raw data file struct
@@ -64,8 +66,6 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const = 0;
-
-    virtual ParameterSet getParameterSchema() const;
 
   protected:
     // Forced to write this, because the other user-defined constructors inhibit
@@ -80,6 +80,8 @@ namespace SmartPeak
     int getID() const override { return 1; }
     std::string getName() const override { return "LOAD_RAW_DATA"; }
     std::string getDescription() const override { return "Read in raw data mzML file from disk."; }
+
+    virtual ParameterSet getParameterSchema() const;
 
     /** Read in raw data mzML file from disk.
 
@@ -395,6 +397,8 @@ namespace SmartPeak
     int getID() const override { return 6; }
     std::string getName() const override { return "VALIDATE_FEATURES"; }
     std::string getDescription() const override { return "Compare selected features to a reference data set."; }
+
+    virtual ParameterSet getParameterSchema() const override;
 
     /** Validate the selected peaks against reference data.
     */

--- a/src/smartpeak/include/SmartPeak/core/Utilities.h
+++ b/src/smartpeak/include/SmartPeak/core/Utilities.h
@@ -69,6 +69,19 @@ public:
     );
 
     /**
+      Update a OpenMS' DefaultParamHandler object with user parameters.
+
+      @param[in,out] Param_handler_IO OpenMS' DefaultParamHandler object to update
+      @param[in] parameters_I user parameters
+      @param[in] param_handler_name set if user parameter have different name entry.
+    */
+    static void setUserParameters(
+      OpenMS::DefaultParamHandler& Param_handler_IO,
+      const ParameterSet& user_parameters_I,
+      const std::string param_handler_name_I = ""
+    );
+
+    /**
       Update a Param object.
 
       The type check is case insensitive.

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -89,17 +89,9 @@ namespace SmartPeak
       standards_featureMaps.push_back(sequenceHandler_I.getSequence().at(index).getRawData().getFeatureMap());
     }
 
-    if (params_I.at("AbsoluteQuantitation").empty()) {
-      LOGE << "Parameters not found for AbsoluteQuantitation. Returning";
-      LOGD << "END optimizeCalibrationCurves";
-      return;
-    }
-
     // add in the method parameters
     OpenMS::AbsoluteQuantitation absoluteQuantitation;
-    OpenMS::Param parameters = absoluteQuantitation.getParameters();
-    Utilities::updateParameters(parameters, params_I.at("AbsoluteQuantitation"));
-    absoluteQuantitation.setParameters(parameters);
+    Utilities::setUserParameters(absoluteQuantitation, params_I);
 
     absoluteQuantitation.setQuantMethods(sequenceSegmentHandler_IO.getQuantitationMethods());
     std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> components_to_concentrations;

--- a/src/smartpeak/source/core/Utilities.cpp
+++ b/src/smartpeak/source/core/Utilities.cpp
@@ -71,6 +71,21 @@ namespace SmartPeak
     }
   }
 
+  void Utilities::setUserParameters(
+    OpenMS::DefaultParamHandler& Param_handler_IO,
+    const ParameterSet& user_parameters_I,
+    const std::string param_handler_name
+  )
+  {
+    std::string function_parameters_name = (param_handler_name.empty() ? Param_handler_IO.getName() : param_handler_name);
+    if (user_parameters_I.count(function_parameters_name))
+    {
+      OpenMS::Param parameters = Param_handler_IO.getParameters();
+      Utilities::updateParameters(parameters, user_parameters_I.at(function_parameters_name));
+      Param_handler_IO.setParameters(parameters);
+    }
+  }
+
   void Utilities::updateParameters(
     OpenMS::Param& Param_IO,
     const FunctionParameters& parameters_I

--- a/src/tests/class_tests/smartpeak/source/Utilities_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Utilities_test.cpp
@@ -28,6 +28,7 @@
 #include <boost/filesystem.hpp>
 #include <sys/stat.h>
 #include <SmartPeak/core/Utilities.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h>
 
 using namespace SmartPeak;
 using namespace std;
@@ -56,6 +57,44 @@ BOOST_AUTO_TEST_CASE(castString)
   Utilities::castString(string("35.35"), string("float"), c);
   BOOST_CHECK_EQUAL(c.getTag() == CastValue::Type::FLOAT, true);
   BOOST_CHECK_CLOSE(c.f_, (float)35.35, 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(setUserParameters)
+{
+  OpenMS::MRMFeatureFinderScoring feature;
+  auto param = feature.getParameters();
+  // default value is 1 for add_up_spectra
+  BOOST_CHECK_EQUAL(int(param.getValue("add_up_spectra")), 1);
+  
+  // user set parameter
+  map<std::string, vector<map<string, string>>> feat_params_struct1({
+  {"MRMFeatureFinderScoring", {
+    { {"name", "add_up_spectra"}, {"type", "int"}, {"value", "42"} },
+  }}
+  });
+  ParameterSet feat_params1(feat_params_struct1);
+  Utilities::setUserParameters(feature, feat_params1);
+  BOOST_CHECK_EQUAL(int(feature.getParameters().getValue("add_up_spectra")), 42);
+
+  // user set parameter - alias name
+  map<std::string, vector<map<string, string>>> feat_params_struct2({
+  {"AliasName", {
+    { {"name", "add_up_spectra"}, {"type", "int"}, {"value", "43"} },
+  }}
+  });
+  ParameterSet feat_params2(feat_params_struct2);
+  Utilities::setUserParameters(feature, feat_params2, "AliasName");
+  BOOST_CHECK_EQUAL(int(feature.getParameters().getValue("add_up_spectra")), 43);
+
+  // not matching parameter
+  map<std::string, vector<map<string, string>>> feat_params_struct3({
+  {"NotMatching", {
+    { {"name", "add_up_spectra"}, {"type", "int"}, {"value", "43"} },
+  }}
+  });
+  ParameterSet feat_params3(feat_params_struct3);
+  Utilities::setUserParameters(feature, feat_params3);
+  BOOST_CHECK_EQUAL(int(feature.getParameters().getValue("add_up_spectra")), 43);
 }
 
 BOOST_AUTO_TEST_CASE(updateParameters)


### PR DESCRIPTION
Removed the check on processor methods where user has to specify a minimum set of parameters to run it. Actually, we will use the default parameter values if the user doesn't specify them.

Two exceptions:
1. LoadRawData::process, where not setting the parameters will change the behavior
2. SelectFeatures::process where user is supposed to specify MRMFeatureSelector.schedule_MRMFeatures_score or MRMFeatureSelector.schedule_MRMFeatures_qmip (on of the 2)
changing these exceptions would require more work, and would break the compatibility of old parameters files (the behavior, running old parameters files, would change)

Also introduced Utilities::setUserParameters to populate OpenMS' DefaultParamHandler with the user parameter, making code more clear and simple.
