### PR TITLE
[fix/aut982] Display error if required column is missing in the parameters file

### DIFF
--- a/src/smartpeak/source/io/ParametersParser.cpp
+++ b/src/smartpeak/source/io/ParametersParser.cpp
@@ -67,13 +67,20 @@ namespace SmartPeak
       s_description, // optional
       s_comment      // optional
     );
-    if (!in.has_column(s_used)
-        || !in.has_column(s_function)
-        || !in.has_column(s_name)
-        || !in.has_column(s_value))
+
+    // check for required columns
+    static const std::vector<std::string>
+      required_column{ s_used , s_function, s_name, s_value };
+    for (const auto& column : required_column)
     {
-      throw "Missing required column.";
+      if (!in.has_column(column))
+      {
+        std::ostringstream os;
+        os << "Missing required column \'" << column  << "\'";
+        throw std::invalid_argument(os.str());
+      }
     }
+
     const bool has_type = in.has_column(s_type);
     const bool has_tags = in.has_column(s_tags);
     const bool has_description = in.has_column(s_description);

--- a/src/tests/class_tests/smartpeak/data/FileReader_parameters_missing_function.csv
+++ b/src/tests/class_tests/smartpeak/data/FileReader_parameters_missing_function.csv
@@ -1,0 +1,8 @@
+name,type,value,default,restrictions,description,used_,comment_,comparator,an_ignored_header
+param1,int,-1,-1,,,TRUE,,,
+param2,float,-1,-1,,a description,True,,,
+param3,float,-1,-1,,"a quoted description, containing a comma",True,,,
+param4,float,-1,-1,,this one won't be used,fAlSe,,,
+param1,float,0.5,,,,tRuE,,,
+param2,bool,FALSE,,,,true,,,
+param1,bool,FALSE,,,,TRUE,,,

--- a/src/tests/class_tests/smartpeak/data/FileReader_parameters_missing_name.csv
+++ b/src/tests/class_tests/smartpeak/data/FileReader_parameters_missing_name.csv
@@ -1,0 +1,8 @@
+function,type,value,default,restrictions,description,used_,comment_,comparator,an_ignored_header
+func1,int,-1,-1,,,TRUE,,,
+func1,float,-1,-1,,a description,True,,,
+func1,float,-1,-1,,"a quoted description, containing a comma",True,,,
+func1,float,-1,-1,,this one won't be used,fAlSe,,,
+func2,float,0.5,,,,tRuE,,,
+func2,bool,FALSE,,,,true,,,
+func3,bool,FALSE,,,,TRUE,,,

--- a/src/tests/class_tests/smartpeak/data/FileReader_parameters_missing_used.csv
+++ b/src/tests/class_tests/smartpeak/data/FileReader_parameters_missing_used.csv
@@ -1,0 +1,8 @@
+function,name,type,value,default,restrictions,description,comment_,comparator,an_ignored_header
+func1,param1,int,-1,-1,,,,,
+func1,param2,float,-1,-1,,a description,,,
+func1,param3,float,-1,-1,,"a quoted description, containing a comma",,,
+func1,param4,float,-1,-1,,this one won't be used,,,
+func2,param1,float,0.5,,,,,,
+func2,param2,bool,FALSE,,,,,,
+func3,param1,bool,FALSE,,,,,,

--- a/src/tests/class_tests/smartpeak/data/FileReader_parameters_missing_value.csv
+++ b/src/tests/class_tests/smartpeak/data/FileReader_parameters_missing_value.csv
@@ -1,0 +1,8 @@
+function,name,type,default,restrictions,description,used_,comment_,comparator,an_ignored_header
+func1,param1,int,-1,,,TRUE,,,
+func1,param2,float,-1,,a description,True,,,
+func1,param3,float,-1,,"a quoted description, containing a comma",True,,,
+func1,param4,float,-1,,this one won't be used,fAlSe,,,
+func2,param1,float,,,,tRuE,,,
+func2,param2,bool,,,,true,,,
+func3,param1,bool,,,,TRUE,,,

--- a/src/tests/class_tests/smartpeak/source/ParametersParser_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/ParametersParser_test.cpp
@@ -96,6 +96,57 @@ TEST(ParametersParser, read_invalid)
   }
 }
 
+TEST(ParametersParser, read_missing_columns)
+{
+  try {
+    ParameterSet parameters;
+    ParametersParser::read(SMARTPEAK_GET_TEST_DATA_PATH("FileReader_parameters_missing_function.csv"), parameters);
+    FAIL() << "Expected std::invalid_argument";
+  }
+  catch (std::invalid_argument const& err) {
+    EXPECT_STREQ(err.what(), "Missing required column 'function'");
+  }
+  catch (...) {
+    FAIL() << "Expected std::invalid_argument";
+  }
+
+  try {
+    ParameterSet parameters;
+    ParametersParser::read(SMARTPEAK_GET_TEST_DATA_PATH("FileReader_parameters_missing_name.csv"), parameters);
+    FAIL() << "Expected std::invalid_argument";
+  }
+  catch (std::invalid_argument const& err) {
+    EXPECT_STREQ(err.what(), "Missing required column 'name'");
+  }
+  catch (...) {
+    FAIL() << "Expected std::invalid_argument";
+  }
+
+  try {
+    ParameterSet parameters;
+    ParametersParser::read(SMARTPEAK_GET_TEST_DATA_PATH("FileReader_parameters_missing_used.csv"), parameters);
+    FAIL() << "Expected std::invalid_argument";
+  }
+  catch (std::invalid_argument const& err) {
+    EXPECT_STREQ(err.what(), "Missing required column 'used_'");
+  }
+  catch (...) {
+    FAIL() << "Expected std::invalid_argument";
+  }
+
+  try {
+    ParameterSet parameters;
+    ParametersParser::read(SMARTPEAK_GET_TEST_DATA_PATH("FileReader_parameters_missing_value.csv"), parameters);
+    FAIL() << "Expected std::invalid_argument";
+  }
+  catch (std::invalid_argument const& err) {
+    EXPECT_STREQ(err.what(), "Missing required column 'value'");
+  }
+  catch (...) {
+    FAIL() << "Expected std::invalid_argument";
+  }
+}
+
 TEST(ParametersParser, write)
 {
   const string pathname = SMARTPEAK_GET_TEST_DATA_PATH("FileReader_parameters.csv");

--- a/src/tests/class_tests/smartpeak/source/Utilities_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Utilities_test.cpp
@@ -32,7 +32,7 @@ using namespace SmartPeak;
 using namespace std;
 namespace fs = std::filesystem;
 
-const unsigned int nb_files_in_data_directory = 52;
+const unsigned int nb_files_in_data_directory = 56;
 
 TEST(utilities, castString)
 {


### PR DESCRIPTION
properly handle error. the error is now displayed in the information and the log shows what column is missing