### PR TITLE
[feat/aut896] Adding issue template - bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**logs**
+Attach log file. Log, by default, can be found in:
+ - Windows: C:\Users\user_name\AppData\Local\SmartPeak
+ - Linux: /home/user_name/.SmartPeak
+ - MacOS: /Users/user_name/.SmartPeak
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**data**
+Link for data files directory [e.g O:\ScientificDep\Exp42\..].
+you can also attach public files but do not attach private data files to this report!
+
+**Version information**
+ - OS: [MacOS, Ubuntu, Windows]
+ - Version [e.g. 1.0.0]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
This is the template when user want to fill a bug report.

This is based on the template that github propose for bug report, with some minor modifications.

Note that github proposes 2 kinds of templates: bug report or features request.

