### PR TITLE
CI: use requirements.txt to install python dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ jobs:
           name: "Install prerequisites"
           command: |
             apt-get update
-            pip install gitpython
+            pip install -r tools/smartpeak/requirements.txt
       - add_ssh_keys:
           fingerprints:
             - "e8:9a:a0:0b:75:00:75:1c:04:71:9c:7d:07:af:a2:0d"


### PR DESCRIPTION
CI failed on the trigger release step.

https://app.circleci.com/pipelines/github/AutoFlowResearch/SmartPeak?branch=develop
(this release trigger has been triggered because there was the word "release" in the comments right?)

it seems to be because we don't get python dependence modules with the requirment.txt

![image](https://user-images.githubusercontent.com/1705849/114142197-ed063480-9912-11eb-95c6-42abea695c07.png)
