### PR TITLE
Fix/aut954 fixed crash when loading multiple sequence

### DIFF
--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -122,10 +122,10 @@ int main(int argc, char** argv)
   auto spectra_plot_widget_ = std::make_shared<SpectraPlotWidget>(session_handler_, application_handler_.sequenceHandler_, "Spectra Main Window", "Spectra", event_dispatcher);
   auto feature_line_plot_ = std::make_shared<LinePlot2DWidget>("Features (line)");
   auto calibrators_line_plot_ = std::make_shared<CalibratorsPlotWidget>("Calibrators");
-  auto injections_explorer_window_ = std::make_shared<ExplorerWidget>("InjectionsExplorerWindow", "Injections");
-  auto transitions_explorer_window_ = std::make_shared<ExplorerWidget>("TransitionsExplorerWindow", "Transitions");
-  auto features_explorer_window_ = std::make_shared<ExplorerWidget>("FeaturesExplorerWindow", "Features");
-  auto spectrum_explorer_window_ = std::make_shared<ExplorerWidget>("SpectrumExplorerWindow", "Spectrum");
+  auto injections_explorer_window_ = std::make_shared<ExplorerWidget>("InjectionsExplorerWindow", "Injections", &event_dispatcher);
+  auto transitions_explorer_window_ = std::make_shared<ExplorerWidget>("TransitionsExplorerWindow", "Transitions", &event_dispatcher);
+  auto features_explorer_window_ = std::make_shared<ExplorerWidget>("FeaturesExplorerWindow", "Features", &event_dispatcher);
+  auto spectrum_explorer_window_ = std::make_shared<ExplorerWidget>("SpectrumExplorerWindow", "Spectrum", &event_dispatcher);
   auto sequence_main_window_ = std::make_shared<SequenceTableWidget>("SequenceMainWindow", "Sequence",
                                                                       &session_handler_, &application_handler_.sequenceHandler_);
   auto transitions_main_window_ = std::make_shared<GenericTableWidget>("TransitionsMainWindow", "Transitions");
@@ -348,8 +348,6 @@ int main(int argc, char** argv)
 
     { // keeping this block to easily collapse/expand the bulk of the loop
       // Intialize the window sizes
-
-      event_dispatcher.dispatchEvents();
 
       win_size_and_pos.setXAndYSizes(io.DisplaySize.x, io.DisplaySize.y);
       if ((!workflow_is_done_) && workflow_manager_.isWorkflowDone()) // workflow just finished
@@ -683,6 +681,8 @@ int main(int argc, char** argv)
       
       ImGui::EndMainMenuBar();
     }
+
+    event_dispatcher.dispatchEvents();
 
     // ======================================
     // Window size computation

