### PR TITLE
Feat/aut950 - Ability to export Sequence

### DIFF
--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -584,6 +584,13 @@ int main(int argc, char** argv)
           //if (ImGui::MenuItem("Sequence")) {} // TODO: updated sequence file
           //if (ImGui::MenuItem("Transitions")) {} // TODO: updated transitions file
           //if (ImGui::MenuItem("Standards Conc")) {} // TODO: updated standards concentration file
+          if (ImGui::MenuItem("Sequence")) {
+            static StoreSequenceFileSmartPeak processor(application_handler_);
+            processor.process();
+//            file_picker_.setProcessor(processor);
+//            file_picker_.visible_ = true;
+//            update_session_cache_ = true;
+          }
           if (ImGui::MenuItem("Parameters")) {
             static StoreSequenceParameters processor(application_handler_);
             file_picker_.setProcessor(processor);

--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -585,11 +585,9 @@ int main(int argc, char** argv)
           //if (ImGui::MenuItem("Transitions")) {} // TODO: updated transitions file
           //if (ImGui::MenuItem("Standards Conc")) {} // TODO: updated standards concentration file
           if (ImGui::MenuItem("Sequence")) {
-            static StoreSequenceFileSmartPeak processor(application_handler_);
-            processor.process();
-//            file_picker_.setProcessor(processor);
-//            file_picker_.visible_ = true;
-//            update_session_cache_ = true;
+            static StoreSequence processor(application_handler_);
+            file_picker_.setProcessor(processor);
+            file_picker_.visible_ = true;
           }
           if (ImGui::MenuItem("Parameters")) {
             static StoreSequenceParameters processor(application_handler_);

--- a/src/smartpeak/include/SmartPeak/core/ApplicationProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/ApplicationProcessor.h
@@ -103,6 +103,13 @@ namespace SmartPeak
     std::string getName() const override { return "LoadSequenceParameters"; };
   };
 
+  struct StoreSequence : FilePickerProcessor {
+    StoreSequence(ApplicationHandler& application_handler) :
+      FilePickerProcessor(application_handler) {}
+    bool process() override;
+    std::string getName() const override { return "StoreSequence"; };
+  };
+
   struct StoreSequenceParameters : FilePickerProcessor {
     StoreSequenceParameters(ApplicationHandler& application_handler) :
       FilePickerProcessor(application_handler) {}
@@ -210,6 +217,7 @@ namespace SmartPeak
     StoreSequenceFileSmartPeak(ApplicationHandler& application_handler) : ApplicationProcessor(application_handler) {}
     bool process() override;
     std::string getName() const override { return "StoreSequenceFileSmartPeak"; };
+    std::string pathname_;
   };
 
   struct StoreSequenceFileAnalyst : ApplicationProcessor {

--- a/src/smartpeak/include/SmartPeak/core/ApplicationProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/ApplicationProcessor.h
@@ -206,6 +206,12 @@ namespace SmartPeak
     std::string getName() const override { return "LoadSequenceSegmentFeatureBackgroundQCComponentGroups"; };
   };
 
+  struct StoreSequenceFileSmartPeak : ApplicationProcessor {
+    StoreSequenceFileSmartPeak(ApplicationHandler& application_handler) : ApplicationProcessor(application_handler) {}
+    bool process() override;
+    std::string getName() const override { return "StoreSequenceFileSmartPeak"; };
+  };
+
   struct StoreSequenceFileAnalyst : ApplicationProcessor {
     StoreSequenceFileAnalyst(ApplicationHandler& application_handler) : ApplicationProcessor(application_handler) {}
     bool process() override;

--- a/src/smartpeak/include/SmartPeak/core/MetaDataHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/MetaDataHandler.h
@@ -71,35 +71,41 @@ public:
 
     std::string getAcquisitionDateAndTimeAsString(const std::string& format = "%Y-%m-%d_%H%M%S") const;
 
-    std::string getRackNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const
-    {
-      return ((rack_number != -1) || (!undefined_str)) ? std::to_string(rack_number) : *undefined_str;
-    }
+    /**
+     @brief return string form of rack number
+     @param[in] undefined_str string to return if the value is not defined
+    */
+    std::string getRackNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const;
 
-    std::string getPlateNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const
-    {
-      return ((plate_number != -1) || (!undefined_str)) ? std::to_string(plate_number) : *undefined_str;
-    }
+    /**
+      @brief return string form of plate number
+      @param[in] undefined_str string to return if the value is not defined
+    */
+    std::string getPlateNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const;
+    
+    /**
+      @brief return string form of pos number
+      @param[in] undefined_str string to return if the value is not defined
+    */
+    std::string getPosNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const;
 
-    std::string getPosNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const
-    {
-      return ((pos_number != -1) || (!undefined_str)) ? std::to_string(pos_number) : *undefined_str;
-    }
+    /**
+      @brief return string form of injection number
+      @param[in] undefined_str string to return if the value is not defined
+    */
+    std::string getInjectionNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const;
 
-    std::string getInjectionNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const
-    {
-      return ((inj_number != -1) || (!undefined_str)) ? std::to_string(inj_number) : *undefined_str;
-    }
+    /**
+      @brief return string form of mass low value
+      @param[in] undefined_str string to return if the value is not defined
+    */
+    std::string getScanMassLowAsString(std::optional<std::string> undefined_str = std::nullopt) const;
 
-    std::string getScanMassLowAsString(std::optional<std::string> undefined_str = std::nullopt) const
-    {
-      return ((scan_mass_low != 0.0f) || (!undefined_str)) ? std::to_string(scan_mass_low) : *undefined_str;
-    }
-
-    std::string getScanMassHighAsString(std::optional<std::string> undefined_str = std::nullopt) const
-    {
-      return ((scan_mass_high != 1e12f) || (!undefined_str)) ? std::to_string(scan_mass_high) : *undefined_str;
-    }
+    /**
+      @brief return string form of mass high
+      @param[in] undefined_str string to return if the value is not defined
+    */
+    std::string getScanMassHighAsString(std::optional<std::string> undefined_str = std::nullopt) const;
 
     // required
     std::string acq_method_name;

--- a/src/smartpeak/include/SmartPeak/core/MetaDataHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/MetaDataHandler.h
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <ctime>
+#include <optional>
 
 namespace SmartPeak {
   class MetaDataHandler {
@@ -70,6 +71,36 @@ public:
 
     std::string getAcquisitionDateAndTimeAsString(const std::string& format = "%Y-%m-%d_%H%M%S") const;
 
+    std::string getRackNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const
+    {
+      return ((rack_number != -1) || (!undefined_str)) ? std::to_string(rack_number) : *undefined_str;
+    }
+
+    std::string getPlateNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const
+    {
+      return ((plate_number != -1) || (!undefined_str)) ? std::to_string(plate_number) : *undefined_str;
+    }
+
+    std::string getPosNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const
+    {
+      return ((pos_number != -1) || (!undefined_str)) ? std::to_string(pos_number) : *undefined_str;
+    }
+
+    std::string getInjectionNumberAsString(std::optional<std::string> undefined_str = std::nullopt) const
+    {
+      return ((inj_number != -1) || (!undefined_str)) ? std::to_string(inj_number) : *undefined_str;
+    }
+
+    std::string getScanMassLowAsString(std::optional<std::string> undefined_str = std::nullopt) const
+    {
+      return ((scan_mass_low != 0.0f) || (!undefined_str)) ? std::to_string(scan_mass_low) : *undefined_str;
+    }
+
+    std::string getScanMassHighAsString(std::optional<std::string> undefined_str = std::nullopt) const
+    {
+      return ((scan_mass_high != 1e12f) || (!undefined_str)) ? std::to_string(scan_mass_high) : *undefined_str;
+    }
+
     // required
     std::string acq_method_name;
     float inj_volume = -1.0;
@@ -87,8 +118,8 @@ public:
     std::string proc_method_name;
     std::tm acquisition_date_and_time = { 0, 0, 0, 1, 0, 0, 0, 0, 0 }; // Need to start at Day 1 of the month
     std::string scan_polarity = "Unknown";
-    float scan_mass_low = 0.0; // in Da
-    float scan_mass_high = 1e12; // in Da
+    float scan_mass_low = 0.0f; // in Da
+    float scan_mass_high = 1e12f; // in Da
 
   protected:
     // required

--- a/src/smartpeak/include/SmartPeak/io/SequenceParser.h
+++ b/src/smartpeak/include/SmartPeak/io/SequenceParser.h
@@ -51,6 +51,18 @@ public:
       const std::string& delimiter
     );
 
+    static void makeSequenceFileSmartPeak(
+      SequenceHandler& sequenceHandler,
+      std::vector<std::vector<std::string>>& rows_out,
+      std::vector<std::string>& headers_out
+    );
+
+    static void writeSequenceFileSmartPeak(
+      SequenceHandler& sequenceHandler,
+      const std::string& filename,
+      const std::string& delimiter = ","
+    );
+
     static void makeSequenceFileAnalyst(
       SequenceHandler& sequenceHandler,
       std::vector<std::vector<std::string>>& rows_out,
@@ -87,28 +99,6 @@ public:
       const std::string& delimiter = "\t"
     );
 
-    template<typename T>
-    static bool validateAndConvert(
-      const std::string& s,
-      T& output
-    )
-    {
-      if (Utilities::trimString(s).empty()) {
-        return false;
-      }
-
-      if (std::is_same<T, int>::value) {
-        output = std::stoi(s);
-      } else if (std::is_same<T, float>::value) {
-        output = std::stof(s);
-      } else {
-        LOGE << "Case not handled";
-        return false;
-      }
-
-      return true;
-    }
-
     /*
     @brief make a table (row major) of string representations of
       all meta_data for all sample_types in the feature history.
@@ -132,34 +122,6 @@ public:
       const std::vector<FeatureMetadata>& meta_data,
       const std::set<SampleType>& sample_types
     );
-
-    struct Row
-    {
-      Row() = default;
-      ~Row() = default;
-      Row(const Row&) = default;
-      Row& operator=(const Row&) = default;
-      Row(Row&&) = default;
-      Row& operator=(Row&&) = default;
-
-      Row(const std::string& cgn, const std::string& cn, const std::string& mvn) :
-        component_group_name(cgn),
-        component_name(cn),
-        meta_value_name(mvn) {}
-
-      std::string component_group_name;
-      std::string component_name;
-      std::string meta_value_name;
-    };
-
-    struct Row_less
-    {
-      bool operator()(const Row& lhs, const Row& rhs) const
-      {
-        return lhs.component_group_name + lhs.component_name + lhs.meta_value_name <
-          rhs.component_group_name + rhs.component_name + rhs.meta_value_name;
-      }
-    };
 
     static void makeDataMatrixFromMetaValue(
       const SequenceHandler& sequenceHandler,

--- a/src/smartpeak/source/core/ApplicationProcessor.cpp
+++ b/src/smartpeak/source/core/ApplicationProcessor.cpp
@@ -366,6 +366,22 @@ namespace SmartPeak
     }
   }
 
+  bool StoreSequence::process()
+  {
+    if (application_handler_.sequenceHandler_.getSequence().size()) {
+      RawDataHandler& rawDataHandler = application_handler_.sequenceHandler_.getSequence().at(0).getRawData();
+      StoreSequenceFileSmartPeak storeSequenceSmartPeak(application_handler_);
+      storeSequenceSmartPeak.pathname_ = pathname_;
+      storeSequenceSmartPeak.process();
+      return true;
+    }
+    else
+    {
+      LOGE << "Parameters file cannot be stored without first loading the sequence.";
+      return false;
+    }
+  }
+
   bool StoreSequenceParameters::process()
   {
     if (application_handler_.sequenceHandler_.getSequence().size()) {
@@ -667,7 +683,7 @@ namespace SmartPeak
 
   bool StoreSequenceFileSmartPeak::process() {
     if (application_handler_.sequenceHandler_.getSequence().size()) {
-      SequenceParser::writeSequenceFileSmartPeak(application_handler_.sequenceHandler_, application_handler_.main_dir_ + "/test.csv");
+      SequenceParser::writeSequenceFileSmartPeak(application_handler_.sequenceHandler_, pathname_);
       return true;
     }
     else

--- a/src/smartpeak/source/core/ApplicationProcessor.cpp
+++ b/src/smartpeak/source/core/ApplicationProcessor.cpp
@@ -665,6 +665,18 @@ namespace SmartPeak
     }
   }
 
+  bool StoreSequenceFileSmartPeak::process() {
+    if (application_handler_.sequenceHandler_.getSequence().size()) {
+      SequenceParser::writeSequenceFileSmartPeak(application_handler_.sequenceHandler_, application_handler_.main_dir_ + "/test.csv");
+      return true;
+    }
+    else
+    {
+      LOGE << "Sequence file cannot be converted and stored without first loading the sequence.";
+      return false;
+    }
+  }
+
   bool StoreSequenceFileAnalyst::process() {
     if (application_handler_.sequenceHandler_.getSequence().size()) {
       SequenceParser::writeSequenceFileAnalyst(application_handler_.sequenceHandler_, application_handler_.main_dir_ + "/SequenceFileAnalyst.txt");

--- a/src/smartpeak/source/core/MetaDataHandler.cpp
+++ b/src/smartpeak/source/core/MetaDataHandler.cpp
@@ -262,4 +262,34 @@ namespace SmartPeak
     std::string acquisition_datetime(time_repr);
     return acquisition_datetime;
   }
+
+  std::string MetaDataHandler::getRackNumberAsString(std::optional<std::string> undefined_str) const
+  {
+    return ((rack_number != -1) || (!undefined_str)) ? std::to_string(rack_number) : *undefined_str;
+  }
+
+  std::string MetaDataHandler::getPlateNumberAsString(std::optional<std::string> undefined_str) const
+  {
+    return ((plate_number != -1) || (!undefined_str)) ? std::to_string(plate_number) : *undefined_str;
+  }
+
+  std::string MetaDataHandler::getPosNumberAsString(std::optional<std::string> undefined_str) const
+  {
+    return ((pos_number != -1) || (!undefined_str)) ? std::to_string(pos_number) : *undefined_str;
+  }
+
+  std::string MetaDataHandler::getInjectionNumberAsString(std::optional<std::string> undefined_str) const
+  {
+    return ((inj_number != -1) || (!undefined_str)) ? std::to_string(inj_number) : *undefined_str;
+  }
+
+  std::string MetaDataHandler::getScanMassLowAsString(std::optional<std::string> undefined_str) const
+  {
+    return ((scan_mass_low != 0.0f) || (!undefined_str)) ? std::to_string(scan_mass_low) : *undefined_str;
+  }
+
+  std::string MetaDataHandler::getScanMassHighAsString(std::optional<std::string> undefined_str) const
+  {
+    return ((scan_mass_high != 1e12f) || (!undefined_str)) ? std::to_string(scan_mass_high) : *undefined_str;
+  }
 }

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -44,17 +44,21 @@ namespace SmartPeak
     T& output
   )
   {
-    if (Utilities::trimString(s).empty()) {
+    if (Utilities::trimString(s).empty())
+    {
       return false;
     }
 
-    if (std::is_same<T, int>::value) {
+    if (std::is_same<T, int>::value)
+    {
       output = std::stoi(s);
     }
-    else if (std::is_same<T, float>::value) {
+    else if (std::is_same<T, float>::value)
+    {
       output = std::stof(s);
     }
-    else {
+    else
+    {
       LOGE << "Case not handled";
       return false;
     }

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -293,7 +293,7 @@ namespace SmartPeak
   {
     using namespace std::string_literals;
 
-    // Headers expected by the Analyst software
+    // Headers expected by the SmartPeak software
     headers_out.clear();
     headers_out = {
       "sample_name",

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -37,6 +37,31 @@
 
 namespace SmartPeak
 {
+
+  template<typename T>
+  static bool validateAndConvert(
+    const std::string& s,
+    T& output
+  )
+  {
+    if (Utilities::trimString(s).empty()) {
+      return false;
+    }
+
+    if (std::is_same<T, int>::value) {
+      output = std::stoi(s);
+    }
+    else if (std::is_same<T, float>::value) {
+      output = std::stof(s);
+    }
+    else {
+      LOGE << "Case not handled";
+      return false;
+    }
+
+    return true;
+  }
+
   template<typename DELIMITER>
   void SequenceParser::readSequenceFile(
     SequenceHandler& sequenceHandler,
@@ -258,6 +283,98 @@ namespace SmartPeak
     }
 
     LOGD << "END readSequenceFile";
+  }
+
+  void SequenceParser::makeSequenceFileSmartPeak(SequenceHandler& sequenceHandler, std::vector<std::vector<std::string>>& rows_out, std::vector<std::string>& headers_out)
+  {
+    using namespace std::string_literals;
+
+    // Headers expected by the Analyst software
+    headers_out.clear();
+    headers_out = {
+      "sample_name",
+      "sample_group_name",
+      "sequence_segment_name",
+      "replicate_group_name",
+      "sample_type",
+      "original_filename",
+      "proc_method_name",
+      "rack_number",
+      "plate_number",
+      "pos_number",
+      "inj_number",
+      "dilution_factor",
+      "acq_method_name",
+      "operator_name",
+      "acquisition_date_and_time",
+      "inj_volume",
+      "inj_volume_units",
+      "batch_name",
+      "scan_polarity",
+      "scan_mass_low",
+      "scan_mass_high"
+    };
+
+    rows_out.clear();
+    for (const InjectionHandler& sampleHandler : sequenceHandler.getSequence()) {
+      std::vector<std::string> row;
+      const MetaDataHandler& mdh = sampleHandler.getMetaData();
+      row.push_back(mdh.getSampleName());
+      row.push_back(mdh.getSampleGroupName());
+      row.push_back(mdh.getSequenceSegmentName());
+      row.push_back(mdh.getReplicateGroupName());
+      row.push_back(mdh.getSampleTypeAsString());
+      row.push_back(mdh.getFilename());
+      row.push_back(mdh.proc_method_name);
+      row.push_back(mdh.getRackNumberAsString(""s));
+      row.push_back(mdh.getPlateNumberAsString(""s));
+      row.push_back(mdh.getPosNumberAsString(""s));
+      row.push_back(mdh.getInjectionNumberAsString(""s));
+      row.push_back(std::to_string(mdh.dilution_factor));
+      row.push_back(mdh.acq_method_name);
+      row.push_back(mdh.operator_name);
+      row.push_back(mdh.getAcquisitionDateAndTimeAsString());
+      row.push_back(std::to_string(mdh.inj_volume));
+      row.push_back(mdh.inj_volume_units);
+      row.push_back(mdh.batch_name);
+      row.push_back(mdh.scan_polarity);
+      row.push_back(mdh.getScanMassLowAsString(""s));
+      row.push_back(mdh.getScanMassHighAsString(""s));
+      rows_out.push_back(row);
+    }
+  }
+
+  void SequenceParser::writeSequenceFileSmartPeak(SequenceHandler& sequenceHandler, const std::string& filename, const std::string& delimiter)
+  {
+    LOGD << "START writeSequenceFileSmartPeak";
+    LOGD << "Delimiter: " << delimiter;
+
+    LOGI << "Loading: " << filename;
+
+    if (filename.empty()) {
+      LOGE << "filename is empty";
+      LOGD << "END writeSequenceFileSmartPeak";
+      return;
+    }
+
+    // Make the file
+    std::vector<std::vector<std::string>> rows;
+    std::vector<std::string> headers;
+    makeSequenceFileSmartPeak(sequenceHandler, rows, headers);
+
+    // Write the output file
+    CSVWriter writer(filename, delimiter);
+    const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
+
+    if (cnt < headers.size()) {
+      LOGD << "END writeSequenceFileSmartPeak";
+    }
+
+    for (const std::vector<std::string>& line : rows) {
+      writer.writeDataInRow(line.cbegin(), line.cend());
+    }
+
+    LOGD << "END writeSequenceFileSmartPeak";
   }
 
   void SequenceParser::makeSequenceFileAnalyst(SequenceHandler& sequenceHandler, std::vector<std::vector<std::string>>& rows_out, std::vector<std::string>& headers_out)
@@ -667,6 +784,34 @@ namespace SmartPeak
     LOGD << "END writeDataTableFromMetaValue";
     return true;
   }
+
+  struct Row
+  {
+    Row() = default;
+    ~Row() = default;
+    Row(const Row&) = default;
+    Row& operator=(const Row&) = default;
+    Row(Row&&) = default;
+    Row& operator=(Row&&) = default;
+
+    Row(const std::string& cgn, const std::string& cn, const std::string& mvn) :
+      component_group_name(cgn),
+      component_name(cn),
+      meta_value_name(mvn) {}
+
+    std::string component_group_name;
+    std::string component_name;
+    std::string meta_value_name;
+  };
+
+  struct Row_less
+  {
+    bool operator()(const Row& lhs, const Row& rhs) const
+    {
+      return lhs.component_group_name + lhs.component_name + lhs.meta_value_name <
+        rhs.component_group_name + rhs.component_name + rhs.meta_value_name;
+    }
+  };
 
   void SequenceParser::makeDataMatrixFromMetaValue(
     const SequenceHandler& sequenceHandler,

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -363,6 +363,7 @@ namespace SmartPeak
 
     // Make the file
     std::vector<std::vector<std::string>> rows;
+    //  deepcode ignore ContainerUpdatedButNeverQueried: headers are used, looks like false positive
     std::vector<std::string> headers;
     makeSequenceFileSmartPeak(sequenceHandler, rows, headers);
 
@@ -432,6 +433,7 @@ namespace SmartPeak
 
     // Make the file
     std::vector<std::vector<std::string>> rows;
+    //  deepcode ignore ContainerUpdatedButNeverQueried: headers are used, looks like false positive
     std::vector<std::string> headers;
     makeSequenceFileAnalyst(sequenceHandler, rows, headers);
 
@@ -495,6 +497,7 @@ namespace SmartPeak
 
     // Make the file
     std::vector<std::vector<std::string>> rows;
+    //  deepcode ignore ContainerUpdatedButNeverQueried: headers are used, looks like false positive
     std::vector<std::string> headers;
     makeSequenceFileMasshunter(sequenceHandler, rows, headers);
 

--- a/src/tests/class_tests/smartpeak/source/MetaDataHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/MetaDataHandler_test.cpp
@@ -173,4 +173,70 @@ BOOST_AUTO_TEST_CASE(getInjectionName)
   BOOST_CHECK_EQUAL(m.getInjectionName(), "SampleName_14_BatchName_2019-01-31_154055");
 }
 
+BOOST_AUTO_TEST_CASE(getRackNumberAsString)
+{
+  using namespace std::string_literals;
+  MetaDataHandler m;
+  BOOST_CHECK_EQUAL(m.getRackNumberAsString(), "-1");
+  BOOST_CHECK_EQUAL(m.getRackNumberAsString("invalid"s), "invalid");
+  m.rack_number = 42;
+  BOOST_CHECK_EQUAL(m.getRackNumberAsString(), "42");
+  BOOST_CHECK_EQUAL(m.getRackNumberAsString("invalid"s), "42");
+}
+
+BOOST_AUTO_TEST_CASE(getPlateNumberAsString)
+{
+  using namespace std::string_literals;
+  MetaDataHandler m;
+  BOOST_CHECK_EQUAL(m.getPlateNumberAsString(), "-1");
+  BOOST_CHECK_EQUAL(m.getPlateNumberAsString("invalid"s), "invalid");
+  m.plate_number = 42;
+  BOOST_CHECK_EQUAL(m.getPlateNumberAsString(), "42");
+  BOOST_CHECK_EQUAL(m.getPlateNumberAsString("invalid"s), "42");
+}
+
+BOOST_AUTO_TEST_CASE(getPosNumberAsString)
+{
+  using namespace std::string_literals;
+  MetaDataHandler m;
+  BOOST_CHECK_EQUAL(m.getPosNumberAsString(), "-1");
+  BOOST_CHECK_EQUAL(m.getPosNumberAsString("invalid"s), "invalid");
+  m.pos_number = 42;
+  BOOST_CHECK_EQUAL(m.getPosNumberAsString(), "42");
+  BOOST_CHECK_EQUAL(m.getPosNumberAsString("invalid"s), "42");
+}
+
+BOOST_AUTO_TEST_CASE(getInjectionNumberAsString)
+{
+  using namespace std::string_literals;
+  MetaDataHandler m;
+  BOOST_CHECK_EQUAL(m.getInjectionNumberAsString(), "-1");
+  BOOST_CHECK_EQUAL(m.getInjectionNumberAsString("invalid"s), "invalid");
+  m.inj_number = 42;
+  BOOST_CHECK_EQUAL(m.getInjectionNumberAsString(), "42");
+  BOOST_CHECK_EQUAL(m.getInjectionNumberAsString("invalid"s), "42");
+}
+
+BOOST_AUTO_TEST_CASE(getScanMassLowAsString)
+{
+  using namespace std::string_literals;
+  MetaDataHandler m;
+  BOOST_CHECK_EQUAL(m.getScanMassLowAsString(), "0.000000");
+  BOOST_CHECK_EQUAL(m.getScanMassLowAsString("invalid"s), "invalid");
+  m.scan_mass_low = 42;
+  BOOST_CHECK_EQUAL(m.getScanMassLowAsString(), "42.000000");
+  BOOST_CHECK_EQUAL(m.getScanMassLowAsString("invalid"s), "42.000000");
+}
+
+BOOST_AUTO_TEST_CASE(getScanMassHighAsString)
+{
+  using namespace std::string_literals;
+  MetaDataHandler m;
+  BOOST_CHECK_EQUAL(m.getScanMassHighAsString(), "999999995904.000000");
+  BOOST_CHECK_EQUAL(m.getScanMassHighAsString("invalid"s), "invalid");
+  m.scan_mass_high = 42;
+  BOOST_CHECK_EQUAL(m.getScanMassHighAsString(), "42.000000");
+  BOOST_CHECK_EQUAL(m.getScanMassHighAsString("invalid"s), "42.000000");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/class_tests/smartpeak/source/SequenceParser_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceParser_test.cpp
@@ -343,6 +343,99 @@ BOOST_AUTO_TEST_CASE(makeDataMatrixFromMetaValue)
   // SequenceParser::writeDataMatrixFromMetaValue(sequenceHandler, pathname_output);
 }
 
+BOOST_AUTO_TEST_CASE(makeSequenceSmartPeak)
+{
+  SequenceHandler sequenceHandler;
+
+  const vector<string> sample_names = {
+    "170808_Jonathan_yeast_Sacc1_1x",
+    "170808_Jonathan_yeast_Sacc2_1x",
+    "170808_Jonathan_yeast_Sacc3_1x",
+    "170808_Jonathan_yeast_Yarr1_1x",
+    "170808_Jonathan_yeast_Yarr2_1x",
+    "170808_Jonathan_yeast_Yarr3_1x"
+  };
+
+  int inj_num = 0;
+  for (const string& sample_name : sample_names) {
+    ++inj_num;
+    MetaDataHandler metaDataHandler;
+    metaDataHandler.setSampleName(sample_name);
+    metaDataHandler.setSampleType(SampleType::Unknown);
+    metaDataHandler.setSampleGroupName("sample_group");
+    metaDataHandler.setSequenceSegmentName("sequence_segment");
+    metaDataHandler.setReplicateGroupName("replicate_group_name");
+    metaDataHandler.plate_number = 3;
+    metaDataHandler.rack_number = 4;
+    metaDataHandler.pos_number = inj_num;
+    metaDataHandler.dilution_factor = 8.0;
+    metaDataHandler.setAcquisitionDateAndTimeFromString("01-01-2020 17:14:00", "%m-%d-%Y %H:%M:%S");
+    metaDataHandler.inj_number = inj_num;
+    metaDataHandler.acq_method_name = "RapidRIP";
+    metaDataHandler.inj_volume = 7.0;
+    metaDataHandler.inj_volume_units = "8";
+    metaDataHandler.batch_name = "FluxTest";
+    metaDataHandler.scan_polarity = "negative";
+    metaDataHandler.scan_mass_high = 2000;
+    metaDataHandler.scan_mass_low = 60;
+    metaDataHandler.setFilename(metaDataHandler.getInjectionName());
+
+    sequenceHandler.addSampleToSequence(metaDataHandler, OpenMS::FeatureMap());
+  }
+
+  vector<vector<string>> data_out;
+  vector<string> headers_out;
+
+  SequenceParser::makeSequenceFileSmartPeak(sequenceHandler, data_out, headers_out);
+
+  BOOST_CHECK_EQUAL(data_out.size(), 6);
+  BOOST_REQUIRE(data_out.at(0).size() == 21);
+  BOOST_CHECK_EQUAL(data_out.at(0).at(0), "170808_Jonathan_yeast_Sacc1_1x");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(1), "sample_group");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(2), "sequence_segment");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(3), "replicate_group_name");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(4), "Unknown");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(5), "170808_Jonathan_yeast_Sacc1_1x_1_FluxTest_2020-01-01_171400");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(6), "");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(7), "4");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(8), "3");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(9), "1");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(10), "1");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(11), "8.000000");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(12), "RapidRIP");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(13), "");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(14), "2020-01-01_171400");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(15), "7.000000");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(16), "8");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(17), "FluxTest");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(18), "negative");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(19), "60.000000");
+  BOOST_CHECK_EQUAL(data_out.at(0).at(20), "2000.000000");
+
+  BOOST_CHECK_EQUAL(headers_out.size(), 21);
+  BOOST_CHECK_EQUAL(headers_out.at(0), "sample_name");
+  BOOST_CHECK_EQUAL(headers_out.at(1), "sample_group_name");
+  BOOST_CHECK_EQUAL(headers_out.at(2), "sequence_segment_name");
+  BOOST_CHECK_EQUAL(headers_out.at(3), "replicate_group_name");
+  BOOST_CHECK_EQUAL(headers_out.at(4), "sample_type");
+  BOOST_CHECK_EQUAL(headers_out.at(5), "original_filename");
+  BOOST_CHECK_EQUAL(headers_out.at(6), "proc_method_name");
+  BOOST_CHECK_EQUAL(headers_out.at(7), "rack_number");
+  BOOST_CHECK_EQUAL(headers_out.at(8), "plate_number");
+  BOOST_CHECK_EQUAL(headers_out.at(9), "pos_number");
+  BOOST_CHECK_EQUAL(headers_out.at(10), "inj_number");
+  BOOST_CHECK_EQUAL(headers_out.at(11), "dilution_factor");
+  BOOST_CHECK_EQUAL(headers_out.at(12), "acq_method_name");
+  BOOST_CHECK_EQUAL(headers_out.at(13), "operator_name");
+  BOOST_CHECK_EQUAL(headers_out.at(14), "acquisition_date_and_time");
+  BOOST_CHECK_EQUAL(headers_out.at(15), "inj_volume");
+  BOOST_CHECK_EQUAL(headers_out.at(16), "inj_volume_units");
+  BOOST_CHECK_EQUAL(headers_out.at(17), "batch_name");
+  BOOST_CHECK_EQUAL(headers_out.at(18), "scan_polarity");
+  BOOST_CHECK_EQUAL(headers_out.at(19), "scan_mass_low");
+  BOOST_CHECK_EQUAL(headers_out.at(20), "scan_mass_high");
+}
+
 BOOST_AUTO_TEST_CASE(makeSequenceFileAnalyst)
 {
   SequenceHandler sequenceHandler;


### PR DESCRIPTION
Add the ability to export the sequence.
unlike the other export sequence options (MassHunter, ...), but as the export parameter or export workflow does, the file picker is shown here to let the user choose what file to write.

The other export sequence commands should also use the file picker, but I think we may need some rework, factorization about all these processors that use the FilePicker. An internal ticket has been open for that, we can handle this in another story.
