### PR TITLE
[fix/aut995] Fixed flooding of log when workflow fails to be loaded

### DIFF
--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -43,7 +43,7 @@
 #include <SmartPeak/ui/SpectraMSMSPlotWidget.h>
 #include <SmartPeak/ui/ParametersTableWidget.h>
 #include <SmartPeak/ui/Report.h>
-#include <SmartPeak/ui/Workflow.h>
+#include <SmartPeak/ui/WorkflowWidget.h>
 #include <SmartPeak/ui/StatisticsWidget.h>
 #include <SmartPeak/ui/Widget.h>
 #include <SmartPeak/ui/InfoWidget.h>
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
                                                             event_dispatcher,
                                                             event_dispatcher);
   auto report_ = std::make_shared<Report>(application_handler_);
-  auto workflow_ = std::make_shared<Workflow>("Workflow", application_handler_, workflow_manager_);
+  auto workflow_ = std::make_shared<WorkflowWidget>("Workflow", application_handler_, workflow_manager_);
   auto statistics_ = std::make_shared<StatisticsWidget>("Statistics", application_handler_, event_dispatcher);
   auto run_workflow_widget_ = std::make_shared<RunWorkflowWidget>(application_handler_, 
                                                                   session_handler_, 

--- a/src/smartpeak/include/SmartPeak/ui/Widget.h
+++ b/src/smartpeak/include/SmartPeak/ui/Widget.h
@@ -406,15 +406,6 @@ namespace SmartPeak
   };
 
   /**
-    @brief Class for configuring a workflow
-  */
-  class WorkflowWidget : public GenericGraphicWidget
-  {
-  public:
-    void draw() override;
-  };
-
-  /**
    @brief Shows Quick Help tooltip when ui_element_name is present in tooltip_info (Help.h).
    
    @param[in,out] ui_element_name such as table_id_.

--- a/src/smartpeak/include/SmartPeak/ui/WorkflowWidget.h
+++ b/src/smartpeak/include/SmartPeak/ui/WorkflowWidget.h
@@ -27,28 +27,35 @@
 #include <SmartPeak/ui/WorkflowStepWidget.h>
 #include <SmartPeak/core/ApplicationHandler.h>
 #include <SmartPeak/core/WorkflowManager.h>
+#include <SmartPeak/core/ApplicationProcessor.h>
 #include <string>
 #include <vector>
 
 namespace SmartPeak
 {
-  class Workflow final : public Widget
+  class WorkflowWidget : public Widget
   {
   public:
 
-    Workflow(const std::string title, ApplicationHandler& application_handler, WorkflowManager& workflow_manager)
+    WorkflowWidget(const std::string title, ApplicationHandler& application_handler, WorkflowManager& workflow_manager)
       : Widget(title),
       application_handler_(application_handler),
       workflow_step_widget_(application_handler),
-      workflow_manager_(workflow_manager)
+      workflow_manager_(workflow_manager),
+      buildCommandsFromNames_(application_handler)
     {
     };
 
     void draw() override;
 
   protected:
+    virtual void updatecommands();
+
+  protected:
     ApplicationHandler& application_handler_;
     WorkflowStepWidget workflow_step_widget_;
     WorkflowManager& workflow_manager_;
+    BuildCommandsFromNames buildCommandsFromNames_;
+    bool error_building_commands_ = false;
   };
 }

--- a/src/smartpeak/include/SmartPeak/ui/sources.cmake
+++ b/src/smartpeak/include/SmartPeak/ui/sources.cmake
@@ -12,6 +12,7 @@ set(sources_list_h
 	GraphicDataVizWidget.h
 	GuiAppender.h
 	Heatmap2DWidget.h
+	Help.h
 	ImEntry.h
 	InfoWidget.h
 	LogWidget.h
@@ -26,10 +27,8 @@ set(sources_list_h
 	SpectraPlotWidget.h
 	StatisticsWidget.h
 	Widget.h
-	ImEntry.h
-	Help.h
 	WindowSizesAndPositions.h
-	Workflow.h
+	WorkflowWidget.h
 	WorkflowStepWidget.h
 )
 

--- a/src/smartpeak/source/core/ApplicationProcessor.cpp
+++ b/src/smartpeak/source/core/ApplicationProcessor.cpp
@@ -208,7 +208,7 @@ namespace SmartPeak
     }
     else 
     {
-      LOGE << "\nNo command for selection name " << name_;
+      LOGE << "No command for selection name " << name_;
       return false;
     }
     return true;

--- a/src/smartpeak/source/ui/Widget.cpp
+++ b/src/smartpeak/source/ui/Widget.cpp
@@ -667,10 +667,6 @@ namespace SmartPeak
     // TODO: add selected samples to workflow widget
   }
 
-  void WorkflowWidget::draw()
-  {
-  }
-
   void GenericTextWidget::draw()
   {
     for (const std::string& line : text_lines) {

--- a/src/smartpeak/source/ui/sources.cmake
+++ b/src/smartpeak/source/ui/sources.cmake
@@ -27,7 +27,7 @@ set(sources_list
 	StatisticsWidget.cpp
 	Widget.cpp
 	WindowSizesAndPositions.cpp
-	Workflow.cpp
+	WorkflowWidget.cpp
 	WorkflowStepWidget.cpp
 )
 

--- a/src/tests/class_tests/smartpeak/source/Widget_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Widget_test.cpp
@@ -277,8 +277,6 @@ public:
 
 TEST(WorkflowWidget, updateCommands)
 {
-  SmartPeak::SessionHandler session_handler;
-  SmartPeak::SequenceHandler sequence_handler;
   SmartPeak::ApplicationHandler application_handler;
   SmartPeak::WorkflowManager workflow_manager;
   WorkflowWidget_Test workflow_widget("Workflow Widget", application_handler, workflow_manager);

--- a/src/tests/class_tests/smartpeak/source/Widget_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Widget_test.cpp
@@ -28,7 +28,11 @@
 #include <SmartPeak/core/MetaDataHandler.h>
 #include <SmartPeak/core/RawDataProcessor.h>
 #include <SmartPeak/core/SampleType.h>
+#include <SmartPeak/core/WorkflowManager.h>
 #include <SmartPeak/ui/GraphicDataVizWidget.h>
+#include <SmartPeak/ui/WorkflowWidget.h>
+
+bool SmartPeak::enable_quick_help = false;
 
 void getDummyTableEntries(Eigen::Tensor<std::string, 2>& rows_out)
 {
@@ -248,3 +252,50 @@ TEST(GraphicDataVizWidget, plotLimits)
   EXPECT_NEAR(plot_min_y, 98.910003662109375, 1e-6);
   EXPECT_NEAR(plot_max_y, 341, 1e-6);
 }
+
+class WorkflowWidget_Test : public SmartPeak::WorkflowWidget
+{
+public:
+  WorkflowWidget_Test(const std::string title, 
+                      SmartPeak::ApplicationHandler& application_handler, 
+                      SmartPeak::WorkflowManager& workflow_manager) :
+    WorkflowWidget(title, application_handler, workflow_manager)
+  {};
+
+public:
+  // wrappers to protected methods
+  virtual void updatecommands() override
+  {
+    WorkflowWidget::updatecommands();
+  }
+
+  bool errorBuildingCommands()
+  {
+    return error_building_commands_;
+  }
+};
+
+TEST(WorkflowWidget, updateCommands)
+{
+  SmartPeak::SessionHandler session_handler;
+  SmartPeak::SequenceHandler sequence_handler;
+  SmartPeak::ApplicationHandler application_handler;
+  SmartPeak::WorkflowManager workflow_manager;
+  WorkflowWidget_Test workflow_widget("Workflow Widget", application_handler, workflow_manager);
+  
+  // initial state
+  EXPECT_FALSE(workflow_widget.errorBuildingCommands());
+  
+  // empty commands
+  workflow_widget.updatecommands();
+  EXPECT_FALSE(workflow_widget.errorBuildingCommands());
+
+  application_handler.sequenceHandler_.setWorkflow({ "LOAD_FEATURES" });
+  workflow_widget.updatecommands();
+  EXPECT_FALSE(workflow_widget.errorBuildingCommands());
+  
+  application_handler.sequenceHandler_.setWorkflow({ "NON_EXISTING_COMMAND" });
+  workflow_widget.updatecommands();
+  EXPECT_TRUE(workflow_widget.errorBuildingCommands());
+}
+


### PR DESCRIPTION
log flooding is fixed.
also, the panel shows that an error occurred.

included in this PR:

- Workflow widget renamed WorkflowWodget for consistency
- Added unit test. I don't like testing the protected methods and even more protected member variables, but we have no choice here (for UI objects). I think it makes sense if we select the ones that are very key to the internal logic (here: error flag is checked).

![image](https://user-images.githubusercontent.com/1705849/127852270-4bc8b5b0-76bb-4c6e-8718-6d9b0429ee4f.png)
