### PR TITLE
[fix/aut714] Fixed crash when launching workflow with no injection

### DIFF
--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -138,17 +138,20 @@ namespace SmartPeak
     }
 
     // Determine the number of threads to launch
-    const auto& params = injections.front().getRawData().getParameters();
     int n_threads = 6;
-    if (params.count("SequenceProcessor") && !params.at("SequenceProcessor").empty()) {
-      for (const auto& p : params.at("SequenceProcessor")) {
-        if (p.getName() == "n_thread") {
-          try {
-            n_threads = std::stoi(p.getValueAsString());
-            LOGI << "n_threads set to " << n_threads;
-          }
-          catch (const std::exception& e) {
-            LOGE << e.what();
+    if (injections.size())
+    {
+      const auto& params = injections.front().getRawData().getParameters();
+      if (params.count("SequenceProcessor") && !params.at("SequenceProcessor").empty()) {
+        for (const auto& p : params.at("SequenceProcessor")) {
+          if (p.getName() == "n_thread") {
+            try {
+              n_threads = std::stoi(p.getValueAsString());
+              LOGI << "n_threads set to " << n_threads;
+            }
+            catch (const std::exception& e) {
+              LOGE << e.what();
+            }
           }
         }
       }

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -432,6 +432,18 @@ BOOST_AUTO_TEST_CASE(processSampleGroups)
   // TODO: Selected sample group names
 }
 
+BOOST_AUTO_TEST_CASE(processSampleGroups_no_injections)
+{
+  // Try to launch ProcessSequence while no injections is set.
+  SequenceHandler sequenceHandler;
+  CreateSequence cs(sequenceHandler);
+  ProcessSequence ps(sequenceHandler);
+  const vector<std::shared_ptr<RawDataProcessor>> raw_data_processing_methods = { std::make_shared<LoadFeatures>() };
+  ps.raw_data_processing_methods_ = raw_data_processing_methods;
+  ps.process();
+  // we actually just expect it will not crash (no BOOST_CHECK)
+}
+
 BOOST_AUTO_TEST_CASE(StoreWorkflow1)
 {
   SequenceHandler sequenceHandler;


### PR DESCRIPTION
When running the processors, even if we don't have any sequence, we were getting the parameters from the injection, which do not exist, to get the nb_thread option.
Now we will just use the default value and run empty sequence which run, without crash, doing nothing.
