### PR TITLE
[fix/aut990] Added headless client to package

### DIFF
--- a/cmake/package_general.cmake
+++ b/cmake/package_general.cmake
@@ -108,6 +108,11 @@ if (WIN32)
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy \"\${EXECS}\" \"\${DEST}\")
     SET(DIRS ${Qt5Core_DIR} ${Qt5Network_DIR} ${Qt5_DIR} ${OpenMS_LIBRARY_DIR}  ${SDL2_LIBRARIES_DIR})
     fixup_bundle(\"\${DEST}\" \"\" \"\${DIRS}\")
+    SET(EXECS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/SmartPeakCLI.exe)
+    SET(DEST \"\${CMAKE_INSTALL_PREFIX}/bin/SmartPeakCLI.exe\")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy \"\${EXECS}\" \"\${DEST}\")
+    SET(DIRS ${Qt5Core_DIR} ${Qt5Network_DIR} ${Qt5_DIR} ${OpenMS_LIBRARY_DIR}  ${SDL2_LIBRARIES_DIR})
+    fixup_bundle(\"\${DEST}\" \"\" \"\${DIRS}\")
     " 
     COMPONENT applications)
     
@@ -140,8 +145,10 @@ elseif(UNIX AND CMAKE_SYSTEM_NAME MATCHES Linux)
   install(CODE "
     include(InstallRequiredSystemLibraries)
     include(BundleUtilities)
+    SET(EXECS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SmartPeakCLI)
+    SET(DIRS ${Qt5Core_DIR} ${Qt5Network_DIR} ${Qt5_DIR} ${OpenMS_LIBRARY_DIR}  ${SDL2_LIBRARIES_DIR})
+    fixup_bundle(\"\${EXECS}\" \"\" \"\${DIRS}\")
     SET(EXECS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SmartPeakGUI)
-    # execute_process(COMMAND ${CMAKE_COMMAND} -E copy \"\${EXECS}\" \"\${DEST}\")
     SET(DIRS ${Qt5Core_DIR} ${Qt5Network_DIR} ${Qt5_DIR} ${OpenMS_LIBRARY_DIR}  ${SDL2_LIBRARIES_DIR})
     fixup_bundle(\"\${EXECS}\" \"\" \"\${DIRS}\")
     " 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -151,12 +151,13 @@ foreach(_examples ${EXAMPLE_executables})
         set(OpenMS_SHARE_DIR ${OpenMS_DIR}/../share/OpenMS/)
       endif()
       install(DIRECTORY ${OpenMS_SHARE_DIR} DESTINATION share/OpenMS COMPONENT share)
-
-    else()
-
+    elseif(${_examples} STREQUAL "SmartPeakCLI")
       add_executable(${_examples} source/${_examples})
       target_link_libraries(${_examples} PUBLIC ${SmartPeak_LIBRARIES} OpenMS)
-
+      install_tool(${_examples}) 
+    else()
+      add_executable(${_examples} source/${_examples})
+      target_link_libraries(${_examples} PUBLIC ${SmartPeak_LIBRARIES} OpenMS)
     endif()
 
   else() # Win


### PR DESCRIPTION
Seems to be ok with windows and ubuntu package.
(one note about windows: you need to launch the cli from the installation directory)
MacOS package needs to be verified.