--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -349,6 +349,10 @@ int main(int argc, char** argv)
     { // keeping this block to easily collapse/expand the bulk of the loop
       // Intialize the window sizes
 
+      session_handler_.setMinimalDataAndFilters(application_handler_.sequenceHandler_);
+
+      event_dispatcher.dispatchEvents();
+
       win_size_and_pos.setXAndYSizes(io.DisplaySize.x, io.DisplaySize.y);
       if ((!workflow_is_done_) && workflow_manager_.isWorkflowDone()) // workflow just finished
       {
@@ -682,8 +686,6 @@ int main(int argc, char** argv)
       ImGui::EndMainMenuBar();
     }
 
-    event_dispatcher.dispatchEvents();
-
     // ======================================
     // Window size computation
     // ======================================
@@ -701,8 +703,6 @@ int main(int argc, char** argv)
     // all of them yet)
     // ======================================
     
-    session_handler_.setMinimalDataAndFilters(application_handler_.sequenceHandler_);
-
     // Sequence
     if (sequence_main_window_->visible_)
     {

--- a/src/smartpeak/include/SmartPeak/ui/Widget.h
+++ b/src/smartpeak/include/SmartPeak/ui/Widget.h
@@ -304,7 +304,10 @@ namespace SmartPeak
     ExplorerWidget(const std::string& table_id, const std::string title ="", SequenceObservable* sequence_observable = nullptr)
       :GenericTableWidget(table_id, title)
     {
-      sequence_observable->addSequenceObserver(this);
+      if (sequence_observable)
+      {
+        sequence_observable->addSequenceObserver(this);
+      }
     };
     /*
     @brief Show the explorer

--- a/src/smartpeak/include/SmartPeak/ui/Widget.h
+++ b/src/smartpeak/include/SmartPeak/ui/Widget.h
@@ -296,11 +296,16 @@ namespace SmartPeak
     - searching
     - color coding of rows by status
   */
-  class ExplorerWidget final : public GenericTableWidget
+  class ExplorerWidget final : 
+    public GenericTableWidget,
+    public ISequenceObserver
   {
   public:
-    ExplorerWidget(const std::string& table_id, const std::string title ="")
-      :GenericTableWidget(table_id, title) {};
+    ExplorerWidget(const std::string& table_id, const std::string title ="", SequenceObservable* sequence_observable = nullptr)
+      :GenericTableWidget(table_id, title)
+    {
+      sequence_observable->addSequenceObserver(this);
+    };
     /*
     @brief Show the explorer
 
@@ -309,6 +314,12 @@ namespace SmartPeak
     @param[in,out] checked_rows What rows are checked/filtered
     */
     void draw() override;
+
+    /**
+    ISequenceObserver
+    */
+    virtual void onSequenceUpdated() override;
+
     Eigen::Tensor<std::string, 1> checkbox_headers_;
     Eigen::Tensor<bool, 2> *checkbox_columns_ = nullptr;
   };

--- a/src/smartpeak/source/ui/Widget.cpp
+++ b/src/smartpeak/source/ui/Widget.cpp
@@ -323,6 +323,11 @@ namespace SmartPeak
     static ImGuiTextFilter filter;
     filter.Draw("Find");
 
+    if (table_data_.body_.dimensions().TotalSize() > 0) {
+      updateTableContents(table_entries_, table_scanned_,
+        table_data_.body_, *checkbox_columns_);
+    }
+
     // drop-down list for search field(s)
     cols_.resize(table_data_.headers_.size() + 1);
     for (size_t header_name = 0; header_name < table_data_.headers_.size() + 1; ++header_name) {
@@ -440,22 +445,6 @@ namespace SmartPeak
       }
     }
 
-    if (table_data_.body_.dimension(0) == table_entries_.size())
-      table_scanned_ = true;
-    else
-      table_scanned_ = false;
-
-    if (table_data_.body_.dimensions().TotalSize() > 0) {
-      updateTableContents(table_entries_, table_scanned_,
-        table_data_.body_, *checkbox_columns_);
-    }
-    
-    if (table_scanned_ && table_entries_.size() > 0) {
-      if (table_data_.headers_.size()+checkbox_headers_.size() != table_entries_[0].entry_contents.size()) {
-        table_scanned_ = false;
-      }
-    }
-
     if (ImGui::BeginTable(table_id_.c_str(), table_data_.headers_.size() + checkbox_headers_.size(), table_flags)) {
       // First row headers
       for (int col = 0; col < table_data_.headers_.size(); col++) {
@@ -527,6 +516,10 @@ namespace SmartPeak
     }
   }
 
+  void ExplorerWidget::onSequenceUpdated()
+  {
+    table_scanned_ = false;
+  }
 
   void GenericGraphicWidget::draw()
   {


### PR DESCRIPTION
Explorer Widget now uses the observer to refresh the data, in this way the search information is well synchronized with the session handler data.

another addition to fixing the crash was to move the session_handler_.setMinimalDataAndFilters before the event_dispatcher.dispatchEvents() so that the SessionHandler and the widget draw are synchronized as well. 