### PR TITLE
[fix/aut953] fixed crash when updating parameters list

### DIFF
--- a/src/smartpeak/source/ui/ParametersTableWidget.cpp
+++ b/src/smartpeak/source/ui/ParametersTableWidget.cpp
@@ -63,6 +63,7 @@ namespace SmartPeak
   void ParametersTableWidget::updateParametersTable()
   {
     parameters_.clear();
+    is_scanned_ = false;
     if (application_handler_.sequenceHandler_.getSequence().size() > 0)
     {
       parameters_ = application_handler_.sequenceHandler_.getSequence().at(0).getRawData().getParameters();


### PR DESCRIPTION
to synchronize search data (parameters_table_entries_) with the parameters, we need to reset is_scanned_  flag in the updateParametersTable 