### PR TITLE
Smartpeak pipeline doesn't fail on test failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,9 +139,9 @@ jobs:
       - run:
           name: Running SmartPeak Class Tests
           command: |
-            set +o pipefail
+            set -e -o pipefail
             cd ~/SmartPeak/smartpeak_release_build
-            ctest -VV -F --timeout 1200 || true
+            ctest -VV -F --timeout 1200
             cd ~/SmartPeak
             export PYTHONPATH="${PWD}/tools"
             python3 -m unittest discover -s ./tools/smartpeak
@@ -261,6 +261,7 @@ jobs:
           name: Building SmartPeak, running Class Tests and Packaging
           command: |
             $ErrorActionPreference = "Stop"
+            function ThrowOnFailure($Msg) { if (-not $?) { throw $Msg } }
             Get-Content "$env:temp\vcvars64.txt" | Foreach-Object {
             if ($_ -match "^(.*?)=(.*)$") {
                 Set-Content "env:\$($matches[1])" $matches[2]
@@ -279,10 +280,13 @@ jobs:
             msbuild src/examples/SmartPeak_class_examples_smartpeak.sln /maxcpucount /property:Configuration=Release
             refreshenv
             & 'C:\Program Files\cmake\bin\ctest.exe' -VV -F
+            ThrowOnFailure "CTest failed!"
             & 'C:\Program Files\cmake\bin\cpack.exe' -G NSIS64
+            ThrowOnFailure "CPack failed!"
             cd ~/SmartPeak
             $env:PYTHONPATH = $PWD.Path + "\tools"
             python -m unittest discover -s .\tools\smartpeak\
+            ThrowOnFailure "Python tests failed!"
       - run:
           name: Signing SmartPeak with trusted certificate
           command: |


### PR DESCRIPTION
This should prevent CircleCI from reporting a success for jobs that fail tests.