### PR TITLE
Feat/aut994 - Rework of Filenames class

### DIFF
--- a/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
@@ -13,10 +13,10 @@ void test_main_FIAMS_FullScan_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns");
   Filenames filenames_main;
-  filenames_main.setTag("MAIN_DIR", main_dir);
-  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
-  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
-  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::MAIN_DIR, main_dir);
+  filenames_main.setTag(Filenames::Tag::MZML_INPUT_PATH, main_dir + "/mzML/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_INPUT_PATH, main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, main_dir + "/features/");
 
   example_FIAMS_FullScan_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
@@ -13,10 +13,10 @@ void test_main_FIAMS_FullScan_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns");
   Filenames filenames_main;
-  filenames_main.setRootPaths(main_dir,
-    main_dir + "/mzML/",
-    main_dir + "/features/",
-    main_dir + "/features/");
+  filenames_main.setTag("MAIN_DIR", main_dir);
+  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
+  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
 
   example_FIAMS_FullScan_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
@@ -21,19 +21,19 @@ void test_main_FIAMS_FullScan_Unknown()
   LoadAnnotations loadAnnotations;
   Filenames filenames;
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_13_BatchName_1900-01-01_000000.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_13_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
-  filenames.setFullPathName("mzTab_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_13_BatchName_1900-01-01_000000.mzTab"));
+  filenames.setFullPath("mzTab_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_13_BatchName_1900-01-01_000000.mzTab"));
   loadAnnotations.process(rawDataHandler, {}, filenames);
   OpenMS::MzTab mt1 = rawDataHandler.getMzTab();
 
   rawDataHandler.clear();
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_test.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
-  filenames.setFullPathName("mzTab_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_test.mzTab"));
+  filenames.setFullPath("mzTab_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_test.mzTab"));
   loadAnnotations.process(rawDataHandler, {}, filenames);
   OpenMS::MzTab mt2 = rawDataHandler.getMzTab();
   

--- a/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
@@ -12,9 +12,9 @@ using namespace std;
 void test_main_FIAMS_FullScan_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns");
-  Filenames static_filenames;
+  Filenames filenames_main;
 
-  example_FIAMS_FullScan_Unknowns(main_dir, static_filenames, ",");
+  example_FIAMS_FullScan_Unknowns(main_dir, filenames_main, ",");
 
   RawDataHandler rawDataHandler;
   LoadFeatures loadFeatures;

--- a/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
@@ -13,6 +13,10 @@ void test_main_FIAMS_FullScan_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns");
   Filenames filenames_main;
+  filenames_main.setRootPaths(main_dir,
+    main_dir + "/mzML/",
+    main_dir + "/features/",
+    main_dir + "/features/");
 
   example_FIAMS_FullScan_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/FIAMS_FullScan_Unknown_test.cpp
@@ -12,7 +12,7 @@ using namespace std;
 void test_main_FIAMS_FullScan_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns");
-  const Filenames static_filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames static_filenames;
 
   example_FIAMS_FullScan_Unknowns(main_dir, static_filenames, ",");
 
@@ -21,19 +21,19 @@ void test_main_FIAMS_FullScan_Unknown()
   LoadAnnotations loadAnnotations;
   Filenames filenames;
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_13_BatchName_1900-01-01_000000.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_13_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
-  filenames.mzTab_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_13_BatchName_1900-01-01_000000.mzTab");
+  filenames.setFullPathName("mzTab_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_13_BatchName_1900-01-01_000000.mzTab"));
   loadAnnotations.process(rawDataHandler, {}, filenames);
   OpenMS::MzTab mt1 = rawDataHandler.getMzTab();
 
   rawDataHandler.clear();
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_test.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
-  filenames.mzTab_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_test.mzTab");
+  filenames.setFullPathName("mzTab_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("FIAMS_FullScan_Unknowns/features/20200618_QCserum_NewSourceSettings_80_20MeOH_water_100to1000Da_NEG_1_test.mzTab"));
   loadAnnotations.process(rawDataHandler, {}, filenames);
   OpenMS::MzTab mt2 = rawDataHandler.getMzTab();
   

--- a/src/examples/source/GCMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/GCMS_FullScan_Unknown_test.cpp
@@ -13,10 +13,10 @@ void test_main_GCMS_FullScan_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns");
   Filenames filenames_main;
-  filenames_main.setTag("MAIN_DIR", main_dir);
-  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
-  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
-  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::MAIN_DIR, main_dir);
+  filenames_main.setTag(Filenames::Tag::MZML_INPUT_PATH, main_dir + "/mzML/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_INPUT_PATH, main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, main_dir + "/features/");
 
   example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/GCMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/GCMS_FullScan_Unknown_test.cpp
@@ -13,10 +13,10 @@ void test_main_GCMS_FullScan_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns");
   Filenames filenames_main;
-  filenames_main.setRootPaths(main_dir,
-    main_dir + "/mzML/",
-    main_dir + "/features/",
-    main_dir + "/features/");
+  filenames_main.setTag("MAIN_DIR", main_dir);
+  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
+  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
 
   example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/GCMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/GCMS_FullScan_Unknown_test.cpp
@@ -13,6 +13,10 @@ void test_main_GCMS_FullScan_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns");
   Filenames filenames_main;
+  filenames_main.setRootPaths(main_dir,
+    main_dir + "/mzML/",
+    main_dir + "/features/",
+    main_dir + "/features/");
 
   example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/GCMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/GCMS_FullScan_Unknown_test.cpp
@@ -12,9 +12,9 @@ using namespace std;
 void test_main_GCMS_FullScan_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns");
-  Filenames static_filenames;
+  Filenames filenames_main;
 
-  example_LCMS_MRM_Unknowns(main_dir, static_filenames, ",");
+  example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 
   RawDataHandler rawDataHandler;
   LoadFeatures loadFeatures;

--- a/src/examples/source/GCMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/GCMS_FullScan_Unknown_test.cpp
@@ -20,13 +20,13 @@ void test_main_GCMS_FullScan_Unknown()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns/features/GCMS_FullScan_1_BatchName_1900-01-01_000000.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns/features/GCMS_FullScan_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns/features/GCMS_FullScan_test.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns/features/GCMS_FullScan_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/GCMS_FullScan_Unknown_test.cpp
+++ b/src/examples/source/GCMS_FullScan_Unknown_test.cpp
@@ -12,7 +12,7 @@ using namespace std;
 void test_main_GCMS_FullScan_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns");
-  const Filenames static_filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames static_filenames;
 
   example_LCMS_MRM_Unknowns(main_dir, static_filenames, ",");
 
@@ -20,13 +20,13 @@ void test_main_GCMS_FullScan_Unknown()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns/features/GCMS_FullScan_1_BatchName_1900-01-01_000000.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns/features/GCMS_FullScan_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns/features/GCMS_FullScan_test.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_FullScan_Unknowns/features/GCMS_FullScan_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/GCMS_SIM_Unknown_test.cpp
+++ b/src/examples/source/GCMS_SIM_Unknown_test.cpp
@@ -13,6 +13,10 @@ void test_main_GCMS_SIM_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns");
   Filenames filenames_main;
+  filenames_main.setRootPaths(main_dir,
+    main_dir + "/mzML/",
+    main_dir + "/features/",
+    main_dir + "/features/");
 
   example_GCMS_SIM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/GCMS_SIM_Unknown_test.cpp
+++ b/src/examples/source/GCMS_SIM_Unknown_test.cpp
@@ -13,10 +13,10 @@ void test_main_GCMS_SIM_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns");
   Filenames filenames_main;
-  filenames_main.setTag("MAIN_DIR", main_dir);
-  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
-  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
-  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::MAIN_DIR, main_dir);
+  filenames_main.setTag(Filenames::Tag::MZML_INPUT_PATH, main_dir + "/mzML/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_INPUT_PATH, main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, main_dir + "/features/");
 
   example_GCMS_SIM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/GCMS_SIM_Unknown_test.cpp
+++ b/src/examples/source/GCMS_SIM_Unknown_test.cpp
@@ -12,9 +12,9 @@ using namespace std;
 void test_main_GCMS_SIM_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns");
-  Filenames static_filenames;
+  Filenames filenames_main;
 
-  example_GCMS_SIM_Unknowns(main_dir, static_filenames, ",");
+  example_GCMS_SIM_Unknowns(main_dir, filenames_main, ",");
 
   RawDataHandler rawDataHandler;
   LoadFeatures loadFeatures;

--- a/src/examples/source/GCMS_SIM_Unknown_test.cpp
+++ b/src/examples/source/GCMS_SIM_Unknown_test.cpp
@@ -13,10 +13,10 @@ void test_main_GCMS_SIM_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns");
   Filenames filenames_main;
-  filenames_main.setRootPaths(main_dir,
-    main_dir + "/mzML/",
-    main_dir + "/features/",
-    main_dir + "/features/");
+  filenames_main.setTag("MAIN_DIR", main_dir);
+  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
+  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
 
   example_GCMS_SIM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/GCMS_SIM_Unknown_test.cpp
+++ b/src/examples/source/GCMS_SIM_Unknown_test.cpp
@@ -12,7 +12,7 @@ using namespace std;
 void test_main_GCMS_SIM_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns");
-  const Filenames static_filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames static_filenames;
 
   example_GCMS_SIM_Unknowns(main_dir, static_filenames, ",");
 
@@ -20,13 +20,13 @@ void test_main_GCMS_SIM_Unknown()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns/features/GCMS_SIM_1_BatchName_1900-01-01_000000.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns/features/GCMS_SIM_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns/features/GCMS_SIM_test.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns/features/GCMS_SIM_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/GCMS_SIM_Unknown_test.cpp
+++ b/src/examples/source/GCMS_SIM_Unknown_test.cpp
@@ -20,13 +20,13 @@ void test_main_GCMS_SIM_Unknown()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns/features/GCMS_SIM_1_BatchName_1900-01-01_000000.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns/features/GCMS_SIM_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns/features/GCMS_SIM_test.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("GCMS_SIM_Unknowns/features/GCMS_SIM_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/HPLC_UV_Standards_test.cpp
+++ b/src/examples/source/HPLC_UV_Standards_test.cpp
@@ -12,9 +12,9 @@ using namespace std;
 void test_main_HPLC_UV_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards");
-  Filenames static_filenames;
+  Filenames filenames_main;
 
-  example_HPLC_UV_Standards(main_dir, static_filenames, ",");
+  example_HPLC_UV_Standards(main_dir, filenames_main, ",");
 
   RawDataHandler rawDataHandler;
   LoadFeatures loadFeatures;

--- a/src/examples/source/HPLC_UV_Standards_test.cpp
+++ b/src/examples/source/HPLC_UV_Standards_test.cpp
@@ -20,13 +20,13 @@ void test_main_HPLC_UV_Standards()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards/features/100ug_8_BatchName_1900-01-01_000000.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards/features/100ug_8_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards/features/100ug_test.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards/features/100ug_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/HPLC_UV_Standards_test.cpp
+++ b/src/examples/source/HPLC_UV_Standards_test.cpp
@@ -13,10 +13,10 @@ void test_main_HPLC_UV_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards");
   Filenames filenames_main;
-  filenames_main.setRootPaths(main_dir,
-    main_dir + "/mzML/",
-    main_dir + "/features/",
-    main_dir + "/features/");
+  filenames_main.setTag("MAIN_DIR", "main_dir");
+  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
+  filenames_main.setTag("FEATURES_INPUT_PATH", "/features/");
+  filenames_main.setTag("FEATURES_OUTPUT_PATH", "/features/");
 
   example_HPLC_UV_Standards(main_dir, filenames_main, ",");
 

--- a/src/examples/source/HPLC_UV_Standards_test.cpp
+++ b/src/examples/source/HPLC_UV_Standards_test.cpp
@@ -13,6 +13,10 @@ void test_main_HPLC_UV_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards");
   Filenames filenames_main;
+  filenames_main.setRootPaths(main_dir,
+    main_dir + "/mzML/",
+    main_dir + "/features/",
+    main_dir + "/features/");
 
   example_HPLC_UV_Standards(main_dir, filenames_main, ",");
 

--- a/src/examples/source/HPLC_UV_Standards_test.cpp
+++ b/src/examples/source/HPLC_UV_Standards_test.cpp
@@ -12,7 +12,7 @@ using namespace std;
 void test_main_HPLC_UV_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards");
-  const Filenames static_filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames static_filenames;
 
   example_HPLC_UV_Standards(main_dir, static_filenames, ",");
 
@@ -20,13 +20,13 @@ void test_main_HPLC_UV_Standards()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards/features/100ug_8_BatchName_1900-01-01_000000.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards/features/100ug_8_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards/features/100ug_test.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards/features/100ug_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/HPLC_UV_Standards_test.cpp
+++ b/src/examples/source/HPLC_UV_Standards_test.cpp
@@ -13,10 +13,10 @@ void test_main_HPLC_UV_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards");
   Filenames filenames_main;
-  filenames_main.setTag("MAIN_DIR", main_dir);
-  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
-  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
-  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::MAIN_DIR, main_dir);
+  filenames_main.setTag(Filenames::Tag::MZML_INPUT_PATH, main_dir + "/mzML/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_INPUT_PATH, main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, main_dir + "/features/");
 
   example_HPLC_UV_Standards(main_dir, filenames_main, ",");
 

--- a/src/examples/source/HPLC_UV_Standards_test.cpp
+++ b/src/examples/source/HPLC_UV_Standards_test.cpp
@@ -13,10 +13,10 @@ void test_main_HPLC_UV_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Standards");
   Filenames filenames_main;
-  filenames_main.setTag("MAIN_DIR", "main_dir");
+  filenames_main.setTag("MAIN_DIR", main_dir);
   filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
-  filenames_main.setTag("FEATURES_INPUT_PATH", "/features/");
-  filenames_main.setTag("FEATURES_OUTPUT_PATH", "/features/");
+  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
 
   example_HPLC_UV_Standards(main_dir, filenames_main, ",");
 

--- a/src/examples/source/HPLC_UV_Unknown_test.cpp
+++ b/src/examples/source/HPLC_UV_Unknown_test.cpp
@@ -20,13 +20,13 @@ void test_main_HPLC_UV_Unknown()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns/features/20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2_1_BatchName_1900-01-01_000000.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns/features/20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns/features/20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2_test.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns/features/20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/HPLC_UV_Unknown_test.cpp
+++ b/src/examples/source/HPLC_UV_Unknown_test.cpp
@@ -12,7 +12,7 @@ using namespace std;
 void test_main_HPLC_UV_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns");
-  const Filenames static_filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames static_filenames;
 
   example_HPLC_UV_Unknowns(main_dir, static_filenames, ",");
 
@@ -20,13 +20,13 @@ void test_main_HPLC_UV_Unknown()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns/features/20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2_1_BatchName_1900-01-01_000000.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns/features/20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns/features/20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2_test.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns/features/20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/HPLC_UV_Unknown_test.cpp
+++ b/src/examples/source/HPLC_UV_Unknown_test.cpp
@@ -13,6 +13,10 @@ void test_main_HPLC_UV_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns");
   Filenames filenames_main;
+  filenames_main.setRootPaths(main_dir,
+    main_dir + "/mzML/",
+    main_dir + "/features/",
+    main_dir + "/features/");
 
   example_HPLC_UV_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/HPLC_UV_Unknown_test.cpp
+++ b/src/examples/source/HPLC_UV_Unknown_test.cpp
@@ -13,10 +13,10 @@ void test_main_HPLC_UV_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns");
   Filenames filenames_main;
-  filenames_main.setRootPaths(main_dir,
-    main_dir + "/mzML/",
-    main_dir + "/features/",
-    main_dir + "/features/");
+  filenames_main.setTag("MAIN_DIR", main_dir);
+  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
+  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
 
   example_HPLC_UV_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/HPLC_UV_Unknown_test.cpp
+++ b/src/examples/source/HPLC_UV_Unknown_test.cpp
@@ -12,9 +12,9 @@ using namespace std;
 void test_main_HPLC_UV_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns");
-  Filenames static_filenames;
+  Filenames filenames_main;
 
-  example_HPLC_UV_Unknowns(main_dir, static_filenames, ",");
+  example_HPLC_UV_Unknowns(main_dir, filenames_main, ",");
 
   RawDataHandler rawDataHandler;
   LoadFeatures loadFeatures;

--- a/src/examples/source/HPLC_UV_Unknown_test.cpp
+++ b/src/examples/source/HPLC_UV_Unknown_test.cpp
@@ -13,10 +13,10 @@ void test_main_HPLC_UV_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("HPLC_UV_Unknowns");
   Filenames filenames_main;
-  filenames_main.setTag("MAIN_DIR", main_dir);
-  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
-  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
-  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::MAIN_DIR, main_dir);
+  filenames_main.setTag(Filenames::Tag::MZML_INPUT_PATH, main_dir + "/mzML/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_INPUT_PATH, main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, main_dir + "/features/");
 
   example_HPLC_UV_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/LCMS_MRM_QCs_test.cpp
+++ b/src/examples/source/LCMS_MRM_QCs_test.cpp
@@ -13,6 +13,10 @@ void test_main_LCMS_MRM_QCs()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs");
   Filenames filenames_main;
+  filenames_main.setRootPaths(main_dir,
+    main_dir + "/mzML/",
+    main_dir + "/features/",
+    main_dir + "/features/");
 
   example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/LCMS_MRM_QCs_test.cpp
+++ b/src/examples/source/LCMS_MRM_QCs_test.cpp
@@ -20,13 +20,13 @@ void test_main_LCMS_MRM_QCs()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs/features/150601_0_BloodProject01_PLT_QC_Broth-1_1_BatchName_1900-01-01_000000.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs/features/150601_0_BloodProject01_PLT_QC_Broth-1_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs/features/150601_0_BloodProject01_PLT_QC_Broth-1_test.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs/features/150601_0_BloodProject01_PLT_QC_Broth-1_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/LCMS_MRM_QCs_test.cpp
+++ b/src/examples/source/LCMS_MRM_QCs_test.cpp
@@ -13,10 +13,10 @@ void test_main_LCMS_MRM_QCs()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs");
   Filenames filenames_main;
-  filenames_main.setRootPaths(main_dir,
-    main_dir + "/mzML/",
-    main_dir + "/features/",
-    main_dir + "/features/");
+  filenames_main.setTag("MAIN_DIR", main_dir);
+  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
+  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
 
   example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/LCMS_MRM_QCs_test.cpp
+++ b/src/examples/source/LCMS_MRM_QCs_test.cpp
@@ -13,10 +13,10 @@ void test_main_LCMS_MRM_QCs()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs");
   Filenames filenames_main;
-  filenames_main.setTag("MAIN_DIR", main_dir);
-  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
-  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
-  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::MAIN_DIR, main_dir);
+  filenames_main.setTag(Filenames::Tag::MZML_INPUT_PATH, main_dir + "/mzML/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_INPUT_PATH, main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, main_dir + "/features/");
 
   example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/LCMS_MRM_QCs_test.cpp
+++ b/src/examples/source/LCMS_MRM_QCs_test.cpp
@@ -12,7 +12,7 @@ using namespace std;
 void test_main_LCMS_MRM_QCs()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs");
-  const Filenames static_filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames static_filenames;
 
   example_LCMS_MRM_Unknowns(main_dir, static_filenames, ",");
 
@@ -20,13 +20,13 @@ void test_main_LCMS_MRM_QCs()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs/features/150601_0_BloodProject01_PLT_QC_Broth-1_1_BatchName_1900-01-01_000000.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs/features/150601_0_BloodProject01_PLT_QC_Broth-1_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs/features/150601_0_BloodProject01_PLT_QC_Broth-1_test.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs/features/150601_0_BloodProject01_PLT_QC_Broth-1_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/LCMS_MRM_QCs_test.cpp
+++ b/src/examples/source/LCMS_MRM_QCs_test.cpp
@@ -12,9 +12,9 @@ using namespace std;
 void test_main_LCMS_MRM_QCs()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_QCs");
-  Filenames static_filenames;
+  Filenames filenames_main;
 
-  example_LCMS_MRM_Unknowns(main_dir, static_filenames, ",");
+  example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 
   RawDataHandler rawDataHandler;
   LoadFeatures loadFeatures;

--- a/src/examples/source/LCMS_MRM_Standards_test.cpp
+++ b/src/examples/source/LCMS_MRM_Standards_test.cpp
@@ -12,7 +12,7 @@ using namespace std;
 void test_main_LCMS_MRM_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards");
-  const Filenames static_filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames static_filenames;
 
   example_LCMS_MRM_Standards(main_dir, static_filenames, ",");
 
@@ -20,13 +20,13 @@ void test_main_LCMS_MRM_Standards()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards/features/150516_CM1_Level1_1_BatchName_1900-01-01_000000.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards/features/150516_CM1_Level1_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards/features/150516_CM1_Level1_test.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards/features/150516_CM1_Level1_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/LCMS_MRM_Standards_test.cpp
+++ b/src/examples/source/LCMS_MRM_Standards_test.cpp
@@ -20,13 +20,13 @@ void test_main_LCMS_MRM_Standards()
   LoadFeatures loadFeatures;
   Filenames filenames;
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards/features/150516_CM1_Level1_1_BatchName_1900-01-01_000000.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards/features/150516_CM1_Level1_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards/features/150516_CM1_Level1_test.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards/features/150516_CM1_Level1_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
 

--- a/src/examples/source/LCMS_MRM_Standards_test.cpp
+++ b/src/examples/source/LCMS_MRM_Standards_test.cpp
@@ -13,6 +13,10 @@ void test_main_LCMS_MRM_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards");
   Filenames filenames_main;
+  filenames_main.setRootPaths(main_dir,
+    main_dir + "/mzML/",
+    main_dir + "/features/",
+    main_dir + "/features/");
 
   example_LCMS_MRM_Standards(main_dir, filenames_main, ",");
 

--- a/src/examples/source/LCMS_MRM_Standards_test.cpp
+++ b/src/examples/source/LCMS_MRM_Standards_test.cpp
@@ -13,10 +13,10 @@ void test_main_LCMS_MRM_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards");
   Filenames filenames_main;
-  filenames_main.setRootPaths(main_dir,
-    main_dir + "/mzML/",
-    main_dir + "/features/",
-    main_dir + "/features/");
+  filenames_main.setTag("MAIN_DIR", main_dir);
+  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
+  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
 
   example_LCMS_MRM_Standards(main_dir, filenames_main, ",");
 

--- a/src/examples/source/LCMS_MRM_Standards_test.cpp
+++ b/src/examples/source/LCMS_MRM_Standards_test.cpp
@@ -13,10 +13,10 @@ void test_main_LCMS_MRM_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards");
   Filenames filenames_main;
-  filenames_main.setTag("MAIN_DIR", main_dir);
-  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
-  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
-  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::MAIN_DIR, main_dir);
+  filenames_main.setTag(Filenames::Tag::MZML_INPUT_PATH, main_dir + "/mzML/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_INPUT_PATH, main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, main_dir + "/features/");
 
   example_LCMS_MRM_Standards(main_dir, filenames_main, ",");
 

--- a/src/examples/source/LCMS_MRM_Standards_test.cpp
+++ b/src/examples/source/LCMS_MRM_Standards_test.cpp
@@ -12,9 +12,9 @@ using namespace std;
 void test_main_LCMS_MRM_Standards()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Standards");
-  Filenames static_filenames;
+  Filenames filenames_main;
 
-  example_LCMS_MRM_Standards(main_dir, static_filenames, ",");
+  example_LCMS_MRM_Standards(main_dir, filenames_main, ",");
 
   RawDataHandler rawDataHandler;
   LoadFeatures loadFeatures;

--- a/src/examples/source/LCMS_MRM_Unknown_test.cpp
+++ b/src/examples/source/LCMS_MRM_Unknown_test.cpp
@@ -13,10 +13,10 @@ void test_main_LCMS_MRM_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns");
   Filenames filenames_main;
-  filenames_main.setRootPaths(main_dir,
-    main_dir + "/mzML/",
-    main_dir + "/features/",
-    main_dir + "/features/");
+  filenames_main.setTag("MAIN_DIR", main_dir);
+  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
+  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
 
   example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/LCMS_MRM_Unknown_test.cpp
+++ b/src/examples/source/LCMS_MRM_Unknown_test.cpp
@@ -12,7 +12,7 @@ using namespace std;
 void test_main_LCMS_MRM_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns");
-  const Filenames static_filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames static_filenames;
 
   example_LCMS_MRM_Unknowns(main_dir, static_filenames, ",");
 
@@ -21,19 +21,19 @@ void test_main_LCMS_MRM_Unknown()
   LoadParameters loadParameters;
   Filenames filenames;
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/features/170808_Jonathan_yeast_Sacc1_1x_1_BatchName_1900-01-01_000000.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/features/170808_Jonathan_yeast_Sacc1_1x_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.featureXML_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/features/170808_Jonathan_yeast_Sacc1_1x_test.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/features/170808_Jonathan_yeast_Sacc1_1x_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
   
   rawDataHandler.clear();
   
-  filenames.parameters_csv_i = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/parameters.csv");
+  filenames.setFullPathName("parameters_csv_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/parameters.csv"));
   loadParameters.process(rawDataHandler,{}, filenames);
   
   ParameterSet* params;

--- a/src/examples/source/LCMS_MRM_Unknown_test.cpp
+++ b/src/examples/source/LCMS_MRM_Unknown_test.cpp
@@ -21,19 +21,19 @@ void test_main_LCMS_MRM_Unknown()
   LoadParameters loadParameters;
   Filenames filenames;
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/features/170808_Jonathan_yeast_Sacc1_1x_1_BatchName_1900-01-01_000000.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/features/170808_Jonathan_yeast_Sacc1_1x_1_BatchName_1900-01-01_000000.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm1 = rawDataHandler.getFeatureMap();
 
   rawDataHandler.clear();
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/features/170808_Jonathan_yeast_Sacc1_1x_test.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/features/170808_Jonathan_yeast_Sacc1_1x_test.featureXML"));
   loadFeatures.process(rawDataHandler, {}, filenames);
   OpenMS::FeatureMap fm2 = rawDataHandler.getFeatureMap();
   
   rawDataHandler.clear();
   
-  filenames.setFullPathName("parameters_csv_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/parameters.csv"));
+  filenames.setFullPath("parameters_csv_i", SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns/parameters.csv"));
   loadParameters.process(rawDataHandler,{}, filenames);
   
   ParameterSet* params;

--- a/src/examples/source/LCMS_MRM_Unknown_test.cpp
+++ b/src/examples/source/LCMS_MRM_Unknown_test.cpp
@@ -13,10 +13,10 @@ void test_main_LCMS_MRM_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns");
   Filenames filenames_main;
-  filenames_main.setTag("MAIN_DIR", main_dir);
-  filenames_main.setTag("MZML_INPUT_PATH", main_dir + "/mzML/");
-  filenames_main.setTag("FEATURES_INPUT_PATH", main_dir + "/features/");
-  filenames_main.setTag("FEATURES_OUTPUT_PATH", main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::MAIN_DIR, main_dir);
+  filenames_main.setTag(Filenames::Tag::MZML_INPUT_PATH, main_dir + "/mzML/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_INPUT_PATH, main_dir + "/features/");
+  filenames_main.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, main_dir + "/features/");
 
   example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/LCMS_MRM_Unknown_test.cpp
+++ b/src/examples/source/LCMS_MRM_Unknown_test.cpp
@@ -12,9 +12,9 @@ using namespace std;
 void test_main_LCMS_MRM_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns");
-  Filenames static_filenames;
+  Filenames filenames_main;
 
-  example_LCMS_MRM_Unknowns(main_dir, static_filenames, ",");
+  example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 
   RawDataHandler rawDataHandler;
   LoadFeatures loadFeatures;

--- a/src/examples/source/LCMS_MRM_Unknown_test.cpp
+++ b/src/examples/source/LCMS_MRM_Unknown_test.cpp
@@ -13,6 +13,10 @@ void test_main_LCMS_MRM_Unknown()
 {
   const std::string main_dir = SMARTPEAK_GET_EXAMPLES_DATA_PATH("LCMS_MRM_Unknowns");
   Filenames filenames_main;
+  filenames_main.setRootPaths(main_dir,
+    main_dir + "/mzML/",
+    main_dir + "/features/",
+    main_dir + "/features/");
 
   example_LCMS_MRM_Unknowns(main_dir, filenames_main, ",");
 

--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -72,8 +72,8 @@ void initializeDataDirs(ApplicationHandler& state);
 void initializeDataDir(
   ApplicationHandler& state,
   const std::string& label,
-  std::string& data_dir_member,
-  const std::string& default_dir
+  std::filesystem::path& data_dir_member,
+  const std::filesystem::path& default_dir
 );
 
 void checkTitles(const std::vector<std::shared_ptr<Widget>> windows);
@@ -925,15 +925,15 @@ void initializeDataDirs(ApplicationHandler& application_handler)
 void initializeDataDir(
   ApplicationHandler& application_handler,
   const std::string& label,
-  std::string& data_dir_member,
-  const std::string& default_dir
+  std::filesystem::path& data_dir_member,
+  const std::filesystem::path& default_dir
 )
 {
-  if (data_dir_member.size()) {
+  if (!data_dir_member.empty()) {
     return;
   }
-  data_dir_member = application_handler.main_dir_ + "/" + default_dir;
-  LOGN << "\n\nGenerated path for '" << label << "':\t" << data_dir_member;
+  data_dir_member = application_handler.main_dir_ / default_dir;
+  LOGN << "\n\nGenerated path for '" << label << "':\t" << data_dir_member.generic_string();
 }
 
 void checkTitles(const std::vector<std::shared_ptr<Widget>> windows)

--- a/src/smartpeak/include/SmartPeak/core/ApplicationHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/ApplicationHandler.h
@@ -109,13 +109,13 @@ namespace SmartPeak
       }
     };
 
-    std::string                           sequence_pathname_;
-    std::string                           main_dir_                = ".";
-    std::string                           mzML_dir_;
-    std::string                           features_in_dir_;
-    std::string                           features_out_dir_;
-    Filenames                             static_filenames_;
-    SequenceHandler                       sequenceHandler_;
+    std::string           sequence_pathname_;
+    std::filesystem::path main_dir_                = ".";
+    std::filesystem::path mzML_dir_;
+    std::filesystem::path features_in_dir_;
+    std::filesystem::path features_out_dir_;
+    Filenames             static_filenames_;
+    SequenceHandler       sequenceHandler_;
   };
 
 

--- a/src/smartpeak/include/SmartPeak/core/ApplicationHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/ApplicationHandler.h
@@ -114,7 +114,6 @@ namespace SmartPeak
     std::filesystem::path mzML_dir_;
     std::filesystem::path features_in_dir_;
     std::filesystem::path features_out_dir_;
-    Filenames             static_filenames_;
     SequenceHandler       sequenceHandler_;
   };
 

--- a/src/smartpeak/include/SmartPeak/core/ApplicationHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/ApplicationHandler.h
@@ -123,7 +123,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override
     {
       application_handler->mzML_dir_ = filename;
       return true;
@@ -134,7 +134,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override
     {
       application_handler->features_in_dir_ = filename;
       return true;
@@ -146,7 +146,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override
     {
       application_handler->features_out_dir_ = filename;
       return true;

--- a/src/smartpeak/include/SmartPeak/core/ApplicationHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/ApplicationHandler.h
@@ -109,7 +109,7 @@ namespace SmartPeak
       }
     };
 
-    std::string           sequence_pathname_;
+    std::filesystem::path sequence_pathname_;
     std::filesystem::path main_dir_                = ".";
     std::filesystem::path mzML_dir_;
     std::filesystem::path features_in_dir_;

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -42,10 +42,10 @@ public:
     );
 
     void setRootPaths(
-      const std::string& main_dir,
-      const std::string& mzml_input_path,
-      const std::string& features_input_path,
-      const std::string& output_path
+      const std::filesystem::path& main_dir,
+      const std::filesystem::path& mzml_input_path,
+      const std::filesystem::path& features_input_path,
+      const std::filesystem::path& output_path
     );
 
     enum class FileScope

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -33,11 +33,7 @@ namespace SmartPeak
   {
 public:
 
-    void setPathsAndNames(
-      const std::string& main_dir,
-      const std::string& mzml_input_path,
-      const std::string& features_input_path,
-      const std::string& output_path,
+    void setFileVariants(
       const std::string& input_mzML_filename,
       const std::string& input_inj_name,
       const std::string& output_inj_name,

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -78,7 +78,9 @@ public:
       bool full_path_override_ = false;
     };
 
-    void updateRootPath(const std::string& dir, FileScope file_scope);
+    void updateRootPath(const std::filesystem::path& dir, FileScope file_scope);
+    void updateRootPaths();
+    void updateFileVariants();
     void updateFileVariant(const std::string& variant, FileScope file_scope);
     void updateFullPathName(FileName& filname);
 
@@ -87,5 +89,10 @@ public:
     std::filesystem::path mzml_input_path_;
     std::filesystem::path input_path_;
     std::filesystem::path output_path_;
+    std::string input_mzML_filename_;
+    std::string input_inj_name_;
+    std::string output_inj_name_;
+    std::string input_sample_name_;
+    std::string output_sample_name_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -64,9 +64,10 @@ public:
     void setFullPathName(const std::string& id, const std::string& full_path);
     void merge(const Filenames& other);
 
+  protected:
+
     friend class Filenames;
 
-  protected:
     struct FileName
     {
       std::string default_name_;
@@ -77,15 +78,14 @@ public:
       bool full_path_override_ = false;
     };
 
-    std::map<std::string, FileName> file_names_;
-
-    void setRootPath(const std::string& dir, FileScope file_scope);
-    void setFileVariant(const std::string& variant, FileScope file_scope);
+    void updateRootPath(const std::string& dir, FileScope file_scope);
+    void updateFileVariant(const std::string& variant, FileScope file_scope);
     void updateFullPathName(FileName& filname);
 
+    std::map<std::string, FileName> file_names_;
     std::string main_dir_;
     std::string mzml_input_path_;
-    std::string features_input_path_;
+    std::string input_path_;
     std::string output_path_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -85,6 +85,13 @@ public:
     */
     void merge(const Filenames& other);
 
+    /**
+      @brief returns registered file ids.
+    */
+    std::vector<std::string> getFileIds() const;
+
+  protected:
+
     struct FileName
     {
       std::string default_name_;
@@ -94,13 +101,6 @@ public:
       std::filesystem::path full_path_;
       bool full_path_override_ = false;
     };
-
-    /**
-      @brief returns detailed filenames.
-    */
-    const std::map<std::string, FileName>& getFileNames() const { return file_names_; };
-
-  protected:
 
     friend class Filenames;
 

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -51,15 +51,15 @@ public:
       const std::filesystem::path& main_dir,
       const std::filesystem::path& mzml_input_path,
       const std::filesystem::path& features_input_path,
-      const std::filesystem::path& output_path
+      const std::filesystem::path& features_output_path
     );
 
     enum class FileScope
     {
       EFileScopeMain,
       EFileScopeMzMLInput,
-      EFileScopeInjectionOutput,
       EFileScopeInjectionInput,
+      EFileScopeInjectionOutput,
       EFileScopeSampleGroupInput,
       EFileScopeSampleGroupOutput,
       EFileScopeUnspecified
@@ -73,7 +73,7 @@ public:
     /**
       @brief Returns the full path, with root path and variant applied (or the overridden full path).
     */
-    std::string getFullPath(const std::string& id) const;
+    std::filesystem::path getFullPath(const std::string& id) const;
 
     /**
       @brief Sets the ful path name, overriding computation using variant and root path.

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <filesystem>
 #include <map>
+#include <vector>
 
 namespace SmartPeak
 {

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -34,42 +34,10 @@ namespace SmartPeak
   {
 public:
 
-    /**
-      @brief sets the file name vairants: injection name, group names ...
-    */
-    void setFileVariants(
-      const std::string& input_mzML_filename,
-      const std::string& input_inj_name,
-      const std::string& output_inj_name,
-      const std::string& input_sample_name,
-      const std::string& output_sample_name
-    );
-
-    /**
-      @brief sets the directories paths
-    */
-    void setRootPaths(
-      const std::filesystem::path& main_dir,
-      const std::filesystem::path& mzml_input_path,
-      const std::filesystem::path& features_input_path,
-      const std::filesystem::path& features_output_path
-    );
-
-    enum class FileScope
-    {
-      EFileScopeMain,
-      EFileScopeMzMLInput,
-      EFileScopeInjectionInput,
-      EFileScopeInjectionOutput,
-      EFileScopeSampleGroupInput,
-      EFileScopeSampleGroupOutput,
-      EFileScopeUnspecified
-    };
-
-    /**
+  /**
       @brief Adds file to the Filename
     */
-    void addFileName(const std::string& id, const std::string& default_name, FileScope file_scope);
+    void addFileName(const std::string& id, const std::string& name_pattern);
 
     /**
       @brief Returns the full path, with root path and variant applied (or the overridden full path).
@@ -91,35 +59,26 @@ public:
     */
     std::vector<std::string> getFileIds() const;
 
+    /**
+      @brief set tags and update paths.
+    */
+    void setTag(const std::string& tag_id, const std::string& value);
+
   protected:
 
     struct FileName
     {
-      std::string default_name_;
-      FileScope file_scope_;
-      std::string file_variant_;
-      std::filesystem::path root_path_;
+      std::string name_pattern_;
       std::filesystem::path full_path_;
       bool full_path_override_ = false;
     };
 
     friend class Filenames;
 
-    void updateRootPath(const std::filesystem::path& dir, FileScope file_scope);
-    void updateRootPaths();
-    void updateFileVariants();
-    void updateFileVariant(const std::string& variant, FileScope file_scope);
-    void updateFullPath(FileName& filname);
+    void updateFullPaths();
+    void updateFullPath(FileName& filename);
 
     std::map<std::string, FileName> file_names_;
-    std::filesystem::path main_dir_;
-    std::filesystem::path mzml_input_path_;
-    std::filesystem::path input_path_;
-    std::filesystem::path output_path_;
-    std::string input_mzML_filename_;
-    std::string input_inj_name_;
-    std::string output_inj_name_;
-    std::string input_sample_name_;
-    std::string output_sample_name_;
+    std::map<std::string, std::string> tags_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -32,9 +32,22 @@ namespace SmartPeak
 {
   class Filenames
   {
-public:
+  public:
 
-  /**
+    enum class Tag
+    {
+      MAIN_DIR,
+      MZML_INPUT_PATH,
+      FEATURES_INPUT_PATH,
+      FEATURES_OUTPUT_PATH,
+      INPUT_MZML_FILENAME,
+      INPUT_INJECTION_NAME,
+      OUTPUT_INJECTION_NAME,
+      INPUT_GROUP_NAME,
+      OUTPUT_GROUP_NAME
+    };
+
+    /**
       @brief Adds file to the Filename
     */
     void addFileName(const std::string& id, const std::string& name_pattern);
@@ -62,7 +75,7 @@ public:
     /**
       @brief set tags and update paths.
     */
-    void setTag(const std::string& tag_id, const std::string& value);
+    void setTag(Tag tag, const std::string& value);
 
   protected:
 
@@ -79,6 +92,8 @@ public:
     void updateFullPath(FileName& filename);
 
     std::map<std::string, FileName> file_names_;
-    std::map<std::string, std::string> tags_;
+    std::map<Tag, std::string> tags_;
+
+    static std::map<std::string, Tag> string_to_tag_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -73,8 +73,8 @@ public:
       std::string default_name_;
       FileScope file_scope_;
       std::string file_variant_;
-      std::string root_path_;
-      std::string full_path_;
+      std::filesystem::path root_path_;
+      std::filesystem::path full_path_;
       bool full_path_override_ = false;
     };
 
@@ -83,9 +83,9 @@ public:
     void updateFullPathName(FileName& filname);
 
     std::map<std::string, FileName> file_names_;
-    std::string main_dir_;
-    std::string mzml_input_path_;
-    std::string input_path_;
-    std::string output_path_;
+    std::filesystem::path main_dir_;
+    std::filesystem::path mzml_input_path_;
+    std::filesystem::path input_path_;
+    std::filesystem::path output_path_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -64,10 +64,6 @@ public:
     void setFullPathName(const std::string& id, const std::filesystem::path& full_path);
     void merge(const Filenames& other);
 
-  protected:
-
-    friend class Filenames;
-
     struct FileName
     {
       std::string default_name_;
@@ -77,6 +73,12 @@ public:
       std::filesystem::path full_path_;
       bool full_path_override_ = false;
     };
+
+    const std::map<std::string, FileName>& getFileNames() const { return file_names_; };
+
+  protected:
+
+    friend class Filenames;
 
     void updateRootPath(const std::filesystem::path& dir, FileScope file_scope);
     void updateRootPaths();

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -33,6 +33,9 @@ namespace SmartPeak
   {
 public:
 
+    /**
+      @brief sets the file name vairants: injection name, group names ...
+    */
     void setFileVariants(
       const std::string& input_mzML_filename,
       const std::string& input_inj_name,
@@ -41,6 +44,9 @@ public:
       const std::string& output_sample_name
     );
 
+    /**
+      @brief sets the directories paths
+    */
     void setRootPaths(
       const std::filesystem::path& main_dir,
       const std::filesystem::path& mzml_input_path,
@@ -59,9 +65,24 @@ public:
       EFileScopeUnspecified
     };
 
+    /**
+      @brief Adds file to the Filename
+    */
     void addFileName(const std::string& id, const std::string& default_name, FileScope file_scope);
-    std::string getFullPathName(const std::string& id) const;
-    void setFullPathName(const std::string& id, const std::filesystem::path& full_path);
+
+    /**
+      @brief Returns the full path, with root path and variant applied (or the overridden full path).
+    */
+    std::string getFullPath(const std::string& id) const;
+
+    /**
+      @brief Sets the ful path name, overriding computation using variant and root path.
+    */
+    void setFullPath(const std::string& id, const std::filesystem::path& full_path);
+
+    /**
+      @brief Merges two Filenames. Will not overwrite file that already exists.
+    */
     void merge(const Filenames& other);
 
     struct FileName
@@ -74,6 +95,9 @@ public:
       bool full_path_override_ = false;
     };
 
+    /**
+      @brief returns detailed filenames.
+    */
     const std::map<std::string, FileName>& getFileNames() const { return file_names_; };
 
   protected:
@@ -84,7 +108,7 @@ public:
     void updateRootPaths();
     void updateFileVariants();
     void updateFileVariant(const std::string& variant, FileScope file_scope);
-    void updateFullPathName(FileName& filname);
+    void updateFullPath(FileName& filname);
 
     std::map<std::string, FileName> file_names_;
     std::filesystem::path main_dir_;

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -61,7 +61,7 @@ public:
 
     void addFileName(const std::string& id, const std::string& default_name, FileScope file_scope);
     std::string getFullPathName(const std::string& id) const;
-    void setFullPathName(const std::string& id, const std::string& full_path);
+    void setFullPathName(const std::string& id, const std::filesystem::path& full_path);
     void merge(const Filenames& other);
 
   protected:

--- a/src/smartpeak/include/SmartPeak/core/Filenames.h
+++ b/src/smartpeak/include/SmartPeak/core/Filenames.h
@@ -25,77 +25,16 @@
 
 #include <string>
 #include <filesystem>
+#include <map>
 
 namespace SmartPeak
 {
   class Filenames
   {
 public:
-    std::string sequence_csv_i;
-    std::string parameters_csv_i;
-    std::string workflow_csv_i;
-    std::string traML_csv_i;
-    std::string traML_csv_o;
-    std::string featureFilterComponents_csv_i;
-    std::string featureFilterComponentGroups_csv_i;
-    std::string featureQCComponents_csv_i;
-    std::string featureQCComponentGroups_csv_i;
-    std::string featureRSDFilterComponents_csv_i;
-    std::string featureRSDFilterComponentGroups_csv_i;
-    std::string featureRSDQCComponents_csv_i;
-    std::string featureRSDQCComponentGroups_csv_i;
-    std::string featureBackgroundFilterComponents_csv_i;
-    std::string featureBackgroundFilterComponentGroups_csv_i;
-    std::string featureBackgroundQCComponents_csv_i;
-    std::string featureBackgroundQCComponentGroups_csv_i;
-    std::string featureRSDEstimationComponents_csv_i;
-    std::string featureRSDEstimationComponentGroups_csv_i;
-    std::string featureBackgroundEstimationComponents_csv_i;
-    std::string featureBackgroundEstimationComponentGroups_csv_i;
-    std::string quantitationMethods_csv_i;
-    std::string standardsConcentrations_csv_i;
-    std::string referenceData_csv_i;
-    std::string selectDilutions_csv_i;
-    std::string mzML_i;
-    std::string mzTab_i;
-    std::string mzTab_o;
-    std::string featureXML_o;
-    std::string features_pdf_o;
-    std::string featureXMLSampleGroup_o;
-    std::string featureXML_i;
-    std::string featureXMLSampleGroup_i;
-    std::string featureFilterComponents_csv_o;
-    std::string featureFilterComponentGroups_csv_o;
-    std::string featureQCComponents_csv_o;
-    std::string featureQCComponentGroups_csv_o;
-    std::string featureRSDFilterComponents_csv_o;
-    std::string featureRSDFilterComponentGroups_csv_o;
-    std::string featureRSDQCComponents_csv_o;
-    std::string featureRSDQCComponentGroups_csv_o;
-    std::string featureBackgroundFilterComponents_csv_o;
-    std::string featureBackgroundFilterComponentGroups_csv_o;
-    std::string featureBackgroundQCComponents_csv_o;
-    std::string featureBackgroundQCComponentGroups_csv_o;
-    std::string featureRSDEstimationComponents_csv_o;
-    std::string featureRSDEstimationComponentGroups_csv_o;
-    std::string featureBackgroundEstimationComponents_csv_o;
-    std::string featureBackgroundEstimationComponentGroups_csv_o;
-    std::string quantitationMethods_csv_o;
-    std::string componentsToConcentrations_csv_o;
-    std::string pivotTable_csv_o;
-    std::string featureDB_csv_o;
-    // TODO: do not hardcode entire pathnames (all those above this line)
-    // Instead, construct them when needed, using the strings below
-    std::string mzml_input_path;
-    std::string features_input_path;
-    std::string output_path;
 
-    static Filenames getDefaultStaticFilenames(
-      const std::string& dir
-    );
-
-    static Filenames getDefaultDynamicFilenames(
-      const std::string& static_dir,
+    void setPathsAndNames(
+      const std::string& main_dir,
       const std::string& mzml_input_path,
       const std::string& features_input_path,
       const std::string& output_path,
@@ -106,13 +45,51 @@ public:
       const std::string& output_sample_name
     );
 
-    static void updateDefaultDynamicFilenames(
+    void setRootPaths(
+      const std::string& main_dir,
       const std::string& mzml_input_path,
       const std::string& features_input_path,
-      const std::string& output_path,
-      Filenames& filenames
+      const std::string& output_path
     );
 
-    void clear();
+    enum class FileScope
+    {
+      EFileScopeMain,
+      EFileScopeMzMLInput,
+      EFileScopeInjectionOutput,
+      EFileScopeInjectionInput,
+      EFileScopeSampleGroupInput,
+      EFileScopeSampleGroupOutput,
+      EFileScopeUnspecified
+    };
+
+    void addFileName(const std::string& id, const std::string& default_name, FileScope file_scope);
+    std::string getFullPathName(const std::string& id) const;
+    void setFullPathName(const std::string& id, const std::string& full_path);
+    void merge(const Filenames& other);
+
+    friend class Filenames;
+
+  protected:
+    struct FileName
+    {
+      std::string default_name_;
+      FileScope file_scope_;
+      std::string file_variant_;
+      std::string root_path_;
+      std::string full_path_;
+      bool full_path_override_ = false;
+    };
+
+    std::map<std::string, FileName> file_names_;
+
+    void setRootPath(const std::string& dir, FileScope file_scope);
+    void setFileVariant(const std::string& variant, FileScope file_scope);
+    void updateFullPathName(FileName& filname);
+
+    std::string main_dir_;
+    std::string mzml_input_path_;
+    std::string features_input_path_;
+    std::string output_path_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
@@ -58,7 +58,7 @@ namespace SmartPeak
     virtual void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const = 0;
 
     /* IInputsOutputsProvider */
@@ -88,7 +88,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /** Extracts metadata from the chromatogram.
@@ -115,7 +115,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -133,7 +133,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -150,7 +150,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -165,7 +165,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -182,7 +182,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -199,7 +199,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -214,7 +214,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -232,7 +232,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -250,7 +250,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -268,7 +268,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -288,7 +288,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -305,7 +305,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -322,7 +322,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -339,7 +339,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -354,7 +354,7 @@ namespace SmartPeak
       void process(
           RawDataHandler& rawDataHandler_IO,
           const ParameterSet& params_I,
-          const Filenames& filenames_override
+          const Filenames& filenames_I
       ) const override;
   };
 
@@ -371,7 +371,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -388,7 +388,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -408,7 +408,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -425,7 +425,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -440,7 +440,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -457,7 +457,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -474,7 +474,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -489,7 +489,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -511,7 +511,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
     
     /* IInputsOutputsProvider */
@@ -531,7 +531,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -549,7 +549,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -567,7 +567,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -585,7 +585,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -608,7 +608,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -631,7 +631,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
     static void sanitizeParameters(
       ParameterSet& params_I
@@ -654,7 +654,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
     std::string filename_;
 
@@ -680,7 +680,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
   private:
@@ -706,7 +706,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -723,7 +723,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -740,7 +740,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -757,7 +757,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -772,7 +772,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
   
@@ -789,7 +789,7 @@ namespace SmartPeak
     void process(
                  RawDataHandler& rawDataHandler_IO,
                  const ParameterSet& params_I,
-                 const Filenames& filenames_override
+                 const Filenames& filenames_I
                  ) const override;
   };
   
@@ -806,7 +806,7 @@ namespace SmartPeak
     void process(
                  RawDataHandler& rawDataHandler_IO,
                  const ParameterSet& params_I,
-                 const Filenames& filenames_override
+                 const Filenames& filenames_I
                  ) const override;
   };
   
@@ -823,7 +823,7 @@ namespace SmartPeak
     void process(
                  RawDataHandler& rawDataHandler_IO,
                  const ParameterSet& params_I,
-                 const Filenames& filenames_override
+                 const Filenames& filenames_I
                  ) const override;
   };
 
@@ -840,7 +840,7 @@ namespace SmartPeak
     void process(
                  RawDataHandler& rawDataHandler_IO,
                  const ParameterSet& params_I,
-                 const Filenames& filenames_override
+                 const Filenames& filenames_I
                  ) const override;
   };
 

--- a/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
@@ -498,7 +498,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_TRANSITIONS"; }
@@ -597,7 +597,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_VALIDATION_DATA"; }
@@ -620,7 +620,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_PARAMETERS"; }
@@ -648,7 +648,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     StoreParameters() = default;
     void process(

--- a/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
@@ -32,7 +32,7 @@
 #include <SmartPeak/core/ParametersObservable.h>
 #include <SmartPeak/core/TransitionsObservable.h>
 #include <SmartPeak/iface/IFilePickerHandler.h>
-#include <SmartPeak/iface/IInputsOutputsProvider.h>
+#include <SmartPeak/iface/IFilenamesHandler.h>
 
 #include <map>
 #include <vector>
@@ -41,7 +41,7 @@
 
 namespace SmartPeak
 {
-  struct RawDataProcessor : IProcessorDescription, IInputsOutputsProvider
+  struct RawDataProcessor : IProcessorDescription, IFilenamesHandler
   {
     RawDataProcessor(const RawDataProcessor& other) = delete;
     RawDataProcessor& operator=(const RawDataProcessor& other) = delete;
@@ -61,8 +61,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const = 0;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override { };
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override { };
 
   protected:
     // Forced to write this, because the other user-defined constructors inhibit
@@ -100,8 +100,8 @@ namespace SmartPeak
     */
     static void extractMetaData(RawDataHandler& rawDataHandler_IO);
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreRawData : RawDataProcessor
@@ -118,8 +118,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct ZeroChromatogramBaseline : RawDataProcessor
@@ -217,8 +217,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatures : RawDataProcessor
@@ -235,8 +235,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadAnnotations : RawDataProcessor
@@ -253,8 +253,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreAnnotations : RawDataProcessor
@@ -271,8 +271,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct PickMRMFeatures : RawDataProcessor
@@ -391,8 +391,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct FilterFeatures : RawDataProcessor
@@ -514,8 +514,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
     
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
 
     TransitionsObservable* transitions_observable_ = nullptr;
   };
@@ -534,8 +534,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadFeatureQCsRDP : RawDataProcessor
@@ -552,8 +552,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatureFiltersRDP : RawDataProcessor
@@ -570,8 +570,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatureQCsRDP : RawDataProcessor
@@ -588,8 +588,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadValidationData : RawDataProcessor, IFilePickerHandler
@@ -611,8 +611,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadParameters : RawDataProcessor, IFilePickerHandler
@@ -637,8 +637,8 @@ namespace SmartPeak
       ParameterSet& params_I
     );
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
 
     ParametersObservable* parameters_observable_ = nullptr;
   };
@@ -663,8 +663,8 @@ namespace SmartPeak
     std::string getName() const override { return "STORE_PARAMETERS"; }
     std::string getDescription() const override { return "Store a parameters to file"; }
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct FitFeaturesEMG : RawDataProcessor

--- a/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
@@ -32,6 +32,7 @@
 #include <SmartPeak/core/ParametersObservable.h>
 #include <SmartPeak/core/TransitionsObservable.h>
 #include <SmartPeak/iface/IFilePickerHandler.h>
+#include <SmartPeak/iface/IInputsOutputsProvider.h>
 
 #include <map>
 #include <vector>
@@ -40,7 +41,7 @@
 
 namespace SmartPeak
 {
-  struct RawDataProcessor : IProcessorDescription
+  struct RawDataProcessor : IProcessorDescription, IInputsOutputsProvider
   {
     RawDataProcessor(const RawDataProcessor& other) = delete;
     RawDataProcessor& operator=(const RawDataProcessor& other) = delete;
@@ -59,6 +60,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const = 0;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override { };
 
   protected:
     // Forced to write this, because the other user-defined constructors inhibit
@@ -95,6 +99,9 @@ namespace SmartPeak
         with current injection, sample, and file naming patterns
     */
     static void extractMetaData(RawDataHandler& rawDataHandler_IO);
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreRawData : RawDataProcessor
@@ -110,6 +117,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct ZeroChromatogramBaseline : RawDataProcessor
@@ -206,6 +216,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatures : RawDataProcessor
@@ -221,6 +234,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadAnnotations : RawDataProcessor
@@ -236,6 +252,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreAnnotations : RawDataProcessor
@@ -251,6 +270,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct PickMRMFeatures : RawDataProcessor
@@ -368,6 +390,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct FilterFeatures : RawDataProcessor
@@ -489,6 +514,9 @@ namespace SmartPeak
       const Filenames& filenames
     ) const override;
     
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
+
     TransitionsObservable* transitions_observable_ = nullptr;
   };
 
@@ -505,6 +533,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadFeatureQCsRDP : RawDataProcessor
@@ -520,6 +551,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatureFiltersRDP : RawDataProcessor
@@ -535,6 +569,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatureQCsRDP : RawDataProcessor
@@ -550,6 +587,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadValidationData : RawDataProcessor, IFilePickerHandler
@@ -570,6 +610,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadParameters : RawDataProcessor, IFilePickerHandler
@@ -594,6 +637,9 @@ namespace SmartPeak
       ParameterSet& params_I
     );
 
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
+
     ParametersObservable* parameters_observable_ = nullptr;
   };
 
@@ -616,6 +662,9 @@ namespace SmartPeak
     int getID() const override { return -1; }
     std::string getName() const override { return "STORE_PARAMETERS"; }
     std::string getDescription() const override { return "Store a parameters to file"; }
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct FitFeaturesEMG : RawDataProcessor

--- a/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/RawDataProcessor.h
@@ -58,7 +58,7 @@ namespace SmartPeak
     virtual void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const = 0;
 
     /* IInputsOutputsProvider */
@@ -88,7 +88,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /** Extracts metadata from the chromatogram.
@@ -115,7 +115,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -133,7 +133,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -150,7 +150,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -165,7 +165,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -182,7 +182,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -199,7 +199,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -214,7 +214,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -232,7 +232,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -250,7 +250,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -268,7 +268,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -288,7 +288,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -305,7 +305,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -322,7 +322,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -339,7 +339,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -354,7 +354,7 @@ namespace SmartPeak
       void process(
           RawDataHandler& rawDataHandler_IO,
           const ParameterSet& params_I,
-          const Filenames& filenames
+          const Filenames& filenames_override
       ) const override;
   };
 
@@ -371,7 +371,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -388,7 +388,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -408,7 +408,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -425,7 +425,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -440,7 +440,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -457,7 +457,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -474,7 +474,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -489,7 +489,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -511,7 +511,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
     
     /* IInputsOutputsProvider */
@@ -531,7 +531,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -549,7 +549,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -567,7 +567,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -585,7 +585,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -608,7 +608,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -631,7 +631,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
     static void sanitizeParameters(
       ParameterSet& params_I
@@ -654,7 +654,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
     std::string filename_;
 
@@ -680,7 +680,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
   private:
@@ -706,7 +706,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -723,7 +723,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -740,7 +740,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -757,7 +757,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -772,7 +772,7 @@ namespace SmartPeak
     void process(
       RawDataHandler& rawDataHandler_IO,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
   
@@ -789,7 +789,7 @@ namespace SmartPeak
     void process(
                  RawDataHandler& rawDataHandler_IO,
                  const ParameterSet& params_I,
-                 const Filenames& filenames
+                 const Filenames& filenames_override
                  ) const override;
   };
   
@@ -806,7 +806,7 @@ namespace SmartPeak
     void process(
                  RawDataHandler& rawDataHandler_IO,
                  const ParameterSet& params_I,
-                 const Filenames& filenames
+                 const Filenames& filenames_override
                  ) const override;
   };
   
@@ -823,7 +823,7 @@ namespace SmartPeak
     void process(
                  RawDataHandler& rawDataHandler_IO,
                  const ParameterSet& params_I,
-                 const Filenames& filenames
+                 const Filenames& filenames_override
                  ) const override;
   };
 
@@ -840,7 +840,7 @@ namespace SmartPeak
     void process(
                  RawDataHandler& rawDataHandler_IO,
                  const ParameterSet& params_I,
-                 const Filenames& filenames
+                 const Filenames& filenames_override
                  ) const override;
   };
 

--- a/src/smartpeak/include/SmartPeak/core/SampleGroupProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SampleGroupProcessor.h
@@ -30,14 +30,18 @@
 #include <SmartPeak/core/SampleGroupHandler.h>
 #include <SmartPeak/core/Parameters.h>
 #include <SmartPeak/iface/IProcessorDescription.h>
+#include <SmartPeak/iface/IInputsOutputsProvider.h>
 
 namespace SmartPeak
 {
-  struct SampleGroupProcessor : IProcessorDescription
+  struct SampleGroupProcessor : IProcessorDescription, IInputsOutputsProvider
   {
     SampleGroupProcessor(const SampleGroupProcessor& other) = delete;
     SampleGroupProcessor& operator=(const SampleGroupProcessor& other) = delete;
     virtual ~SampleGroupProcessor() = default;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override { };
 
     /**
       Interface to all sample group processing methods.
@@ -74,6 +78,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct MergeInjections : SampleGroupProcessor
@@ -144,6 +151,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeaturesSampleGroup : SampleGroupProcessor
@@ -162,5 +172,8 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/SampleGroupProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SampleGroupProcessor.h
@@ -55,7 +55,7 @@ namespace SmartPeak
       SampleGroupHandler& sampleGroupHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const = 0;
 
   protected:
@@ -76,7 +76,7 @@ namespace SmartPeak
       SampleGroupHandler& sampleGroupHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -97,7 +97,7 @@ namespace SmartPeak
       SampleGroupHandler& sampleGroupHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
   private:
@@ -149,7 +149,7 @@ namespace SmartPeak
       SampleGroupHandler& sampleGroupHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -170,7 +170,7 @@ namespace SmartPeak
       SampleGroupHandler& sampleGroupHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */

--- a/src/smartpeak/include/SmartPeak/core/SampleGroupProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SampleGroupProcessor.h
@@ -30,18 +30,18 @@
 #include <SmartPeak/core/SampleGroupHandler.h>
 #include <SmartPeak/core/Parameters.h>
 #include <SmartPeak/iface/IProcessorDescription.h>
-#include <SmartPeak/iface/IInputsOutputsProvider.h>
+#include <SmartPeak/iface/IFilenamesHandler.h>
 
 namespace SmartPeak
 {
-  struct SampleGroupProcessor : IProcessorDescription, IInputsOutputsProvider
+  struct SampleGroupProcessor : IProcessorDescription, IFilenamesHandler
   {
     SampleGroupProcessor(const SampleGroupProcessor& other) = delete;
     SampleGroupProcessor& operator=(const SampleGroupProcessor& other) = delete;
     virtual ~SampleGroupProcessor() = default;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override { };
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override { };
 
     /**
       Interface to all sample group processing methods.
@@ -79,8 +79,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct MergeInjections : SampleGroupProcessor
@@ -152,8 +152,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeaturesSampleGroup : SampleGroupProcessor
@@ -173,7 +173,7 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/SampleGroupProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SampleGroupProcessor.h
@@ -55,7 +55,7 @@ namespace SmartPeak
       SampleGroupHandler& sampleGroupHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const = 0;
 
   protected:
@@ -76,7 +76,7 @@ namespace SmartPeak
       SampleGroupHandler& sampleGroupHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -97,7 +97,7 @@ namespace SmartPeak
       SampleGroupHandler& sampleGroupHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
   private:
@@ -149,7 +149,7 @@ namespace SmartPeak
       SampleGroupHandler& sampleGroupHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -170,7 +170,7 @@ namespace SmartPeak
       SampleGroupHandler& sampleGroupHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
@@ -104,7 +104,7 @@ namespace SmartPeak
   */
   void processInjection(
     InjectionHandler& injection,
-    const Filenames& filenames,
+    const Filenames& filenames_override,
     const std::vector<std::shared_ptr<RawDataProcessor>>& methods
   );
 

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
@@ -104,7 +104,7 @@ namespace SmartPeak
   */
   void processInjection(
     InjectionHandler& injection,
-    const Filenames& filenames_override,
+    const Filenames& filenames_I,
     const std::vector<std::shared_ptr<RawDataProcessor>>& methods
   );
 

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
@@ -32,6 +32,7 @@
 #include <SmartPeak/core/SequenceProcessorObservable.h>
 #include <SmartPeak/core/SequenceSegmentProcessorObservable.h>
 #include <SmartPeak/iface/IProcessorDescription.h>
+#include <SmartPeak/iface/IInputsOutputsProvider.h>
 #include <SmartPeak/io/InputDataValidation.h>
 
 #include <map>
@@ -107,7 +108,7 @@ namespace SmartPeak
     const std::vector<std::shared_ptr<RawDataProcessor>>& methods
   );
 
-  struct SequenceProcessor : IProcessorDescription {
+  struct SequenceProcessor : IProcessorDescription, IInputsOutputsProvider {
     explicit SequenceProcessor(SequenceHandler& sh) : sequenceHandler_IO(&sh) {}
     virtual ~SequenceProcessor() = default;
 
@@ -115,6 +116,9 @@ namespace SmartPeak
     
     /* IProcessorDescription */
     ParameterSet getParameterSchema() const override { return ParameterSet(); };
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override {};
 
     SequenceHandler* sequenceHandler_IO = nullptr; /// Sequence handler, used by all SequenceProcessor derived classes
   };
@@ -142,12 +146,15 @@ namespace SmartPeak
     std::string getName() const override { return "CREATE_SEQUENCE"; }
     std::string getDescription() const override { return "Create a new sequence from file or wizard"; }
 
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
+
   private:
     bool buildStaticFilenames(ApplicationHandler* application_handler);
     void updateFilenames(Filenames& f, const std::string& pathname);
     bool requiredPathnamesAreValid(const std::vector<InputDataValidation::FilenameInfo>& validation);
     void clearNonExistantDefaultGeneratedFilenames(Filenames& f);
-    void clearNonExistantFilename(std::string& filename);
+    void clearNonExistantFilename(Filenames& f, const std::string& file_id);
     std::string getValidPathnameOrPlaceholder(const std::string& pathname, const bool is_valid);
   };
 
@@ -172,6 +179,9 @@ namespace SmartPeak
     std::string getName() const override { return "PROCESS_SEQUENCE"; }
     std::string getDescription() const override { return "Apply a processing workflow to all injections in a sequence"; }
     ParameterSet getParameterSchema() const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override {};
   };
 
   /**
@@ -232,6 +242,9 @@ namespace SmartPeak
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_WORKFLOW"; }
     std::string getDescription() const override { return "Load a workflow from file"; }
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreWorkflow : SequenceProcessor, IFilePickerHandler

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
@@ -153,8 +153,6 @@ namespace SmartPeak
     bool buildStaticFilenames(ApplicationHandler* application_handler);
     void updateFilenames(Filenames& f, const std::string& pathname);
     bool requiredPathnamesAreValid(const std::vector<InputDataValidation::FilenameInfo>& validation);
-    void clearNonExistantDefaultGeneratedFilenames(Filenames& f);
-    void clearNonExistantFilename(Filenames& f, const std::string& file_id);
     std::string getValidPathnameOrPlaceholder(const std::string& pathname, const bool is_valid);
   };
 

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
@@ -152,7 +152,6 @@ namespace SmartPeak
   private:
     bool buildStaticFilenames(ApplicationHandler* application_handler, Filenames& f);
     void updateFilenames(Filenames& f, const std::string& pathname);
-    bool requiredPathnamesAreValid(const std::vector<InputDataValidation::FilenameInfo>& validation);
     std::string getValidPathnameOrPlaceholder(const std::string& pathname, const bool is_valid);
   };
 
@@ -234,7 +233,7 @@ namespace SmartPeak
     LoadWorkflow() = default;
     explicit LoadWorkflow(SequenceHandler & sh) : SequenceProcessor(sh) {}
     void process() override;
-    std::filesystem::path filename_;
+    Filenames filenames_;
 
     /* IProcessorDescription */
     int getID() const override { return -1; }

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
@@ -32,7 +32,7 @@
 #include <SmartPeak/core/SequenceProcessorObservable.h>
 #include <SmartPeak/core/SequenceSegmentProcessorObservable.h>
 #include <SmartPeak/iface/IProcessorDescription.h>
-#include <SmartPeak/iface/IInputsOutputsProvider.h>
+#include <SmartPeak/iface/IFilenamesHandler.h>
 #include <SmartPeak/io/InputDataValidation.h>
 
 #include <map>
@@ -108,7 +108,7 @@ namespace SmartPeak
     const std::vector<std::shared_ptr<RawDataProcessor>>& methods
   );
 
-  struct SequenceProcessor : IProcessorDescription, IInputsOutputsProvider {
+  struct SequenceProcessor : IProcessorDescription, IFilenamesHandler {
     explicit SequenceProcessor(SequenceHandler& sh) : sequenceHandler_IO(&sh) {}
     virtual ~SequenceProcessor() = default;
 
@@ -117,8 +117,8 @@ namespace SmartPeak
     /* IProcessorDescription */
     ParameterSet getParameterSchema() const override { return ParameterSet(); };
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override {};
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override {};
 
     SequenceHandler* sequenceHandler_IO = nullptr; /// Sequence handler, used by all SequenceProcessor derived classes
   };
@@ -146,8 +146,8 @@ namespace SmartPeak
     std::string getName() const override { return "CREATE_SEQUENCE"; }
     std::string getDescription() const override { return "Create a new sequence from file or wizard"; }
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
 
   private:
     bool buildStaticFilenames(ApplicationHandler* application_handler, Filenames& f);
@@ -177,8 +177,8 @@ namespace SmartPeak
     std::string getDescription() const override { return "Apply a processing workflow to all injections in a sequence"; }
     ParameterSet getParameterSchema() const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override {};
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override {};
   };
 
   /**
@@ -240,8 +240,8 @@ namespace SmartPeak
     std::string getName() const override { return "LOAD_WORKFLOW"; }
     std::string getDescription() const override { return "Load a workflow from file"; }
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreWorkflow : SequenceProcessor, IFilePickerHandler

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
@@ -150,7 +150,7 @@ namespace SmartPeak
     virtual void getInputsOutputs(Filenames& filenames) const override;
 
   private:
-    bool buildStaticFilenames(ApplicationHandler* application_handler);
+    bool buildStaticFilenames(ApplicationHandler* application_handler, Filenames& f);
     void updateFilenames(Filenames& f, const std::string& pathname);
     bool requiredPathnamesAreValid(const std::vector<InputDataValidation::FilenameInfo>& validation);
     std::string getValidPathnameOrPlaceholder(const std::string& pathname, const bool is_valid);

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessor.h
@@ -131,7 +131,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     Filenames        filenames_;                            /// Pathnames to load
     std::string      delimiter          = ",";              /// String delimiter of the imported file
@@ -229,12 +229,12 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     LoadWorkflow() = default;
     explicit LoadWorkflow(SequenceHandler & sh) : SequenceProcessor(sh) {}
     void process() override;
-    std::string filename_;
+    std::filesystem::path filename_;
 
     /* IProcessorDescription */
     int getID() const override { return -1; }
@@ -250,12 +250,12 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     StoreWorkflow() = default;
     explicit StoreWorkflow(SequenceHandler& sh) : SequenceProcessor(sh) {}
     void process() override;
-    std::string filename_;
+    std::filesystem::path filename_;
 
     /* IProcessorDescription */
     int getID() const override { return -1; }

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
@@ -29,14 +29,14 @@
 #include <SmartPeak/core/SequenceHandler.h>
 #include <SmartPeak/core/SequenceSegmentHandler.h>
 #include <SmartPeak/iface/IProcessorDescription.h>
-#include <SmartPeak/iface/IInputsOutputsProvider.h>
+#include <SmartPeak/iface/IFilenamesHandler.h>
 #include <SmartPeak/core/Parameters.h>
 #include <SmartPeak/core/SequenceSegmentObservable.h>
 #include <SmartPeak/iface/IFilePickerHandler.h>
 
 namespace SmartPeak
 {
-  struct SequenceSegmentProcessor : IProcessorDescription, IInputsOutputsProvider
+  struct SequenceSegmentProcessor : IProcessorDescription, IFilenamesHandler
   {
     SequenceSegmentProcessor(const SequenceSegmentProcessor& other) = delete;
     SequenceSegmentProcessor& operator=(const SequenceSegmentProcessor& other) = delete;
@@ -73,8 +73,8 @@ namespace SmartPeak
     );
 
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override { };
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override { };
 
     SequenceSegmentObservable* sequence_segment_observable_ = nullptr;
 
@@ -128,8 +128,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadQuantitationMethods : SequenceSegmentProcessor, IFilePickerHandler
@@ -155,8 +155,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreQuantitationMethods : SequenceSegmentProcessor
@@ -177,8 +177,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadFeatureFilters : SequenceSegmentProcessor, IFilePickerHandler
@@ -206,8 +206,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadFeatureQCs : SequenceSegmentProcessor, IFilePickerHandler
@@ -235,8 +235,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatureFilters : SequenceSegmentProcessor
@@ -256,8 +256,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatureQCs : SequenceSegmentProcessor
@@ -277,8 +277,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadFeatureRSDFilters : SequenceSegmentProcessor, IFilePickerHandler
@@ -306,8 +306,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadFeatureRSDQCs : SequenceSegmentProcessor, IFilePickerHandler
@@ -335,8 +335,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatureRSDFilters : SequenceSegmentProcessor
@@ -356,8 +356,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatureRSDQCs : SequenceSegmentProcessor
@@ -377,8 +377,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadFeatureBackgroundFilters : SequenceSegmentProcessor, IFilePickerHandler
@@ -406,8 +406,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadFeatureBackgroundQCs : SequenceSegmentProcessor, IFilePickerHandler
@@ -435,8 +435,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatureBackgroundFilters : SequenceSegmentProcessor
@@ -456,8 +456,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatureBackgroundQCs : SequenceSegmentProcessor
@@ -477,8 +477,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct EstimateFeatureFilterValues : SequenceSegmentProcessor
@@ -619,8 +619,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatureRSDEstimations : SequenceSegmentProcessor
@@ -640,8 +640,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct LoadFeatureBackgroundEstimations : SequenceSegmentProcessor
@@ -661,8 +661,8 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 
   struct StoreFeatureBackgroundEstimations : SequenceSegmentProcessor
@@ -682,7 +682,7 @@ namespace SmartPeak
       const Filenames& filenames_I
     ) const override;
 
-    /* IInputsOutputsProvider */
-    virtual void getInputsOutputs(Filenames& filenames) const override;
+    /* IFilenamesHandler */
+    virtual void getFilenames(Filenames& filenames) const override;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
@@ -54,7 +54,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const = 0;
 
     /**
@@ -101,7 +101,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -125,7 +125,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -152,7 +152,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -174,7 +174,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -203,8 +203,11 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadFeatureQCs : SequenceSegmentProcessor, IFilePickerHandler
@@ -229,8 +232,11 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatureFilters : SequenceSegmentProcessor
@@ -247,7 +253,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -268,7 +274,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -297,7 +303,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -326,7 +332,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -347,7 +353,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -368,7 +374,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -397,7 +403,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -426,7 +432,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -447,7 +453,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -468,7 +474,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -492,7 +498,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -513,7 +519,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -532,7 +538,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -551,7 +557,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -572,7 +578,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -591,7 +597,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
   };
 
@@ -610,7 +616,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -631,7 +637,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -652,7 +658,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -673,7 +679,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames_override
+      const Filenames& filenames_I
     ) const override;
 
     /* IInputsOutputsProvider */

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
@@ -29,13 +29,14 @@
 #include <SmartPeak/core/SequenceHandler.h>
 #include <SmartPeak/core/SequenceSegmentHandler.h>
 #include <SmartPeak/iface/IProcessorDescription.h>
+#include <SmartPeak/iface/IInputsOutputsProvider.h>
 #include <SmartPeak/core/Parameters.h>
 #include <SmartPeak/core/SequenceSegmentObservable.h>
 #include <SmartPeak/iface/IFilePickerHandler.h>
 
 namespace SmartPeak
 {
-  struct SequenceSegmentProcessor : IProcessorDescription
+  struct SequenceSegmentProcessor : IProcessorDescription, IInputsOutputsProvider
   {
     SequenceSegmentProcessor(const SequenceSegmentProcessor& other) = delete;
     SequenceSegmentProcessor& operator=(const SequenceSegmentProcessor& other) = delete;
@@ -70,6 +71,10 @@ namespace SmartPeak
       const SampleType sampleType,
       std::vector<size_t>& sampleIndices
     );
+
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override { };
 
     SequenceSegmentObservable* sequence_segment_observable_ = nullptr;
 
@@ -122,6 +127,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadQuantitationMethods : SequenceSegmentProcessor, IFilePickerHandler
@@ -146,6 +154,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreQuantitationMethods : SequenceSegmentProcessor
@@ -165,6 +176,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadFeatureFilters : SequenceSegmentProcessor, IFilePickerHandler
@@ -235,6 +249,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatureQCs : SequenceSegmentProcessor
@@ -253,6 +270,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadFeatureRSDFilters : SequenceSegmentProcessor, IFilePickerHandler
@@ -279,6 +299,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadFeatureRSDQCs : SequenceSegmentProcessor, IFilePickerHandler
@@ -305,6 +328,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatureRSDFilters : SequenceSegmentProcessor
@@ -323,6 +349,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatureRSDQCs : SequenceSegmentProcessor
@@ -341,6 +370,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadFeatureBackgroundFilters : SequenceSegmentProcessor, IFilePickerHandler
@@ -367,6 +399,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadFeatureBackgroundQCs : SequenceSegmentProcessor, IFilePickerHandler
@@ -393,6 +428,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatureBackgroundFilters : SequenceSegmentProcessor
@@ -411,6 +449,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatureBackgroundQCs : SequenceSegmentProcessor
@@ -429,6 +470,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct EstimateFeatureFilterValues : SequenceSegmentProcessor
@@ -568,6 +612,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatureRSDEstimations : SequenceSegmentProcessor
@@ -586,6 +633,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct LoadFeatureBackgroundEstimations : SequenceSegmentProcessor
@@ -604,6 +654,9 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 
   struct StoreFeatureBackgroundEstimations : SequenceSegmentProcessor
@@ -622,5 +675,8 @@ namespace SmartPeak
       const ParameterSet& params_I,
       const Filenames& filenames
     ) const override;
+
+    /* IInputsOutputsProvider */
+    virtual void getInputsOutputs(Filenames& filenames) const override;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
@@ -110,7 +110,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_STANDARDS_CONCENTRATIONS"; }
@@ -137,7 +137,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return 17; }
     std::string getName() const override { return "LOAD_QUANTITATION_METHODS"; }
@@ -189,7 +189,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_FEATURE_FILTERS"; }
@@ -218,7 +218,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_FEATURE_QCS"; }
@@ -289,7 +289,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_FEATURE_RSD_FILTERS"; }
@@ -318,7 +318,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_FEATURE_RSD_QCS"; }
@@ -389,7 +389,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_FEATURE_BACKGROUND_FILTERS"; }
@@ -418,7 +418,7 @@ namespace SmartPeak
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
 
     int getID() const override { return -1; }
     std::string getName() const override { return "LOAD_FEATURE_BACKGROUND_QCS"; }

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessor.h
@@ -54,7 +54,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const = 0;
 
     /**
@@ -101,7 +101,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -125,7 +125,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -152,7 +152,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -174,7 +174,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -203,7 +203,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -229,7 +229,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -247,7 +247,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -268,7 +268,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -297,7 +297,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -326,7 +326,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -347,7 +347,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -368,7 +368,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -397,7 +397,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -426,7 +426,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -447,7 +447,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -468,7 +468,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -492,7 +492,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -513,7 +513,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -532,7 +532,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -551,7 +551,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -572,7 +572,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -591,7 +591,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
   };
 
@@ -610,7 +610,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -631,7 +631,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -652,7 +652,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */
@@ -673,7 +673,7 @@ namespace SmartPeak
       SequenceSegmentHandler& sequenceSegmentHandler_IO,
       const SequenceHandler& sequenceHandler_I,
       const ParameterSet& params_I,
-      const Filenames& filenames
+      const Filenames& filenames_override
     ) const override;
 
     /* IInputsOutputsProvider */

--- a/src/smartpeak/include/SmartPeak/iface/IFilePickerHandler.h
+++ b/src/smartpeak/include/SmartPeak/iface/IFilePickerHandler.h
@@ -29,6 +29,6 @@ namespace SmartPeak
 
   struct IFilePickerHandler
   {
-    virtual bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) = 0;
+    virtual bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) = 0;
   };
 }

--- a/src/smartpeak/include/SmartPeak/iface/IFilenamesHandler.h
+++ b/src/smartpeak/include/SmartPeak/iface/IFilenamesHandler.h
@@ -27,17 +27,17 @@
 
 namespace SmartPeak 
 {
-  struct IInputsOutputsProvider
+  struct IFilenamesHandler
   {
     /**
      @brief add files handled by the processor to the Filnames instance
     */
-    virtual void getInputsOutputs(Filenames& filenames) const = 0;
+    virtual void getFilenames(Filenames& filenames) const = 0;
 
-    virtual Filenames prepareFileNames(const Filenames& filenames_I) const
+    virtual Filenames prepareFilenames(const Filenames& filenames_I) const
     {
       Filenames prepared_filenames(filenames_I);
-      getInputsOutputs(prepared_filenames);
+      getFilenames(prepared_filenames);
       return prepared_filenames;
     }
   };

--- a/src/smartpeak/include/SmartPeak/iface/IInputsOutputsProvider.h
+++ b/src/smartpeak/include/SmartPeak/iface/IInputsOutputsProvider.h
@@ -30,9 +30,7 @@ namespace SmartPeak
   struct IInputsOutputsProvider
   {
     /**
-      TODO
-      id
-      name
+     @brief add files handled by the processor to the Filnames instance
     */
     virtual void getInputsOutputs(Filenames& filenames) const = 0;
 

--- a/src/smartpeak/include/SmartPeak/iface/IInputsOutputsProvider.h
+++ b/src/smartpeak/include/SmartPeak/iface/IInputsOutputsProvider.h
@@ -36,9 +36,9 @@ namespace SmartPeak
     */
     virtual void getInputsOutputs(Filenames& filenames) const = 0;
 
-    virtual Filenames prepareFileNames(const Filenames& filenames_override) const
+    virtual Filenames prepareFileNames(const Filenames& filenames_I) const
     {
-      Filenames prepared_filenames(filenames_override);
+      Filenames prepared_filenames(filenames_I);
       getInputsOutputs(prepared_filenames);
       return prepared_filenames;
     }

--- a/src/smartpeak/include/SmartPeak/iface/IInputsOutputsProvider.h
+++ b/src/smartpeak/include/SmartPeak/iface/IInputsOutputsProvider.h
@@ -35,5 +35,12 @@ namespace SmartPeak
       name
     */
     virtual void getInputsOutputs(Filenames& filenames) const = 0;
+
+    virtual Filenames prepareFileNames(const Filenames& filenames_override) const
+    {
+      Filenames prepared_filenames(filenames_override);
+      getInputsOutputs(prepared_filenames);
+      return prepared_filenames;
+    }
   };
 }

--- a/src/smartpeak/include/SmartPeak/iface/IInputsOutputsProvider.h
+++ b/src/smartpeak/include/SmartPeak/iface/IInputsOutputsProvider.h
@@ -1,0 +1,39 @@
+// --------------------------------------------------------------------------
+//   SmartPeak -- Fast and Accurate CE-, GC- and LC-MS(/MS) Data Processing
+// --------------------------------------------------------------------------
+// Copyright The SmartPeak Team -- Novo Nordisk Foundation 
+// Center for Biosustainability, Technical University of Denmark 2018-2021.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Douglas McCloskey, Bertrand Boudaud $
+// $Authors: Douglas McCloskey, Bertrand Boudaud $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <SmartPeak/core/Filenames.h>
+
+namespace SmartPeak 
+{
+  struct IInputsOutputsProvider
+  {
+    /**
+      TODO
+      id
+      name
+    */
+    virtual void getInputsOutputs(Filenames& filenames) const = 0;
+  };
+}

--- a/src/smartpeak/include/SmartPeak/iface/sources.cmake
+++ b/src/smartpeak/include/SmartPeak/iface/sources.cmake
@@ -4,8 +4,8 @@ set(directory include/SmartPeak/iface)
 ### list all header files of the directory here
 set(sources_list_h
   IApplicationProcessorObserver.h
+  IFilenamesHandler.h
   IFilePickerHandler.h
-  IInputsOutputsProvider.h
   IParametersObserver.h
   IProcessorDescription.h
   ISampleGroupProcessorObserver.h

--- a/src/smartpeak/include/SmartPeak/iface/sources.cmake
+++ b/src/smartpeak/include/SmartPeak/iface/sources.cmake
@@ -5,6 +5,7 @@ set(directory include/SmartPeak/iface)
 set(sources_list_h
   IApplicationProcessorObserver.h
   IFilePickerHandler.h
+  IInputsOutputsProvider.h
   IParametersObserver.h
   IProcessorDescription.h
   ISampleGroupProcessorObserver.h

--- a/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
+++ b/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
@@ -48,13 +48,26 @@ public:
       const Filenames& filenames_I,
       bool required);
 
-    static bool prepareToLoad(const Filenames filenames, const std::string& id);
+    static bool prepareToLoad(
+      const Filenames filenames, const std::string& id
+    );
 
-    static bool prepareToLoadOneOfTwo(const Filenames filenames, const std::string& id1, const std::string& id2);
+    static bool prepareToLoadOneOfTwo(
+      const Filenames filenames,
+      const std::string& id1,
+      const std::string& id2
+    );
 
-    static bool prepareToStore(const Filenames filenames, const std::string& id);
+    static bool prepareToStore(
+      const Filenames filenames,
+      const std::string& id
+    );
 
-    static bool prepareToStoreOneOfTwo(const Filenames filenames, const std::string& id1, const std::string& id2);
+    static bool prepareToStoreOneOfTwo(
+      const Filenames filenames,
+      const std::string& id1,
+      const std::string& id2
+    );
 
     static std::string getSequenceInfo(
       const SequenceHandler& sequenceHandler

--- a/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
+++ b/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
@@ -41,12 +41,12 @@ public:
 
     struct FilenameInfo {
       enum ValidityEnum {invalid, valid, not_provided} validity;
-      std::string pathname;
+      std::filesystem::path pathname;
       std::string member_name;
     };
 
-    static bool fileExists(const std::string& filepath);
-    static FilenameInfo isValidFilename(const std::string& filename, const std::string& member_name, bool required);
+    static bool fileExists(const std::filesystem::path& filepath);
+    static FilenameInfo isValidFilename(const std::filesystem::path& filename, const std::string& member_name, bool required);
 
     static std::string getSequenceInfo(
       const SequenceHandler& sequenceHandler

--- a/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
+++ b/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
@@ -46,7 +46,7 @@ public:
     };
 
     static bool fileExists(const std::string& filepath);
-    static FilenameInfo isValidFilename(const std::string& filename, const std::string& member_name);
+    static FilenameInfo isValidFilename(const std::string& filename, const std::string& member_name, bool required);
 
     static std::string getSequenceInfo(
       const SequenceHandler& sequenceHandler

--- a/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
+++ b/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
@@ -54,6 +54,14 @@ public:
       const Filenames& filenames_I,
       bool required);
 
+    static bool prepareToLoad(const Filenames filenames, const std::string& id);
+
+    static bool prepareToLoadOneOfTwo(const Filenames filenames, const std::string& id1, const std::string& id2);
+
+    static bool prepareToStore(const Filenames filenames, const std::string& id);
+
+    static bool prepareToStoreOneOfTwo(const Filenames filenames, const std::string& id1, const std::string& id2);
+
     static std::string getSequenceInfo(
       const SequenceHandler& sequenceHandler
     );

--- a/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
+++ b/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
@@ -40,17 +40,11 @@ public:
     InputDataValidation(InputDataValidation&&)                 = delete;
     InputDataValidation& operator=(InputDataValidation&&)      = delete;
 
-    struct FilenameInfo {
-      enum ValidityEnum {invalid, valid, not_provided} validity;
-//      std::filesystem::path pathname;
-      std::string member_name;
-    };
-
     static bool fileExists(const std::filesystem::path& filepath);
 
-    static FilenameInfo processorInputAreReady(
+    static bool precheckProcessorInputs(
       const IInputsOutputsProvider& input_files,
-      const std::string& member_name,
+      const std::string& processor_name,
       const Filenames& filenames_I,
       bool required);
 

--- a/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
+++ b/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
@@ -25,6 +25,7 @@
 
 #include <SmartPeak/core/Filenames.h>
 #include <SmartPeak/core/SequenceHandler.h>
+#include <SmartPeak/iface/IInputsOutputsProvider.h>
 #include <string>
 
 namespace SmartPeak
@@ -41,12 +42,17 @@ public:
 
     struct FilenameInfo {
       enum ValidityEnum {invalid, valid, not_provided} validity;
-      std::filesystem::path pathname;
+//      std::filesystem::path pathname;
       std::string member_name;
     };
 
     static bool fileExists(const std::filesystem::path& filepath);
-    static FilenameInfo isValidFilename(const std::filesystem::path& filename, const std::string& member_name, bool required);
+
+    static FilenameInfo processorInputAreReady(
+      const IInputsOutputsProvider& input_files,
+      const std::string& member_name,
+      const Filenames& filenames_I,
+      bool required);
 
     static std::string getSequenceInfo(
       const SequenceHandler& sequenceHandler

--- a/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
+++ b/src/smartpeak/include/SmartPeak/io/InputDataValidation.h
@@ -25,7 +25,7 @@
 
 #include <SmartPeak/core/Filenames.h>
 #include <SmartPeak/core/SequenceHandler.h>
-#include <SmartPeak/iface/IInputsOutputsProvider.h>
+#include <SmartPeak/iface/IFilenamesHandler.h>
 #include <string>
 
 namespace SmartPeak
@@ -43,28 +43,29 @@ public:
     static bool fileExists(const std::filesystem::path& filepath);
 
     static bool precheckProcessorInputs(
-      const IInputsOutputsProvider& input_files,
+      const IFilenamesHandler& input_files,
       const std::string& processor_name,
       const Filenames& filenames_I,
       bool required);
 
     static bool prepareToLoad(
-      const Filenames filenames, const std::string& id
+      const Filenames& filenames,
+      const std::string& id
     );
 
     static bool prepareToLoadOneOfTwo(
-      const Filenames filenames,
+      const Filenames& filenames,
       const std::string& id1,
       const std::string& id2
     );
 
     static bool prepareToStore(
-      const Filenames filenames,
+      const Filenames& filenames,
       const std::string& id
     );
 
     static bool prepareToStoreOneOfTwo(
-      const Filenames filenames,
+      const Filenames& filenames,
       const std::string& id1,
       const std::string& id2
     );

--- a/src/smartpeak/include/SmartPeak/io/SequenceParser.h
+++ b/src/smartpeak/include/SmartPeak/io/SequenceParser.h
@@ -154,7 +154,7 @@ public:
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
   };
 
   struct StoreSequenceFileAnalyst : IFilePickerHandler {
@@ -162,7 +162,7 @@ public:
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
   };
 
   struct StoreSequenceFileMasshunter : IFilePickerHandler {
@@ -170,7 +170,7 @@ public:
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
   };
 
   struct StoreSequenceFileXcalibur : IFilePickerHandler {
@@ -178,6 +178,6 @@ public:
     /**
     IFilePickerHandler
     */
-    bool onFilePicked(const std::string& filename, ApplicationHandler* application_handler) override;
+    bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
   };
 }

--- a/src/smartpeak/include/SmartPeak/io/SequenceParser.h
+++ b/src/smartpeak/include/SmartPeak/io/SequenceParser.h
@@ -48,7 +48,7 @@ public:
 
     static void readSequenceFile(
       SequenceHandler& sequenceHandler,
-      const std::string& pathname,
+      const std::filesystem::path& pathname,
       const std::string& delimiter
     );
 
@@ -60,7 +60,7 @@ public:
 
     static void writeSequenceFileSmartPeak(
       SequenceHandler& sequenceHandler,
-      const std::string& filename,
+      const std::filesystem::path& filename,
       const std::string& delimiter = ","
     );
 
@@ -72,7 +72,7 @@ public:
 
     static void writeSequenceFileAnalyst(
       SequenceHandler& sequenceHandler,
-      const std::string& filename,
+      const std::filesystem::path& filename,
       const std::string& delimiter = "\t"
     );
 
@@ -84,7 +84,7 @@ public:
 
     static void writeSequenceFileMasshunter(
       SequenceHandler& sequenceHandler,
-      const std::string& filename,
+      const std::filesystem::path& filename,
       const std::string& delimiter = "\t"
     );
 
@@ -96,7 +96,7 @@ public:
 
     static void writeSequenceFileXcalibur(
       SequenceHandler& sequenceHandler,
-      const std::string& filename,
+      const std::filesystem::path& filename,
       const std::string& delimiter = "\t"
     );
 
@@ -119,7 +119,7 @@ public:
 
     static bool writeDataTableFromMetaValue(
       const SequenceHandler& sequenceHandler,
-      const std::string& filename,
+      const std::filesystem::path& filename,
       const std::vector<FeatureMetadata>& meta_data,
       const std::set<SampleType>& sample_types
     );
@@ -139,14 +139,14 @@ public:
     // NOTE: Internally, to_string() rounds at 1e-6. Therefore, some precision might be lost.
     static bool writeDataMatrixFromMetaValue(
       const SequenceHandler& sequenceHandler,
-      const std::string& filename,
+      const std::filesystem::path& filename,
       const std::vector<FeatureMetadata>& meta_data,
       const std::set<SampleType>& sample_types
     );
 
     private:
       template<typename delimiter>
-      static void readSequenceFile(SequenceHandler& sequenceHandler, const std::string& pathname);
+      static void readSequenceFile(SequenceHandler& sequenceHandler, const std::filesystem::path& pathname);
   };
 
   struct StoreSequenceFileSmartPeak : IFilePickerHandler

--- a/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
@@ -28,14 +28,14 @@ using namespace SmartPeak;
 
 void example_FIAMS_FullScan_Unknowns(
   const std::string& dir_I,
-  const Filenames& filenames,
+  const Filenames& filenames_I,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_        = filenames;
+  cs.filenames_        = filenames_I;
   cs.delimiter        = delimiter_I;
   cs.checkConsistency = true;
   cs.process();

--- a/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
@@ -28,14 +28,14 @@ using namespace SmartPeak;
 
 void example_FIAMS_FullScan_Unknowns(
   const std::string& dir_I,
-  const Filenames& static_filenames,
+  const Filenames& filenames,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_        = static_filenames;
+  cs.filenames_        = filenames;
   cs.delimiter        = delimiter_I;
   cs.checkConsistency = true;
   cs.process();

--- a/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
@@ -50,10 +50,16 @@ void example_FIAMS_FullScan_Unknowns(
     std::make_shared<StoreFeatures>()
   };
 
+  Filenames methods_filenames;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames);
+  }
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    Filenames injection_filenames = methods_filenames;
+    injection_filenames.setPathsAndNames(
       dir_I,
       dir_I + "/mzML/",
       dir_I + "/features/",
@@ -64,6 +70,7 @@ void example_FIAMS_FullScan_Unknowns(
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
+     dynamic_filenames[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
@@ -51,21 +51,20 @@ void example_FIAMS_FullScan_Unknowns(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setRootPaths(dir_I,
-    dir_I + "/mzML/",
-    dir_I + "/features/",
-    dir_I + "/features/");
+  methods_filenames.setTag("MAIN_DIR", dir_I);
+  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
+  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
+
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setFileVariants(
-      injection.getMetaData().getFilename(),
-      key,
-      key,
-      injection.getMetaData().getSampleGroupName(),
-      injection.getMetaData().getSampleGroupName()
-    );
+    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
@@ -51,6 +51,10 @@ void example_FIAMS_FullScan_Unknowns(
   };
 
   Filenames methods_filenames;
+  methods_filenames.setRootPaths(dir_I,
+    dir_I + "/mzML/",
+    dir_I + "/features/",
+    dir_I + "/features/");
   for (const auto& m : raw_data_processing_methods)
   {
     m->getInputsOutputs(methods_filenames);
@@ -59,11 +63,7 @@ void example_FIAMS_FullScan_Unknowns(
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     Filenames injection_filenames = methods_filenames;
-    injection_filenames.setPathsAndNames(
-      dir_I,
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    injection_filenames.setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,

--- a/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
@@ -51,20 +51,20 @@ void example_FIAMS_FullScan_Unknowns(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setTag("MAIN_DIR", dir_I);
-  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
-  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
-  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::MAIN_DIR, dir_I);
+  methods_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, dir_I + "/mzML/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, dir_I + "/features/");
 
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/FIAMS_FullScan_Unknown_example.h
@@ -55,22 +55,17 @@ void example_FIAMS_FullScan_Unknowns(
     dir_I + "/mzML/",
     dir_I + "/features/",
     dir_I + "/features/");
-  for (const auto& m : raw_data_processing_methods)
-  {
-    m->getInputsOutputs(methods_filenames);
-  }
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    Filenames injection_filenames = methods_filenames;
-    injection_filenames.setFileVariants(
+    dynamic_filenames[key] = methods_filenames;
+    dynamic_filenames[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
-     dynamic_filenames[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
@@ -81,14 +81,14 @@ void example_GCMS_SIM_Unknowns(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    filenames.getFullPathName("pivotTable_csv_o"),
+    filenames.getFullPath("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Unknown}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    filenames.getFullPathName("featureDB_csv_o"),
+    filenames.getFullPath("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
@@ -56,10 +56,16 @@ void example_GCMS_SIM_Unknowns(
     std::make_shared<StoreFeatures>()
   };
 
+  Filenames methods_filenames;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames);
+  }
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    Filenames injection_filenames = methods_filenames;
+    injection_filenames.setPathsAndNames(
       dir_I,
       dir_I + "/mzML/",
       dir_I + "/features/",
@@ -70,6 +76,7 @@ void example_GCMS_SIM_Unknowns(
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
+    dynamic_filenames[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -79,14 +86,14 @@ void example_GCMS_SIM_Unknowns(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.pivotTable_csv_o,
+    static_filenames.getFullPathName("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Unknown}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.featureDB_csv_o,
+    static_filenames.getFullPathName("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
@@ -57,19 +57,19 @@ void example_GCMS_SIM_Unknowns(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setTag("MAIN_DIR", dir_I);
-  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
-  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
-  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::MAIN_DIR, dir_I);
+  methods_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, dir_I + "/mzML/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
@@ -61,22 +61,17 @@ void example_GCMS_SIM_Unknowns(
     dir_I + "/mzML/",
     dir_I + "/features/",
     dir_I + "/features/");
-  for (const auto& m : raw_data_processing_methods)
-  {
-    m->getInputsOutputs(methods_filenames);
-  }
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    Filenames injection_filenames = methods_filenames;
-    injection_filenames.setFileVariants(
+    dynamic_filenames[key] = methods_filenames;
+    dynamic_filenames[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
-    dynamic_filenames[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_GCMS_SIM_Unknowns(
   const std::string& dir_I,
-  const Filenames& static_filenames,
+  const Filenames& filenames,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_          = static_filenames;
+  cs.filenames_          = filenames;
   cs.delimiter          = delimiter_I;
   cs.checkConsistency   = true;
   cs.process();
@@ -81,14 +81,14 @@ void example_GCMS_SIM_Unknowns(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.getFullPathName("pivotTable_csv_o"),
+    filenames.getFullPathName("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Unknown}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.getFullPathName("featureDB_csv_o"),
+    filenames.getFullPathName("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
@@ -57,6 +57,10 @@ void example_GCMS_SIM_Unknowns(
   };
 
   Filenames methods_filenames;
+  methods_filenames.setRootPaths(dir_I,
+    dir_I + "/mzML/",
+    dir_I + "/features/",
+    dir_I + "/features/");
   for (const auto& m : raw_data_processing_methods)
   {
     m->getInputsOutputs(methods_filenames);
@@ -65,11 +69,7 @@ void example_GCMS_SIM_Unknowns(
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     Filenames injection_filenames = methods_filenames;
-    injection_filenames.setPathsAndNames(
-      dir_I,
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    injection_filenames.setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,

--- a/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
@@ -57,21 +57,19 @@ void example_GCMS_SIM_Unknowns(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setRootPaths(dir_I,
-    dir_I + "/mzML/",
-    dir_I + "/features/",
-    dir_I + "/features/");
+  methods_filenames.setTag("MAIN_DIR", dir_I);
+  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
+  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setFileVariants(
-      injection.getMetaData().getFilename(),
-      key,
-      key,
-      injection.getMetaData().getSampleGroupName(),
-      injection.getMetaData().getSampleGroupName()
-    );
+    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/GCMS_SIM_Unknown_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_GCMS_SIM_Unknowns(
   const std::string& dir_I,
-  const Filenames& filenames,
+  const Filenames& filenames_I,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_          = filenames;
+  cs.filenames_          = filenames_I;
   cs.delimiter          = delimiter_I;
   cs.checkConsistency   = true;
   cs.process();
@@ -78,6 +78,10 @@ void example_GCMS_SIM_Unknowns(
   ps.filenames_                     = dynamic_filenames;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;
   ps.process();
+
+  Filenames filenames = filenames_I;
+  filenames.setFullPath("pivotTable_csv_o", dir_I + "/PivotTable.csv");
+  filenames.setFullPath("featureDB_csv_o", dir_I + "/FeatureDB.csv");
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_HPLC_UV_Standards(
   const std::string& dir_I,
-  const Filenames& static_filenames,
+  const Filenames& filenames,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_        = static_filenames;
+  cs.filenames_        = filenames;
   cs.delimiter        = delimiter_I;
   cs.checkConsistency = true;
   cs.process();
@@ -126,14 +126,14 @@ void example_HPLC_UV_Standards(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.getFullPathName("pivotTable_csv_o"),
+    filenames.getFullPathName("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Standard}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.getFullPathName("featureDB_csv_o"),
+    filenames.getFullPathName("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
@@ -56,6 +56,10 @@ void example_HPLC_UV_Standards(
   };
 
   Filenames methods_filenames1;
+  methods_filenames1.setRootPaths(dir_I,
+    dir_I + "/mzML/",
+    dir_I + "/features/",
+    dir_I + "/features/");
   for (const auto& m : raw_data_processing_methods)
   {
     m->getInputsOutputs(methods_filenames1);
@@ -64,11 +68,7 @@ void example_HPLC_UV_Standards(
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     Filenames injection_filenames = methods_filenames1;
-    injection_filenames.setPathsAndNames(
-      dir_I,
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    injection_filenames.setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
@@ -56,19 +56,19 @@ void example_HPLC_UV_Standards(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setTag("MAIN_DIR", dir_I);
-  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
-  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
-  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::MAIN_DIR, dir_I);
+  methods_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, dir_I + "/mzML/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames1;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames1[key] = methods_filenames;
-    dynamic_filenames1[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames1[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames1[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames1[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames1[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames1[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames1[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames1[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames1[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames1[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -85,8 +85,8 @@ void example_HPLC_UV_Standards(
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string& key = sequence_segment.getSequenceSegmentName();
     dynamic_filenames2[key] = methods_filenames;
-    dynamic_filenames2[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames2[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames2[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames2[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
   }
 
   ProcessSequenceSegments pss(sequenceHandler);
@@ -104,11 +104,11 @@ void example_HPLC_UV_Standards(
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames3[key] = methods_filenames;
-    dynamic_filenames3[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames3[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames3[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames3[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames3[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames3[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames3[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames3[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames3[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames3[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   ps.filenames_                     = dynamic_filenames3;

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
@@ -126,14 +126,14 @@ void example_HPLC_UV_Standards(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    filenames.getFullPathName("pivotTable_csv_o"),
+    filenames.getFullPath("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Standard}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    filenames.getFullPathName("featureDB_csv_o"),
+    filenames.getFullPath("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_HPLC_UV_Standards(
   const std::string& dir_I,
-  const Filenames& filenames,
+  const Filenames& filenames_I,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_        = filenames;
+  cs.filenames_        = filenames_I;
   cs.delimiter        = delimiter_I;
   cs.checkConsistency = true;
   cs.process();
@@ -123,6 +123,10 @@ void example_HPLC_UV_Standards(
   ps.filenames_                     = dynamic_filenames3;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;
   ps.process();
+
+  Filenames filenames = filenames_I;
+  filenames.setFullPath("pivotTable_csv_o", dir_I + "/PivotTable.csv");
+  filenames.setFullPath("featureDB_csv_o", dir_I + "/FeatureDB.csv");
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
@@ -60,22 +60,17 @@ void example_HPLC_UV_Standards(
     dir_I + "/mzML/",
     dir_I + "/features/",
     dir_I + "/features/");
-  for (const auto& m : raw_data_processing_methods)
-  {
-    m->getInputsOutputs(methods_filenames1);
-  }
   std::map<std::string, Filenames> dynamic_filenames1;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    Filenames injection_filenames = methods_filenames1;
-    injection_filenames.setFileVariants(
+    dynamic_filenames1[key] = methods_filenames1;
+    dynamic_filenames1[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
-    dynamic_filenames1[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
@@ -55,15 +55,15 @@ void example_HPLC_UV_Standards(
     std::make_shared<StoreFeatures>()
   };
 
-  Filenames methods_filenames1;
-  methods_filenames1.setRootPaths(dir_I,
+  Filenames methods_filenames;
+  methods_filenames.setRootPaths(dir_I,
     dir_I + "/mzML/",
     dir_I + "/features/",
     dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames1;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames1[key] = methods_filenames1;
+    dynamic_filenames1[key] = methods_filenames;
     dynamic_filenames1[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
@@ -84,21 +84,17 @@ void example_HPLC_UV_Standards(
   };
 
   std::map<std::string, Filenames> dynamic_filenames2;
-  /*
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string& key = sequence_segment.getSequenceSegmentName();
-    dynamic_filenames2[key] = Filenames::getDefaultDynamicFilenames(
-      dir_I,
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    dynamic_filenames2[key] = methods_filenames;
+    dynamic_filenames2[key].setFileVariants(
       "",
       key,
       key,
-      "",""
+      "",
+      ""
     );
   }
-  */
 
   ProcessSequenceSegments pss(sequenceHandler);
   pss.filenames_                             = dynamic_filenames2;
@@ -112,14 +108,10 @@ void example_HPLC_UV_Standards(
   };
 
   std::map<std::string, Filenames> dynamic_filenames3;
-  /*
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames3[key] = Filenames::getDefaultDynamicFilenames(
-      dir_I,
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    dynamic_filenames3[key] = methods_filenames;
+    dynamic_filenames3[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
@@ -127,7 +119,6 @@ void example_HPLC_UV_Standards(
       injection.getMetaData().getSampleGroupName()
     );
   }
-  */
 
   ps.filenames_                     = dynamic_filenames3;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
@@ -55,10 +55,16 @@ void example_HPLC_UV_Standards(
     std::make_shared<StoreFeatures>()
   };
 
+  Filenames methods_filenames1;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames1);
+  }
   std::map<std::string, Filenames> dynamic_filenames1;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames1[key] = Filenames::getDefaultDynamicFilenames(
+    Filenames injection_filenames = methods_filenames1;
+    injection_filenames.setPathsAndNames(
       dir_I,
       dir_I + "/mzML/",
       dir_I + "/features/",
@@ -69,6 +75,7 @@ void example_HPLC_UV_Standards(
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
+    dynamic_filenames1[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -82,6 +89,7 @@ void example_HPLC_UV_Standards(
   };
 
   std::map<std::string, Filenames> dynamic_filenames2;
+  /*
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string& key = sequence_segment.getSequenceSegmentName();
     dynamic_filenames2[key] = Filenames::getDefaultDynamicFilenames(
@@ -95,6 +103,7 @@ void example_HPLC_UV_Standards(
       "",""
     );
   }
+  */
 
   ProcessSequenceSegments pss(sequenceHandler);
   pss.filenames_                             = dynamic_filenames2;
@@ -108,6 +117,7 @@ void example_HPLC_UV_Standards(
   };
 
   std::map<std::string, Filenames> dynamic_filenames3;
+  /*
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames3[key] = Filenames::getDefaultDynamicFilenames(
@@ -122,6 +132,7 @@ void example_HPLC_UV_Standards(
       injection.getMetaData().getSampleGroupName()
     );
   }
+  */
 
   ps.filenames_                     = dynamic_filenames3;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;
@@ -129,14 +140,14 @@ void example_HPLC_UV_Standards(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.pivotTable_csv_o,
+    static_filenames.getFullPathName("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Standard}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.featureDB_csv_o,
+    static_filenames.getFullPathName("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Standards_example.h
@@ -56,21 +56,19 @@ void example_HPLC_UV_Standards(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setRootPaths(dir_I,
-    dir_I + "/mzML/",
-    dir_I + "/features/",
-    dir_I + "/features/");
+  methods_filenames.setTag("MAIN_DIR", dir_I);
+  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
+  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames1;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames1[key] = methods_filenames;
-    dynamic_filenames1[key].setFileVariants(
-      injection.getMetaData().getFilename(),
-      key,
-      key,
-      injection.getMetaData().getSampleGroupName(),
-      injection.getMetaData().getSampleGroupName()
-    );
+    dynamic_filenames1[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames1[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames1[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames1[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames1[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -87,13 +85,8 @@ void example_HPLC_UV_Standards(
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string& key = sequence_segment.getSequenceSegmentName();
     dynamic_filenames2[key] = methods_filenames;
-    dynamic_filenames2[key].setFileVariants(
-      "",
-      key,
-      key,
-      "",
-      ""
-    );
+    dynamic_filenames2[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames2[key].setTag("OUTPUT_INJECTION_NAME", key);
   }
 
   ProcessSequenceSegments pss(sequenceHandler);
@@ -111,13 +104,11 @@ void example_HPLC_UV_Standards(
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames3[key] = methods_filenames;
-    dynamic_filenames3[key].setFileVariants(
-      injection.getMetaData().getFilename(),
-      key,
-      key,
-      injection.getMetaData().getSampleGroupName(),
-      injection.getMetaData().getSampleGroupName()
-    );
+    dynamic_filenames3[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames3[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames3[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames3[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames3[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   ps.filenames_                     = dynamic_filenames3;

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_HPLC_UV_Unknowns(
   const std::string& dir_I,
-  const Filenames& filenames,
+  const Filenames& filenames_I,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_        = filenames;
+  cs.filenames_        = filenames_I;
   cs.delimiter        = delimiter_I;
   cs.checkConsistency = true;
   cs.process();
@@ -79,6 +79,10 @@ void example_HPLC_UV_Unknowns(
   ps.filenames_                     = dynamic_filenames;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;
   ps.process();
+
+  Filenames filenames = filenames_I;
+  filenames.setFullPath("pivotTable_csv_o", dir_I + "/PivotTable.csv");
+  filenames.setFullPath("featureDB_csv_o", dir_I + "/FeatureDB.csv");
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_HPLC_UV_Unknowns(
   const std::string& dir_I,
-  const Filenames& static_filenames,
+  const Filenames& filenames,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_        = static_filenames;
+  cs.filenames_        = filenames;
   cs.delimiter        = delimiter_I;
   cs.checkConsistency = true;
   cs.process();
@@ -82,14 +82,14 @@ void example_HPLC_UV_Unknowns(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.getFullPathName("pivotTable_csv_o"),
+    filenames.getFullPathName("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Unknown}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.getFullPathName("featureDB_csv_o"),
+    filenames.getFullPathName("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
@@ -58,21 +58,19 @@ void example_HPLC_UV_Unknowns(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setRootPaths(dir_I,
-    dir_I + "/mzML/",
-    dir_I + "/features/",
-    dir_I + "/features/");
+  methods_filenames.setTag("MAIN_DIR", dir_I);
+  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
+  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setFileVariants(
-      injection.getMetaData().getFilename(),
-      key,
-      key,
-      injection.getMetaData().getSampleGroupName(),
-      injection.getMetaData().getSampleGroupName()
-    );
+    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
@@ -82,14 +82,14 @@ void example_HPLC_UV_Unknowns(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    filenames.getFullPathName("pivotTable_csv_o"),
+    filenames.getFullPath("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Unknown}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    filenames.getFullPathName("featureDB_csv_o"),
+    filenames.getFullPath("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
@@ -57,10 +57,16 @@ void example_HPLC_UV_Unknowns(
     std::make_shared<StoreFeatures>()
   };
 
+  Filenames methods_filenames;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames);
+  }
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    Filenames injection_filenames = methods_filenames;
+    injection_filenames.setPathsAndNames(
       dir_I,
       dir_I + "/mzML/",
       dir_I + "/features/",
@@ -71,6 +77,7 @@ void example_HPLC_UV_Unknowns(
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
+    dynamic_filenames[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -80,14 +87,14 @@ void example_HPLC_UV_Unknowns(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.pivotTable_csv_o,
+    static_filenames.getFullPathName("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Unknown}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.featureDB_csv_o,
+    static_filenames.getFullPathName("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
@@ -58,19 +58,19 @@ void example_HPLC_UV_Unknowns(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setTag("MAIN_DIR", dir_I);
-  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
-  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
-  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::MAIN_DIR, dir_I);
+  methods_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, dir_I + "/mzML/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
@@ -62,22 +62,17 @@ void example_HPLC_UV_Unknowns(
     dir_I + "/mzML/",
     dir_I + "/features/",
     dir_I + "/features/");
-  for (const auto& m : raw_data_processing_methods)
-  {
-    m->getInputsOutputs(methods_filenames);
-  }
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    Filenames injection_filenames = methods_filenames;
-    injection_filenames.setFileVariants(
+    dynamic_filenames[key] = methods_filenames;
+    dynamic_filenames[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
-    dynamic_filenames[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/HPLC_UV_Unknown_example.h
@@ -58,6 +58,10 @@ void example_HPLC_UV_Unknowns(
   };
 
   Filenames methods_filenames;
+  methods_filenames.setRootPaths(dir_I,
+    dir_I + "/mzML/",
+    dir_I + "/features/",
+    dir_I + "/features/");
   for (const auto& m : raw_data_processing_methods)
   {
     m->getInputsOutputs(methods_filenames);
@@ -66,11 +70,7 @@ void example_HPLC_UV_Unknowns(
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     Filenames injection_filenames = methods_filenames;
-    injection_filenames.setPathsAndNames(
-      dir_I,
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    injection_filenames.setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
@@ -55,19 +55,19 @@ void example_LCMS_MRM_Standards(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setTag("MAIN_DIR", dir_I);
-  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
-  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
-  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::MAIN_DIR, dir_I);
+  methods_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, dir_I + "/mzML/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames1;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames1[key] = methods_filenames;
-    dynamic_filenames1[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames1[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames1[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames1[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames1[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames1[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames1[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames1[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames1[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames1[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -84,8 +84,8 @@ void example_LCMS_MRM_Standards(
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string& key = sequence_segment.getSequenceSegmentName();
     dynamic_filenames2[key] = methods_filenames;
-    dynamic_filenames2[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames2[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames2[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames2[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
   }
 
   ProcessSequenceSegments pss(sequenceHandler);
@@ -103,11 +103,11 @@ void example_LCMS_MRM_Standards(
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames3[key] = methods_filenames;
-    dynamic_filenames3[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames3[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames3[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames3[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames3[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames3[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames3[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames3[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames3[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames3[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   ps.filenames_                     = dynamic_filenames3;

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
@@ -55,21 +55,19 @@ void example_LCMS_MRM_Standards(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setRootPaths(dir_I,
-    dir_I + "/mzML/",
-    dir_I + "/features/",
-    dir_I + "/features/");
+  methods_filenames.setTag("MAIN_DIR", dir_I);
+  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
+  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames1;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames1[key] = methods_filenames;
-    dynamic_filenames1[key].setFileVariants(
-      injection.getMetaData().getFilename(),
-      key,
-      key,
-      injection.getMetaData().getSampleGroupName(),
-      injection.getMetaData().getSampleGroupName()
-    );
+    dynamic_filenames1[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames1[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames1[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames1[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames1[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -86,13 +84,8 @@ void example_LCMS_MRM_Standards(
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string& key = sequence_segment.getSequenceSegmentName();
     dynamic_filenames2[key] = methods_filenames;
-    dynamic_filenames2[key].setFileVariants(
-      "",
-      key,
-      key,
-      "",
-      ""
-    );
+    dynamic_filenames2[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames2[key].setTag("OUTPUT_INJECTION_NAME", key);
   }
 
   ProcessSequenceSegments pss(sequenceHandler);
@@ -110,13 +103,11 @@ void example_LCMS_MRM_Standards(
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames3[key] = methods_filenames;
-    dynamic_filenames3[key].setFileVariants(
-      injection.getMetaData().getFilename(),
-      key,
-      key,
-      injection.getMetaData().getSampleGroupName(),
-      injection.getMetaData().getSampleGroupName()
-    );
+    dynamic_filenames3[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames3[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames3[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames3[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames3[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   ps.filenames_                     = dynamic_filenames3;

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
@@ -125,14 +125,14 @@ void example_LCMS_MRM_Standards(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    filenames.getFullPathName("pivotTable_csv_o"),
+    filenames.getFullPath("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Standard}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    filenames.getFullPathName("featureDB_csv_o"),
+    filenames.getFullPath("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
@@ -54,10 +54,16 @@ void example_LCMS_MRM_Standards(
     std::make_shared<StoreFeatures>()
   };
 
+  Filenames methods_filenames1;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames1);
+  }
   std::map<std::string, Filenames> dynamic_filenames1;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames1[key] = Filenames::getDefaultDynamicFilenames(
+    Filenames injection_filenames = methods_filenames1;
+    injection_filenames.setPathsAndNames(
       dir_I,
       dir_I + "/mzML/",
       dir_I + "/features/",
@@ -68,6 +74,7 @@ void example_LCMS_MRM_Standards(
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
+    dynamic_filenames1[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -81,6 +88,7 @@ void example_LCMS_MRM_Standards(
   };
 
   std::map<std::string, Filenames> dynamic_filenames2;
+  /*
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string& key = sequence_segment.getSequenceSegmentName();
     dynamic_filenames2[key] = Filenames::getDefaultDynamicFilenames(
@@ -94,6 +102,7 @@ void example_LCMS_MRM_Standards(
       "", ""
     );
   }
+  */
 
   ProcessSequenceSegments pss(sequenceHandler);
   pss.filenames_                             = dynamic_filenames2;
@@ -107,6 +116,7 @@ void example_LCMS_MRM_Standards(
   };
 
   std::map<std::string, Filenames> dynamic_filenames3;
+  /*
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames3[key] = Filenames::getDefaultDynamicFilenames(
@@ -121,6 +131,7 @@ void example_LCMS_MRM_Standards(
       injection.getMetaData().getSampleGroupName()
     );
   }
+  */
 
   ps.filenames_                     = dynamic_filenames3;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;
@@ -128,14 +139,14 @@ void example_LCMS_MRM_Standards(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.pivotTable_csv_o,
+    static_filenames.getFullPathName("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Standard}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.featureDB_csv_o,
+    static_filenames.getFullPathName("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_LCMS_MRM_Standards(
   const std::string& dir_I,
-  const Filenames& static_filenames,
+  const Filenames& filenames,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_          = static_filenames;
+  cs.filenames_          = filenames;
   cs.delimiter          = delimiter_I;
   cs.checkConsistency   = true;
   cs.process();
@@ -125,14 +125,14 @@ void example_LCMS_MRM_Standards(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.getFullPathName("pivotTable_csv_o"),
+    filenames.getFullPathName("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Standard}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.getFullPathName("featureDB_csv_o"),
+    filenames.getFullPathName("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_LCMS_MRM_Standards(
   const std::string& dir_I,
-  const Filenames& filenames,
+  const Filenames& filenames_I,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_          = filenames;
+  cs.filenames_          = filenames_I;
   cs.delimiter          = delimiter_I;
   cs.checkConsistency   = true;
   cs.process();
@@ -122,6 +122,10 @@ void example_LCMS_MRM_Standards(
   ps.filenames_                     = dynamic_filenames3;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;
   ps.process();
+
+  Filenames filenames = filenames_I;
+  filenames.setFullPath("pivotTable_csv_o", dir_I + "/PivotTable.csv");
+  filenames.setFullPath("featureDB_csv_o", dir_I + "/FeatureDB.csv");
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
@@ -54,15 +54,15 @@ void example_LCMS_MRM_Standards(
     std::make_shared<StoreFeatures>()
   };
 
-  Filenames methods_filenames1;
-  methods_filenames1.setRootPaths(dir_I,
+  Filenames methods_filenames;
+  methods_filenames.setRootPaths(dir_I,
     dir_I + "/mzML/",
     dir_I + "/features/",
     dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames1;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames1[key] = methods_filenames1;
+    dynamic_filenames1[key] = methods_filenames;
     dynamic_filenames1[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
@@ -83,21 +83,17 @@ void example_LCMS_MRM_Standards(
   };
 
   std::map<std::string, Filenames> dynamic_filenames2;
-  /*
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string& key = sequence_segment.getSequenceSegmentName();
-    dynamic_filenames2[key] = Filenames::getDefaultDynamicFilenames(
-      dir_I,
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    dynamic_filenames2[key] = methods_filenames;
+    dynamic_filenames2[key].setFileVariants(
       "",
       key,
       key,
-      "", ""
+      "",
+      ""
     );
   }
-  */
 
   ProcessSequenceSegments pss(sequenceHandler);
   pss.filenames_                             = dynamic_filenames2;
@@ -111,14 +107,10 @@ void example_LCMS_MRM_Standards(
   };
 
   std::map<std::string, Filenames> dynamic_filenames3;
-  /*
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames3[key] = Filenames::getDefaultDynamicFilenames(
-      dir_I,
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    dynamic_filenames3[key] = methods_filenames;
+    dynamic_filenames3[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
@@ -126,7 +118,6 @@ void example_LCMS_MRM_Standards(
       injection.getMetaData().getSampleGroupName()
     );
   }
-  */
 
   ps.filenames_                     = dynamic_filenames3;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
@@ -55,6 +55,10 @@ void example_LCMS_MRM_Standards(
   };
 
   Filenames methods_filenames1;
+  methods_filenames1.setRootPaths(dir_I,
+    dir_I + "/mzML/",
+    dir_I + "/features/",
+    dir_I + "/features/");
   for (const auto& m : raw_data_processing_methods)
   {
     m->getInputsOutputs(methods_filenames1);
@@ -63,11 +67,7 @@ void example_LCMS_MRM_Standards(
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     Filenames injection_filenames = methods_filenames1;
-    injection_filenames.setPathsAndNames(
-      dir_I,
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    injection_filenames.setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Standards_example.h
@@ -59,22 +59,17 @@ void example_LCMS_MRM_Standards(
     dir_I + "/mzML/",
     dir_I + "/features/",
     dir_I + "/features/");
-  for (const auto& m : raw_data_processing_methods)
-  {
-    m->getInputsOutputs(methods_filenames1);
-  }
   std::map<std::string, Filenames> dynamic_filenames1;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    Filenames injection_filenames = methods_filenames1;
-    injection_filenames.setFileVariants(
+    dynamic_filenames1[key] = methods_filenames1;
+    dynamic_filenames1[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
-    dynamic_filenames1[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
@@ -55,10 +55,16 @@ void example_LCMS_MRM_Unknowns(
     std::make_shared<StoreFeatures>()
   };
 
+  Filenames methods_filenames;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames);
+  }
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    Filenames injection_filenames = methods_filenames;
+    injection_filenames.setPathsAndNames(
       dir_I,
       dir_I + "/mzML/",
       dir_I + "/features/",
@@ -69,6 +75,7 @@ void example_LCMS_MRM_Unknowns(
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
+    dynamic_filenames[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -78,14 +85,14 @@ void example_LCMS_MRM_Unknowns(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.pivotTable_csv_o,
+    static_filenames.getFullPathName("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Unknown}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.featureDB_csv_o,
+    static_filenames.getFullPathName("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
@@ -56,21 +56,19 @@ void example_LCMS_MRM_Unknowns(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setRootPaths(dir_I,
-    dir_I + "/mzML/",
-    dir_I + "/features/",
-    dir_I + "/features/");
+  methods_filenames.setTag("MAIN_DIR", dir_I);
+  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
+  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setFileVariants(
-      injection.getMetaData().getFilename(),
-      key,
-      key,
-      injection.getMetaData().getSampleGroupName(),
-      injection.getMetaData().getSampleGroupName()
-    );
+    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
@@ -80,14 +80,14 @@ void example_LCMS_MRM_Unknowns(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    filenames.getFullPathName("pivotTable_csv_o"),
+    filenames.getFullPath("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Unknown}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    filenames.getFullPathName("featureDB_csv_o"),
+    filenames.getFullPath("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_LCMS_MRM_Unknowns(
   const std::string& dir_I,
-  const Filenames& static_filenames,
+  const Filenames& filenames,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_        = static_filenames;
+  cs.filenames_        = filenames;
   cs.delimiter        = delimiter_I;
   cs.checkConsistency = true;
   cs.process();
@@ -80,14 +80,14 @@ void example_LCMS_MRM_Unknowns(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.getFullPathName("pivotTable_csv_o"),
+    filenames.getFullPathName("pivotTable_csv_o"),
     {FeatureMetadata::calculated_concentration},
     {SampleType::Unknown}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.getFullPathName("featureDB_csv_o"),
+    filenames.getFullPathName("featureDB_csv_o"),
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
@@ -56,19 +56,19 @@ void example_LCMS_MRM_Unknowns(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setTag("MAIN_DIR", dir_I);
-  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
-  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
-  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::MAIN_DIR, dir_I);
+  methods_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, dir_I + "/mzML/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_LCMS_MRM_Unknowns(
   const std::string& dir_I,
-  const Filenames& filenames,
+  const Filenames& filenames_I,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_        = filenames;
+  cs.filenames_        = filenames_I;
   cs.delimiter        = delimiter_I;
   cs.checkConsistency = true;
   cs.process();
@@ -77,6 +77,10 @@ void example_LCMS_MRM_Unknowns(
   ps.filenames_                     = dynamic_filenames;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;
   ps.process();
+
+  Filenames filenames = filenames_I;
+  filenames.setFullPath("pivotTable_csv_o", dir_I + "/PivotTable.csv");
+  filenames.setFullPath("featureDB_csv_o", dir_I + "/FeatureDB.csv");
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
@@ -56,6 +56,10 @@ void example_LCMS_MRM_Unknowns(
   };
 
   Filenames methods_filenames;
+  methods_filenames.setRootPaths(dir_I,
+    dir_I + "/mzML/",
+    dir_I + "/features/",
+    dir_I + "/features/");
   for (const auto& m : raw_data_processing_methods)
   {
     m->getInputsOutputs(methods_filenames);
@@ -64,11 +68,7 @@ void example_LCMS_MRM_Unknowns(
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     Filenames injection_filenames = methods_filenames;
-    injection_filenames.setPathsAndNames(
-      dir_I,
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    injection_filenames.setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Unknown_example.h
@@ -60,22 +60,17 @@ void example_LCMS_MRM_Unknowns(
     dir_I + "/mzML/",
     dir_I + "/features/",
     dir_I + "/features/");
-  for (const auto& m : raw_data_processing_methods)
-  {
-    m->getInputsOutputs(methods_filenames);
-  }
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    Filenames injection_filenames = methods_filenames;
-    injection_filenames.setFileVariants(
+    dynamic_filenames[key] = methods_filenames;
+    dynamic_filenames[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
-    dynamic_filenames[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
@@ -53,19 +53,19 @@ void example_LCMS_MRM_Validation(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setTag("MAIN_DIR", dir_I);
-  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
-  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
-  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::MAIN_DIR, dir_I);
+  methods_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, dir_I + "/mzML/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, dir_I + "/features/");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames1[key] = methods_filenames;
-    dynamic_filenames1[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames1[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames1[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames1[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames1[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames1[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames1[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames1[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames1[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames1[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
@@ -53,18 +53,19 @@ void example_LCMS_MRM_Validation(
   };
 
   Filenames methods_filenames;
-  methods_filenames.setRootPaths(dir_I,
-    dir_I + "/mzML/",
-    dir_I + "/features/",
-    dir_I + "/features/");
+  methods_filenames.setTag("MAIN_DIR", dir_I);
+  methods_filenames.setTag("MZML_INPUT_PATH", dir_I + "/mzML/");
+  methods_filenames.setTag("FEATURES_INPUT_PATH", dir_I + "/features/");
+  methods_filenames.setTag("FEATURES_OUTPUT_PATH", dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
     dynamic_filenames1[key] = methods_filenames;
-    dynamic_filenames1[key].setFileVariants(
-      injection.getMetaData().getSampleName(),
-      key
-    );
+    dynamic_filenames1[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames1[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames1[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames1[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames1[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
@@ -55,7 +55,7 @@ void example_LCMS_MRM_Validation(
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::setPathsAndNames(
+    dynamic_filenames[key] = Filenames::setFileVariants(
       dir_I + "/mzML/",
       dir_I + "/features/",
       dir_I + "/features/",

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_LCMS_MRM_Validation(
   const std::string& dir_I,
-  const Filenames& static_filenames,
+  const Filenames& filenames,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_        = static_filenames;
+  cs.filenames_        = filenames;
   cs.delimiter        = delimiter_I;
   cs.checkConsistency = true;
   cs.process();
@@ -74,14 +74,14 @@ void example_LCMS_MRM_Validation(
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,
-    static_filenames.pivotTable_csv_o,
+    filenames.pivotTable_csv_o,
     {FeatureMetadata::accuracy, FeatureMetadata::n_features},
     {SampleType::Unknown}
   );
 
   SequenceParser::writeDataTableFromMetaValue(
     sequenceHandler,
-    static_filenames.featureDB_csv_o,
+    filenames.featureDB_csv_o,
     {
       FeatureMetadata::peak_apex_intensity,
       FeatureMetadata::total_width,

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
@@ -55,7 +55,7 @@ void example_LCMS_MRM_Validation(
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    dynamic_filenames[key] = Filenames::setPathsAndNames(
       dir_I + "/mzML/",
       dir_I + "/features/",
       dir_I + "/features/",

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
@@ -52,13 +52,16 @@ void example_LCMS_MRM_Validation(
     std::make_shared<ValidateFeatures>()
   };
 
+  Filenames methods_filenames;
+  methods_filenames.setRootPaths(dir_I,
+    dir_I + "/mzML/",
+    dir_I + "/features/",
+    dir_I + "/features/");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string& key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::setFileVariants(
-      dir_I + "/mzML/",
-      dir_I + "/features/",
-      dir_I + "/features/",
+    dynamic_filenames1[key] = methods_filenames;
+    dynamic_filenames1[key].setFileVariants(
       injection.getMetaData().getSampleName(),
       key
     );

--- a/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
+++ b/src/smartpeak/include/SmartPeak/pipelines/LCMS_MRM_Validation_example.h
@@ -31,14 +31,14 @@ using namespace SmartPeak;
 
 void example_LCMS_MRM_Validation(
   const std::string& dir_I,
-  const Filenames& filenames,
+  const Filenames& filenames_I,
   const std::string& delimiter_I = ","
 )
 {
   SequenceHandler sequenceHandler;
 
   CreateSequence cs(sequenceHandler);
-  cs.filenames_        = filenames;
+  cs.filenames_        = filenames_I;
   cs.delimiter        = delimiter_I;
   cs.checkConsistency = true;
   cs.process();
@@ -71,6 +71,10 @@ void example_LCMS_MRM_Validation(
   ps.filenames_                     = dynamic_filenames;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;
   ps.process();
+
+  Filenames filenames = filenames_I;
+  filenames.setFullPath("pivotTable_csv_o", dir_I + "/PivotTable.csv");
+  filenames.setFullPath("featureDB_csv_o", dir_I + "/FeatureDB.csv");
 
   SequenceParser::writeDataMatrixFromMetaValue(
     sequenceHandler,

--- a/src/smartpeak/include/SmartPeak/ui/Report.h
+++ b/src/smartpeak/include/SmartPeak/ui/Report.h
@@ -45,10 +45,10 @@ namespace SmartPeak
     bool initializeMetadataAndSampleTypes();
 
     static void run_and_join(
-      bool (*data_writer)(const SequenceHandler&, const std::string&, const std::vector<FeatureMetadata>&, const std::set<SampleType>&),
+      bool (*data_writer)(const SequenceHandler&, const std::filesystem::path&, const std::vector<FeatureMetadata>&, const std::set<SampleType>&),
       const std::string& data_writer_label,
       const SequenceHandler sequence,
-      const std::string& pathname,
+      const std::filesystem::path& pathname,
       const std::vector<FeatureMetadata>& meta_data,
       const std::set<SampleType>& sample_types
     );

--- a/src/smartpeak/include/SmartPeak/ui/RunWorkflowWidget.h
+++ b/src/smartpeak/include/SmartPeak/ui/RunWorkflowWidget.h
@@ -64,9 +64,11 @@ namespace SmartPeak
     ApplicationHandler& application_handler_;
     SessionHandler& session_handler_;
     WorkflowManager& workflow_manager_;
-    std::string mzML_dir_;
-    std::string features_in_dir_;
-    std::string features_out_dir_;
-    bool directories_set_ = false;
+    std::string mzML_dir_edit_;
+    std::string features_in_dir_edit_;
+    std::string features_out_dir_edit_;
+    std::string mzML_dir_old_;
+    std::string features_in_dir_old_;
+    std::string features_out_dir_old_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/ui/RunWorkflowWidget.h
+++ b/src/smartpeak/include/SmartPeak/ui/RunWorkflowWidget.h
@@ -64,5 +64,9 @@ namespace SmartPeak
     ApplicationHandler& application_handler_;
     SessionHandler& session_handler_;
     WorkflowManager& workflow_manager_;
+    std::string mzML_dir_;
+    std::string features_in_dir_;
+    std::string features_out_dir_;
+    bool directories_set_ = false;
   };
 }

--- a/src/smartpeak/source/cli/Task.cpp
+++ b/src/smartpeak/source/cli/Task.cpp
@@ -262,10 +262,10 @@ void InitializeWorkflowSettings::_update_filenames(
     {
         for (auto& p : cmd.dynamic_filenames)
         {
-          p.second.setTag("MAIN_DIR", application_handler.main_dir_.generic_string());
-          p.second.setTag("MZML_INPUT_PATH", application_handler.mzML_dir_.generic_string());
-          p.second.setTag("FEATURES_INPUT_PATH", application_handler.features_in_dir_.generic_string());
-          p.second.setTag("FEATURES_OUTPUT_PATH", application_handler.features_out_dir_.generic_string());
+          p.second.setTag(Filenames::Tag::MAIN_DIR, application_handler.main_dir_.generic_string());
+          p.second.setTag(Filenames::Tag::MZML_INPUT_PATH, application_handler.mzML_dir_.generic_string());
+          p.second.setTag(Filenames::Tag::FEATURES_INPUT_PATH, application_handler.features_in_dir_.generic_string());
+          p.second.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, application_handler.features_out_dir_.generic_string());
         }
     }
 }

--- a/src/smartpeak/source/cli/Task.cpp
+++ b/src/smartpeak/source/cli/Task.cpp
@@ -262,12 +262,10 @@ void InitializeWorkflowSettings::_update_filenames(
     {
         for (auto& p : cmd.dynamic_filenames)
         {
-          p.second.setRootPaths(
-                application_handler.main_dir_,
-                application_handler.mzML_dir_,
-                application_handler.features_in_dir_,
-                application_handler.features_out_dir_
-          );
+          p.second.setTag("MAIN_DIR", application_handler.main_dir_.generic_string());
+          p.second.setTag("MZML_INPUT_PATH", application_handler.mzML_dir_.generic_string());
+          p.second.setTag("FEATURES_INPUT_PATH", application_handler.features_in_dir_.generic_string());
+          p.second.setTag("FEATURES_OUTPUT_PATH", application_handler.features_out_dir_.generic_string());
         }
     }
 }

--- a/src/smartpeak/source/cli/Task.cpp
+++ b/src/smartpeak/source/cli/Task.cpp
@@ -193,21 +193,21 @@ bool InitializeWorkflowResources::operator() (ApplicationManager& application_ma
     if (!application_settings.out_dir.empty() && application_settings.out_dir != ".")
     {
         main_dir = application_settings.out_dir;
-        LOG_DEBUG << "Output feature directory: " << main_dir;
+        LOG_DEBUG << "Output feature directory: " << main_dir.generic_string();
     }
-    application_handler.mzML_dir_           = application_handler.main_dir_ + "/mzML";
-    application_handler.features_in_dir_    = application_handler.main_dir_ + "/features";
-    application_handler.features_out_dir_   = main_dir + "/features";
+    application_handler.mzML_dir_           = application_handler.main_dir_ / "mzML";
+    application_handler.features_in_dir_    = application_handler.main_dir_ / "features";
+    application_handler.features_out_dir_   = main_dir / "features";
 
     auto paths = {
         application_handler.mzML_dir_, 
         application_handler.features_in_dir_, 
         application_handler.features_out_dir_ 
     };
-    auto current_path = std::string{};
+    auto current_path = std::filesystem::path{};
     try
     {
-        for (const std::string& pathname : paths) 
+        for (const auto& pathname : paths) 
         {
             current_path = pathname;
             fs::create_directories(fs::path(pathname));
@@ -405,7 +405,7 @@ bool ExportReport::operator() (ApplicationManager& application_manager)
         if (feature_db)
         {
             auto& sequance_handler = application_handler.sequenceHandler_;
-            const auto filepath = main_dir + "/FeatureDB.csv";
+            const auto filepath = main_dir / "FeatureDB.csv";
             SequenceParser::writeDataTableFromMetaValue(
                 sequance_handler, filepath, 
                 report_metadata, report_sample_types);
@@ -413,7 +413,7 @@ bool ExportReport::operator() (ApplicationManager& application_manager)
         if (pivot_table)
         {
             auto& sequance_handler = application_handler.sequenceHandler_;
-            const auto filepath = main_dir + "/PivotTable.csv";
+            const auto filepath = main_dir / "PivotTable.csv";
             SequenceParser::writeDataMatrixFromMetaValue(
                 sequance_handler, filepath, 
                 report_metadata, report_sample_types);

--- a/src/smartpeak/source/cli/Task.cpp
+++ b/src/smartpeak/source/cli/Task.cpp
@@ -262,12 +262,12 @@ void InitializeWorkflowSettings::_update_filenames(
     {
         for (auto& p : cmd.dynamic_filenames)
         {
-            SmartPeak::Filenames::updateDefaultDynamicFilenames(
+          p.second.setRootPaths(
+                application_handler.main_dir_,
                 application_handler.mzML_dir_,
                 application_handler.features_in_dir_,
-                application_handler.features_out_dir_,
-                p.second
-            );
+                application_handler.features_out_dir_
+          );
         }
     }
 }

--- a/src/smartpeak/source/core/ApplicationProcessor.cpp
+++ b/src/smartpeak/source/core/ApplicationProcessor.cpp
@@ -211,18 +211,16 @@ namespace SmartPeak
         application_handler_.mzML_dir_,
         application_handler_.features_in_dir_,
         application_handler_.features_out_dir_);
-      method->getInputsOutputs(method_filenames);
       for (const InjectionHandler& injection : application_handler_.sequenceHandler_.getSequence()) {
         const std::string& key = injection.getMetaData().getInjectionName();
-        Filenames injection_filenames = method_filenames;
-        injection_filenames.setFileVariants(
+        cmd_.dynamic_filenames[key] = method_filenames;
+        cmd_.dynamic_filenames[key].setFileVariants(
           injection.getMetaData().getFilename(),
           key,
           key,
           injection.getMetaData().getSampleGroupName(),
           injection.getMetaData().getSampleGroupName()
         );
-        cmd_.dynamic_filenames[key] = injection_filenames;
       }
     } else if (std::count(valid_commands_sequence_segment_processor.begin(), valid_commands_sequence_segment_processor.end(), name_)) {
       const auto& method = n_to_seq_seg_method_.at(name_);
@@ -232,18 +230,16 @@ namespace SmartPeak
         application_handler_.mzML_dir_,
         application_handler_.features_in_dir_,
         application_handler_.features_out_dir_);
-      method->getInputsOutputs(method_filenames);
       for (const SequenceSegmentHandler& sequence_segment : application_handler_.sequenceHandler_.getSequenceSegments()) {
         const std::string& key = sequence_segment.getSequenceSegmentName();
-        Filenames sequence_segment_filenames = method_filenames;
-        sequence_segment_filenames.setFileVariants(
+        cmd_.dynamic_filenames[key] = method_filenames;
+        cmd_.dynamic_filenames[key].setFileVariants(
           "",
           key,
           key,
           key,
           key
         );
-        cmd_.dynamic_filenames[key] = sequence_segment_filenames;
       }
     } else if (std::count(valid_commands_sample_group_processor.begin(), valid_commands_sample_group_processor.end(), name_)) {
       const auto& method = n_to_sample_group_method_.at(name_);
@@ -253,18 +249,16 @@ namespace SmartPeak
         application_handler_.mzML_dir_,
         application_handler_.features_in_dir_,
         application_handler_.features_out_dir_);
-      method->getInputsOutputs(method_filenames);
       for (const SampleGroupHandler& sample_group : application_handler_.sequenceHandler_.getSampleGroups()) {
         const std::string& key = sample_group.getSampleGroupName();
-        Filenames sample_group_filenames = method_filenames;
-        sample_group_filenames.setFileVariants(
+        cmd_.dynamic_filenames[key] = method_filenames;
+        cmd_.dynamic_filenames[key].setFileVariants(
           "",
           key,
           key,
           key,
           key
         );
-        cmd_.dynamic_filenames[key] = sample_group_filenames;
       }
     }
     else 

--- a/src/smartpeak/source/core/ApplicationProcessor.cpp
+++ b/src/smartpeak/source/core/ApplicationProcessor.cpp
@@ -206,15 +206,16 @@ namespace SmartPeak
       const auto& method = n_to_raw_data_method_.at(name_);
       cmd_.setMethod(method);
       Filenames method_filenames;
+      method_filenames.setRootPaths(
+        application_handler_.main_dir_,
+        application_handler_.mzML_dir_,
+        application_handler_.features_in_dir_,
+        application_handler_.features_out_dir_);
       method->getInputsOutputs(method_filenames);
       for (const InjectionHandler& injection : application_handler_.sequenceHandler_.getSequence()) {
         const std::string& key = injection.getMetaData().getInjectionName();
         Filenames injection_filenames = method_filenames;
-        injection_filenames.setPathsAndNames(
-          application_handler_.main_dir_,
-          application_handler_.mzML_dir_,
-          application_handler_.features_in_dir_,
-          application_handler_.features_out_dir_,
+        injection_filenames.setFileVariants(
           injection.getMetaData().getFilename(),
           key,
           key,
@@ -227,15 +228,15 @@ namespace SmartPeak
       const auto& method = n_to_seq_seg_method_.at(name_);
       cmd_.setMethod(method);
       Filenames method_filenames;
+      method_filenames.setRootPaths(application_handler_.main_dir_,
+        application_handler_.mzML_dir_,
+        application_handler_.features_in_dir_,
+        application_handler_.features_out_dir_);
       method->getInputsOutputs(method_filenames);
       for (const SequenceSegmentHandler& sequence_segment : application_handler_.sequenceHandler_.getSequenceSegments()) {
         const std::string& key = sequence_segment.getSequenceSegmentName();
         Filenames sequence_segment_filenames = method_filenames;
-        sequence_segment_filenames.setPathsAndNames(
-          application_handler_.main_dir_,
-          application_handler_.mzML_dir_,
-          application_handler_.features_in_dir_,
-          application_handler_.features_out_dir_,
+        sequence_segment_filenames.setFileVariants(
           "",
           key,
           key,
@@ -248,15 +249,15 @@ namespace SmartPeak
       const auto& method = n_to_sample_group_method_.at(name_);
       cmd_.setMethod(method);
       Filenames method_filenames;
+      method_filenames.setRootPaths(application_handler_.main_dir_,
+        application_handler_.mzML_dir_,
+        application_handler_.features_in_dir_,
+        application_handler_.features_out_dir_);
       method->getInputsOutputs(method_filenames);
       for (const SampleGroupHandler& sample_group : application_handler_.sequenceHandler_.getSampleGroups()) {
         const std::string& key = sample_group.getSampleGroupName();
         Filenames sample_group_filenames = method_filenames;
-        sample_group_filenames.setPathsAndNames(
-          application_handler_.main_dir_,
-          application_handler_.mzML_dir_,
-          application_handler_.features_in_dir_,
-          application_handler_.features_out_dir_,
+        sample_group_filenames.setFileVariants(
           "",
           key,
           key,

--- a/src/smartpeak/source/core/ApplicationProcessor.cpp
+++ b/src/smartpeak/source/core/ApplicationProcessor.cpp
@@ -206,52 +206,52 @@ namespace SmartPeak
       const auto& method = n_to_raw_data_method_.at(name_);
       cmd_.setMethod(method);
       Filenames method_filenames;
-      method_filenames.setTag("MAIN_DIR", application_handler_.main_dir_.generic_string());
-      method_filenames.setTag("MZML_INPUT_PATH", application_handler_.mzML_dir_.generic_string());
-      method_filenames.setTag("FEATURES_INPUT_PATH", application_handler_.features_in_dir_.generic_string());
-      method_filenames.setTag("FEATURES_OUTPUT_PATH", application_handler_.features_out_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::MAIN_DIR, application_handler_.main_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, application_handler_.mzML_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, application_handler_.features_in_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, application_handler_.features_out_dir_.generic_string());
       for (const InjectionHandler& injection : application_handler_.sequenceHandler_.getSequence()) {
         const std::string& key = injection.getMetaData().getInjectionName();
         cmd_.dynamic_filenames[key] = method_filenames;
-        cmd_.dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-        cmd_.dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
-        cmd_.dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
-        cmd_.dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-        cmd_.dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
       }
     } else if (std::count(valid_commands_sequence_segment_processor.begin(), valid_commands_sequence_segment_processor.end(), name_)) {
       const auto& method = n_to_seq_seg_method_.at(name_);
       cmd_.setMethod(method);
       Filenames method_filenames;
-      method_filenames.setTag("MAIN_DIR", application_handler_.main_dir_.generic_string());
-      method_filenames.setTag("MZML_INPUT_PATH", application_handler_.mzML_dir_.generic_string());
-      method_filenames.setTag("FEATURES_INPUT_PATH", application_handler_.features_in_dir_.generic_string());
-      method_filenames.setTag("FEATURES_OUTPUT_PATH", application_handler_.features_out_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::MAIN_DIR, application_handler_.main_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, application_handler_.mzML_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, application_handler_.features_in_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, application_handler_.features_out_dir_.generic_string());
       for (const SequenceSegmentHandler& sequence_segment : application_handler_.sequenceHandler_.getSequenceSegments()) {
         const std::string& key = sequence_segment.getSequenceSegmentName();
         cmd_.dynamic_filenames[key] = method_filenames;
-        cmd_.dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", "");
-        cmd_.dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
-        cmd_.dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
-        cmd_.dynamic_filenames[key].setTag("INPUT_GROUP_NAME", key);
-        cmd_.dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", key);
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, "");
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, key);
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, key);
       }
     } else if (std::count(valid_commands_sample_group_processor.begin(), valid_commands_sample_group_processor.end(), name_)) {
       const auto& method = n_to_sample_group_method_.at(name_);
       cmd_.setMethod(method);
       Filenames method_filenames;
-      method_filenames.setTag("MAIN_DIR", application_handler_.main_dir_.generic_string());
-      method_filenames.setTag("MZML_INPUT_PATH", application_handler_.mzML_dir_.generic_string());
-      method_filenames.setTag("FEATURES_INPUT_PATH", application_handler_.features_in_dir_.generic_string());
-      method_filenames.setTag("FEATURES_OUTPUT_PATH", application_handler_.features_out_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::MAIN_DIR, application_handler_.main_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, application_handler_.mzML_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, application_handler_.features_in_dir_.generic_string());
+      method_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, application_handler_.features_out_dir_.generic_string());
       for (const SampleGroupHandler& sample_group : application_handler_.sequenceHandler_.getSampleGroups()) {
         const std::string& key = sample_group.getSampleGroupName();
         cmd_.dynamic_filenames[key] = method_filenames;
-        cmd_.dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", "");
-        cmd_.dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
-        cmd_.dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
-        cmd_.dynamic_filenames[key].setTag("INPUT_GROUP_NAME", key);
-        cmd_.dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", key);
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, "");
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, key);
+        cmd_.dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, key);
       }
     }
     else 

--- a/src/smartpeak/source/core/ApplicationProcessor.cpp
+++ b/src/smartpeak/source/core/ApplicationProcessor.cpp
@@ -105,10 +105,25 @@ namespace SmartPeak
       const ApplicationHandler::Command& cmd = commands[i];
       if (cmd.type == ApplicationHandler::Command::RawDataMethod) {
         std::vector<std::shared_ptr<RawDataProcessor>> raw_methods;
-        std::transform(commands.begin() + i, commands.begin() + j, std::back_inserter(raw_methods),
-          [](const ApplicationHandler::Command& command){ return command.raw_data_method; });
+        std::map<std::string, Filenames> filenames;
+        std::for_each(commands.begin() + i, commands.begin() + j,
+          [&](const ApplicationHandler::Command& command) 
+        { 
+          raw_methods.push_back(command.raw_data_method);
+          for (const auto& filename_to_merge : command.dynamic_filenames)
+          {
+            if (filenames.find(filename_to_merge.first) == filenames.end())
+            {
+              filenames.emplace(filename_to_merge.first, filename_to_merge.second);
+            }
+            else
+            {
+              filenames.at(filename_to_merge.first).merge(filename_to_merge.second);
+            }
+          }
+        });
         ProcessSequence ps(state.sequenceHandler_, sequence_processor_observer);
-        ps.filenames_ = cmd.dynamic_filenames;
+        ps.filenames_ = filenames;
         ps.raw_data_processing_methods_ = raw_methods;
         ps.injection_names_ = injection_names;
         notifyStartCommands<decltype(raw_methods)>(observable, i, raw_methods);
@@ -116,10 +131,25 @@ namespace SmartPeak
         notifyEndCommands<decltype(raw_methods)>(observable, i, raw_methods);
       } else if (cmd.type == ApplicationHandler::Command::SequenceSegmentMethod) {
         std::vector<std::shared_ptr<SequenceSegmentProcessor>> seq_seg_methods;
-        std::transform(commands.begin() + i, commands.begin() + j, std::back_inserter(seq_seg_methods),
-          [](const ApplicationHandler::Command& command){ return command.seq_seg_method; });
+        std::map<std::string, Filenames> filenames;
+        std::for_each(commands.begin() + i, commands.begin() + j,
+          [&](const ApplicationHandler::Command& command)
+        {
+          seq_seg_methods.push_back(command.seq_seg_method);
+          for (const auto& filename_to_merge : command.dynamic_filenames)
+          {
+            if (filenames.find(filename_to_merge.first) == filenames.end())
+            {
+              filenames.emplace(filename_to_merge.first, filename_to_merge.second);
+            }
+            else
+            {
+              filenames.at(filename_to_merge.first).merge(filename_to_merge.second);
+            }
+          }
+        });
         ProcessSequenceSegments pss(state.sequenceHandler_, sequence_segment_processor_observer);
-        pss.filenames_ = cmd.dynamic_filenames;
+        pss.filenames_ = filenames;
         pss.sequence_segment_processing_methods_ = seq_seg_methods;
         pss.sequence_segment_names_ = sequence_segment_names;
         notifyStartCommands<decltype(seq_seg_methods)>(observable, i, seq_seg_methods);
@@ -127,10 +157,25 @@ namespace SmartPeak
         notifyEndCommands<decltype(seq_seg_methods)>(observable, i, seq_seg_methods);
       } else if (cmd.type == ApplicationHandler::Command::SampleGroupMethod) {
         std::vector<std::shared_ptr<SampleGroupProcessor>> sample_group_methods;
-        std::transform(commands.begin() + i, commands.begin() + j, std::back_inserter(sample_group_methods),
-          [](const ApplicationHandler::Command& command) { return command.sample_group_method; });
+        std::map<std::string, Filenames> filenames;
+        std::for_each(commands.begin() + i, commands.begin() + j,
+          [&](const ApplicationHandler::Command& command)
+        {
+          sample_group_methods.push_back(command.sample_group_method);
+          for (const auto& filename_to_merge : command.dynamic_filenames)
+          {
+            if (filenames.find(filename_to_merge.first) == filenames.end())
+            {
+              filenames.emplace(filename_to_merge.first, filename_to_merge.second);
+            }
+            else
+            {
+              filenames.at(filename_to_merge.first).merge(filename_to_merge.second);
+            }
+          }
+        });
         ProcessSampleGroups psg(state.sequenceHandler_, sample_group_processor_observer);
-        psg.filenames_ = cmd.dynamic_filenames;
+        psg.filenames_ = filenames;
         psg.sample_group_processing_methods_ = sample_group_methods;
         psg.sample_group_names_ = sample_group_names;
         notifyStartCommands<decltype(sample_group_methods)>(observable, i, sample_group_methods);
@@ -158,10 +203,14 @@ namespace SmartPeak
 
     // Run the command depending on whether it is a raw data processor method or sequence segment processor method
     if (std::count(valid_commands_raw_data_processor.begin(), valid_commands_raw_data_processor.end(), name_)) {
-      cmd_.setMethod(n_to_raw_data_method_.at(name_));
+      const auto& method = n_to_raw_data_method_.at(name_);
+      cmd_.setMethod(method);
+      Filenames method_filenames;
+      method->getInputsOutputs(method_filenames);
       for (const InjectionHandler& injection : application_handler_.sequenceHandler_.getSequence()) {
         const std::string& key = injection.getMetaData().getInjectionName();
-        cmd_.dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+        Filenames injection_filenames = method_filenames;
+        injection_filenames.setPathsAndNames(
           application_handler_.main_dir_,
           application_handler_.mzML_dir_,
           application_handler_.features_in_dir_,
@@ -172,12 +221,17 @@ namespace SmartPeak
           injection.getMetaData().getSampleGroupName(),
           injection.getMetaData().getSampleGroupName()
         );
+        cmd_.dynamic_filenames[key] = injection_filenames;
       }
     } else if (std::count(valid_commands_sequence_segment_processor.begin(), valid_commands_sequence_segment_processor.end(), name_)) {
-      cmd_.setMethod(n_to_seq_seg_method_.at(name_));
+      const auto& method = n_to_seq_seg_method_.at(name_);
+      cmd_.setMethod(method);
+      Filenames method_filenames;
+      method->getInputsOutputs(method_filenames);
       for (const SequenceSegmentHandler& sequence_segment : application_handler_.sequenceHandler_.getSequenceSegments()) {
         const std::string& key = sequence_segment.getSequenceSegmentName();
-        cmd_.dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+        Filenames sequence_segment_filenames = method_filenames;
+        sequence_segment_filenames.setPathsAndNames(
           application_handler_.main_dir_,
           application_handler_.mzML_dir_,
           application_handler_.features_in_dir_,
@@ -188,12 +242,17 @@ namespace SmartPeak
           key,
           key
         );
+        cmd_.dynamic_filenames[key] = sequence_segment_filenames;
       }
     } else if (std::count(valid_commands_sample_group_processor.begin(), valid_commands_sample_group_processor.end(), name_)) {
-      cmd_.setMethod(n_to_sample_group_method_.at(name_));
+      const auto& method = n_to_sample_group_method_.at(name_);
+      cmd_.setMethod(method);
+      Filenames method_filenames;
+      method->getInputsOutputs(method_filenames);
       for (const SampleGroupHandler& sample_group : application_handler_.sequenceHandler_.getSampleGroups()) {
         const std::string& key = sample_group.getSampleGroupName();
-        cmd_.dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+        Filenames sample_group_filenames = method_filenames;
+        sample_group_filenames.setPathsAndNames(
           application_handler_.main_dir_,
           application_handler_.mzML_dir_,
           application_handler_.features_in_dir_,
@@ -204,6 +263,7 @@ namespace SmartPeak
           key,
           key
         );
+        cmd_.dynamic_filenames[key] = sample_group_filenames;
       }
     }
     else 

--- a/src/smartpeak/source/core/ApplicationProcessor.cpp
+++ b/src/smartpeak/source/core/ApplicationProcessor.cpp
@@ -206,59 +206,52 @@ namespace SmartPeak
       const auto& method = n_to_raw_data_method_.at(name_);
       cmd_.setMethod(method);
       Filenames method_filenames;
-      method_filenames.setRootPaths(
-        application_handler_.main_dir_,
-        application_handler_.mzML_dir_,
-        application_handler_.features_in_dir_,
-        application_handler_.features_out_dir_);
+      method_filenames.setTag("MAIN_DIR", application_handler_.main_dir_.generic_string());
+      method_filenames.setTag("MZML_INPUT_PATH", application_handler_.mzML_dir_.generic_string());
+      method_filenames.setTag("FEATURES_INPUT_PATH", application_handler_.features_in_dir_.generic_string());
+      method_filenames.setTag("FEATURES_OUTPUT_PATH", application_handler_.features_out_dir_.generic_string());
       for (const InjectionHandler& injection : application_handler_.sequenceHandler_.getSequence()) {
         const std::string& key = injection.getMetaData().getInjectionName();
         cmd_.dynamic_filenames[key] = method_filenames;
-        cmd_.dynamic_filenames[key].setFileVariants(
-          injection.getMetaData().getFilename(),
-          key,
-          key,
-          injection.getMetaData().getSampleGroupName(),
-          injection.getMetaData().getSampleGroupName()
-        );
+        cmd_.dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+        cmd_.dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
+        cmd_.dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
+        cmd_.dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+        cmd_.dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
       }
     } else if (std::count(valid_commands_sequence_segment_processor.begin(), valid_commands_sequence_segment_processor.end(), name_)) {
       const auto& method = n_to_seq_seg_method_.at(name_);
       cmd_.setMethod(method);
       Filenames method_filenames;
-      method_filenames.setRootPaths(application_handler_.main_dir_,
-        application_handler_.mzML_dir_,
-        application_handler_.features_in_dir_,
-        application_handler_.features_out_dir_);
+      method_filenames.setTag("MAIN_DIR", application_handler_.main_dir_.generic_string());
+      method_filenames.setTag("MZML_INPUT_PATH", application_handler_.mzML_dir_.generic_string());
+      method_filenames.setTag("FEATURES_INPUT_PATH", application_handler_.features_in_dir_.generic_string());
+      method_filenames.setTag("FEATURES_OUTPUT_PATH", application_handler_.features_out_dir_.generic_string());
       for (const SequenceSegmentHandler& sequence_segment : application_handler_.sequenceHandler_.getSequenceSegments()) {
         const std::string& key = sequence_segment.getSequenceSegmentName();
         cmd_.dynamic_filenames[key] = method_filenames;
-        cmd_.dynamic_filenames[key].setFileVariants(
-          "",
-          key,
-          key,
-          key,
-          key
-        );
+        cmd_.dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", "");
+        cmd_.dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
+        cmd_.dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
+        cmd_.dynamic_filenames[key].setTag("INPUT_GROUP_NAME", key);
+        cmd_.dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", key);
       }
     } else if (std::count(valid_commands_sample_group_processor.begin(), valid_commands_sample_group_processor.end(), name_)) {
       const auto& method = n_to_sample_group_method_.at(name_);
       cmd_.setMethod(method);
       Filenames method_filenames;
-      method_filenames.setRootPaths(application_handler_.main_dir_,
-        application_handler_.mzML_dir_,
-        application_handler_.features_in_dir_,
-        application_handler_.features_out_dir_);
+      method_filenames.setTag("MAIN_DIR", application_handler_.main_dir_.generic_string());
+      method_filenames.setTag("MZML_INPUT_PATH", application_handler_.mzML_dir_.generic_string());
+      method_filenames.setTag("FEATURES_INPUT_PATH", application_handler_.features_in_dir_.generic_string());
+      method_filenames.setTag("FEATURES_OUTPUT_PATH", application_handler_.features_out_dir_.generic_string());
       for (const SampleGroupHandler& sample_group : application_handler_.sequenceHandler_.getSampleGroups()) {
         const std::string& key = sample_group.getSampleGroupName();
         cmd_.dynamic_filenames[key] = method_filenames;
-        cmd_.dynamic_filenames[key].setFileVariants(
-          "",
-          key,
-          key,
-          key,
-          key
-        );
+        cmd_.dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", "");
+        cmd_.dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
+        cmd_.dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
+        cmd_.dynamic_filenames[key].setTag("INPUT_GROUP_NAME", key);
+        cmd_.dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", key);
       }
     }
     else 

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -82,14 +82,6 @@ namespace SmartPeak
         file_pattern = std::regex_replace(file_pattern, replace_regex, replace_with);
         search_string = match.suffix().str();
       }
-/*
-      for (const auto& tag : tags_)
-      {
-        const std::string tag_to_replace = std::string("\\$\\{") + tag.first + std::string("\\}");
-        std::regex reg(tag_to_replace);
-        file_pattern = std::regex_replace(file_pattern, reg, tag.second);
-      }
-*/
       filename.full_path_ = file_pattern;
     }
   }

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -23,44 +23,14 @@
 
 #include <SmartPeak/core/Filenames.h>
 #include <string>
+#include <map>
+#include <iostream>
+#include <string>
 
 namespace SmartPeak
 {
-  Filenames Filenames::getDefaultStaticFilenames(
-    const std::string& dir
-  )
-  {
-    Filenames static_filenames;
-    static_filenames.sequence_csv_i = dir + "/sequence.csv";
-    static_filenames.parameters_csv_i = dir + "/parameters.csv";
-    static_filenames.workflow_csv_i = dir + "/workflow.csv";
-    static_filenames.traML_csv_i = dir + "/traML.csv";
-    static_filenames.featureFilterComponents_csv_i = dir + "/featureFilterComponents.csv";
-    static_filenames.featureFilterComponentGroups_csv_i = dir + "/featureFilterComponentGroups.csv";
-    static_filenames.featureQCComponents_csv_i = dir + "/featureQCComponents.csv";
-    static_filenames.featureQCComponentGroups_csv_i = dir + "/featureQCComponentGroups.csv";
-    static_filenames.featureRSDFilterComponents_csv_i = dir + "/featureRSDFilterComponents.csv";
-    static_filenames.featureRSDFilterComponentGroups_csv_i = dir + "/featureRSDFilterComponentGroups.csv";
-    static_filenames.featureRSDQCComponents_csv_i = dir + "/featureRSDQCComponents.csv";
-    static_filenames.featureRSDQCComponentGroups_csv_i = dir + "/featureRSDQCComponentGroups.csv";
-    static_filenames.featureBackgroundFilterComponents_csv_i = dir + "/featureBackgroundFilterComponents.csv";
-    static_filenames.featureBackgroundFilterComponentGroups_csv_i = dir + "/featureBackgroundFilterComponentGroups.csv";
-    static_filenames.featureBackgroundQCComponents_csv_i = dir + "/featureBackgroundQCComponents.csv";
-    static_filenames.featureBackgroundQCComponentGroups_csv_i = dir + "/featureBackgroundQCComponentGroups.csv";
-    static_filenames.featureRSDEstimationComponents_csv_i = dir + "/featureRSDEstimationComponents.csv";
-    static_filenames.featureRSDEstimationComponentGroups_csv_i = dir + "/featureRSDEstimationComponentGroups.csv";
-    static_filenames.featureBackgroundEstimationComponents_csv_i = dir + "/featureBackgroundEstimationComponents.csv";
-    static_filenames.featureBackgroundEstimationComponentGroups_csv_i = dir + "/featureBackgroundEstimationComponentGroups.csv";
-    static_filenames.quantitationMethods_csv_i = dir + "/quantitationMethods.csv";
-    static_filenames.standardsConcentrations_csv_i = dir + "/standardsConcentrations.csv";
-    static_filenames.referenceData_csv_i = dir + "/referenceData.csv";
-    static_filenames.pivotTable_csv_o = dir + "/PivotTable.csv";
-    static_filenames.featureDB_csv_o = dir + "/FeatureDB.csv";
-    return static_filenames;
-  }
-
-  Filenames Filenames::getDefaultDynamicFilenames(
-    const std::string& static_dir,
+  void Filenames::setPathsAndNames(
+    const std::string& main_dir,
     const std::string& mzml_input_path,
     const std::string& features_input_path,
     const std::string& output_path,
@@ -71,159 +41,106 @@ namespace SmartPeak
     const std::string& output_sample_name
   )
   {
-    Filenames dynamic_filenames;
-
-    dynamic_filenames.mzML_i       = mzml_input_path + "/" + input_mzML_filename + ".mzML";
-
-    const std::string prefix_in = features_input_path + "/" + input_inj_name;
-    dynamic_filenames.featureXML_i = prefix_in + ".featureXML";
-    dynamic_filenames.mzTab_i = prefix_in + ".mzTab";
-
-    dynamic_filenames.featureXMLSampleGroup_i = features_input_path + "/" + input_sample_name + ".featureXML";
-    dynamic_filenames.featureXMLSampleGroup_o = output_path + "/" + output_sample_name + ".featureXML";
-
-    dynamic_filenames.selectDilutions_csv_i = static_dir + "/selectDilutions.csv";
-
-    const std::string prefix_out = output_path + "/" + output_inj_name;
-    dynamic_filenames.featureXML_o                     = prefix_out + ".featureXML";
-    dynamic_filenames.mzTab_o = prefix_out + ".mzTab";
-    dynamic_filenames.traML_csv_o = prefix_out + ".traML";
-    dynamic_filenames.features_pdf_o = prefix_out;
-    dynamic_filenames.featureFilterComponents_csv_o = prefix_out + "_featureFilterComponents.csv";
-    dynamic_filenames.featureFilterComponentGroups_csv_o = prefix_out + "_featureFilterComponentGroups.csv";
-    dynamic_filenames.featureQCComponents_csv_o = prefix_out + "_featureQCComponents.csv";
-    dynamic_filenames.featureQCComponentGroups_csv_o = prefix_out + "_featureQCComponentGroups.csv";
-    dynamic_filenames.featureRSDFilterComponents_csv_o = prefix_out + "_featureRSDFilterComponents.csv";
-    dynamic_filenames.featureRSDFilterComponentGroups_csv_o = prefix_out + "_featureRSDFilterComponentGroups.csv";
-    dynamic_filenames.featureRSDQCComponents_csv_o = prefix_out + "_featureRSDQCComponents.csv";
-    dynamic_filenames.featureRSDQCComponentGroups_csv_o = prefix_out + "_featureRSDQCComponentGroups.csv";
-    dynamic_filenames.featureBackgroundFilterComponents_csv_o = prefix_out + "_featureBackgroundFilterComponents.csv";
-    dynamic_filenames.featureBackgroundFilterComponentGroups_csv_o = prefix_out + "_featureBackgroundFilterComponentGroups.csv";
-    dynamic_filenames.featureBackgroundQCComponents_csv_o = prefix_out + "_featureBackgroundQCComponents.csv";
-    dynamic_filenames.featureBackgroundQCComponentGroups_csv_o = prefix_out + "_featureBackgroundQCComponentGroups.csv";
-    dynamic_filenames.featureRSDEstimationComponents_csv_o = prefix_out + "_featureRSDEstimationComponents.csv";
-    dynamic_filenames.featureRSDEstimationComponentGroups_csv_o = prefix_out + "_featureRSDEstimationComponentGroups.csv";
-    dynamic_filenames.featureBackgroundEstimationComponents_csv_o = prefix_out + "_featureBackgroundEstimationComponents.csv";
-    dynamic_filenames.featureBackgroundEstimationComponentGroups_csv_o = prefix_out + "_featureBackgroundEstimationComponentGroups.csv";
-    dynamic_filenames.quantitationMethods_csv_o        = prefix_out + "_quantitationMethods.csv";
-    dynamic_filenames.componentsToConcentrations_csv_o = prefix_out + "_componentsToConcentrations.csv";
-
-    dynamic_filenames.mzml_input_path = mzml_input_path;
-    dynamic_filenames.features_input_path = features_input_path;
-    dynamic_filenames.output_path = output_path;
-
-    return dynamic_filenames;
+    setFileVariant(input_mzML_filename, FileScope::EFileScopeMzMLInput);
+    setFileVariant(input_inj_name, FileScope::EFileScopeInjectionInput);
+    setFileVariant(input_sample_name, FileScope::EFileScopeSampleGroupInput);
+    setFileVariant(output_sample_name, FileScope::EFileScopeSampleGroupOutput);
+    setFileVariant(output_inj_name, FileScope::EFileScopeInjectionOutput);
+    setRootPaths(main_dir,
+                mzml_input_path,
+                features_input_path,
+                output_path);
   }
 
-  void Filenames::updateDefaultDynamicFilenames(
+  void Filenames::setRootPaths(
+    const std::string& main_dir,
     const std::string& mzml_input_path,
     const std::string& features_input_path,
-    const std::string& output_path,
-    Filenames& filenames
+    const std::string& output_path
   )
   {
-    filenames.mzML_i = std::filesystem::path(mzml_input_path)
-      .append(std::filesystem::path(filenames.mzML_i).filename().string())
-      .string();
-
-    filenames.featureXML_i = std::filesystem::path(features_input_path)
-      .append(std::filesystem::path(filenames.featureXML_i).filename().string())
-      .string();
-
-    filenames.featureXMLSampleGroup_i = std::filesystem::path(features_input_path)
-      .append(std::filesystem::path(filenames.featureXMLSampleGroup_i).filename().string())
-      .string();
-
-    filenames.mzTab_i = std::filesystem::path(features_input_path)
-      .append(std::filesystem::path(filenames.mzTab_i).filename().string())
-      .string();
-
-    const std::filesystem::path prefix { output_path };
-
-    filenames.featureXML_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureXML_o).filename().string()).string();
-    filenames.featureXMLSampleGroup_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureXMLSampleGroup_o).filename().string()).string();
-    filenames.mzTab_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.mzTab_o).filename().string()).string();
-    filenames.traML_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.traML_csv_o).filename().string()).string();
-
-    filenames.featureDB_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureDB_csv_o).filename().string()).string();
-
-    filenames.features_pdf_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.features_pdf_o).filename().string()).string();
-
-    filenames.featureFilterComponents_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureFilterComponents_csv_o).filename().c_str()).string();
-    filenames.featureFilterComponentGroups_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureFilterComponentGroups_csv_o).filename().c_str()).string();
-    filenames.featureQCComponents_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureQCComponents_csv_o).filename().c_str()).string();
-    filenames.featureQCComponentGroups_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureQCComponentGroups_csv_o).filename().c_str()).string();
-    filenames.featureRSDFilterComponents_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureRSDFilterComponents_csv_o).filename().c_str()).string();
-    filenames.featureRSDFilterComponentGroups_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureRSDFilterComponentGroups_csv_o).filename().c_str()).string();
-    filenames.featureRSDQCComponents_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureRSDQCComponents_csv_o).filename().c_str()).string();
-    filenames.featureRSDQCComponentGroups_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureRSDQCComponentGroups_csv_o).filename().c_str()).string();
-    filenames.featureBackgroundFilterComponents_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureBackgroundFilterComponents_csv_o).filename().c_str()).string();
-    filenames.featureBackgroundFilterComponentGroups_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureBackgroundFilterComponentGroups_csv_o).filename().c_str()).string();
-    filenames.featureBackgroundQCComponents_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureBackgroundQCComponents_csv_o).filename().c_str()).string();
-    filenames.featureBackgroundQCComponentGroups_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureBackgroundQCComponentGroups_csv_o).filename().c_str()).string();
-    filenames.featureRSDEstimationComponents_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureRSDEstimationComponents_csv_o).filename().c_str()).string();
-    filenames.featureRSDEstimationComponentGroups_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureRSDEstimationComponentGroups_csv_o).filename().c_str()).string();
-    filenames.featureBackgroundEstimationComponents_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureBackgroundEstimationComponents_csv_o).filename().c_str()).string();
-    filenames.featureBackgroundEstimationComponentGroups_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.featureBackgroundEstimationComponentGroups_csv_o).filename().c_str()).string();
-
-    filenames.quantitationMethods_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.quantitationMethods_csv_o).filename().string()).string();
-
-    filenames.componentsToConcentrations_csv_o = std::filesystem::path(prefix).append(std::filesystem::path(filenames.componentsToConcentrations_csv_o).filename().string()).string();
+    mzml_input_path_ = mzml_input_path;
+    features_input_path_ = features_input_path;
+    output_path_ = output_path;
+    main_dir_ = main_dir;
+    setRootPath(main_dir, FileScope::EFileScopeMain);
+    setRootPath(mzml_input_path, FileScope::EFileScopeMzMLInput);
+    setRootPath(features_input_path, FileScope::EFileScopeInjectionInput);
+    setRootPath(features_input_path, FileScope::EFileScopeSampleGroupInput);
+    setRootPath(output_path, FileScope::EFileScopeSampleGroupOutput);
+    setRootPath(output_path, FileScope::EFileScopeInjectionOutput);
   }
 
-  void Filenames::clear()
+  void Filenames::addFileName(const std::string& id, const std::string& default_name, FileScope file_scope)
   {
-    sequence_csv_i.clear();
-    parameters_csv_i.clear();
-    workflow_csv_i.clear();
-    traML_csv_i.clear();
-    traML_csv_o.clear();
-    featureFilterComponents_csv_i.clear();
-    featureFilterComponentGroups_csv_i.clear();
-    featureQCComponents_csv_i.clear();
-    featureQCComponentGroups_csv_i.clear();
-    featureRSDFilterComponents_csv_i.clear();
-    featureRSDFilterComponentGroups_csv_i.clear();
-    featureRSDQCComponents_csv_i.clear();
-    featureRSDQCComponentGroups_csv_i.clear();
-    featureBackgroundFilterComponents_csv_i.clear();
-    featureBackgroundFilterComponentGroups_csv_i.clear();
-    featureBackgroundQCComponents_csv_i.clear();
-    featureBackgroundQCComponentGroups_csv_i.clear();
-    featureRSDEstimationComponents_csv_i.clear();
-    featureRSDEstimationComponentGroups_csv_i.clear();
-    featureBackgroundEstimationComponents_csv_i.clear();
-    featureBackgroundEstimationComponentGroups_csv_i.clear();
-    quantitationMethods_csv_i.clear();
-    standardsConcentrations_csv_i.clear();
-    referenceData_csv_i.clear();
-    selectDilutions_csv_i.clear();
-    mzML_i.clear();
-    mzTab_i.clear();
-    mzTab_o.clear();
-    featureXML_o.clear();
-    featureXMLSampleGroup_o.clear();
-    featureXML_i.clear();
-    featureXMLSampleGroup_i.clear();
-    featureFilterComponents_csv_o.clear();
-    featureFilterComponentGroups_csv_o.clear();
-    featureQCComponents_csv_o.clear();
-    featureQCComponentGroups_csv_o.clear();
-    featureRSDFilterComponents_csv_o.clear();
-    featureRSDFilterComponentGroups_csv_o.clear();
-    featureRSDQCComponents_csv_o.clear();
-    featureRSDQCComponentGroups_csv_o.clear();
-    featureBackgroundFilterComponents_csv_o.clear();
-    featureBackgroundFilterComponentGroups_csv_o.clear();
-    featureBackgroundQCComponents_csv_o.clear();
-    featureBackgroundQCComponentGroups_csv_o.clear();
-    featureRSDEstimationComponents_csv_o.clear();
-    featureRSDEstimationComponentGroups_csv_o.clear();
-    featureBackgroundEstimationComponents_csv_o.clear();
-    featureBackgroundEstimationComponentGroups_csv_o.clear();
-    quantitationMethods_csv_o.clear();
-    componentsToConcentrations_csv_o.clear();
-    pivotTable_csv_o.clear();
-    featureDB_csv_o.clear();
+    if (file_names_.find(id) == file_names_.end())
+    {
+      FileName f{ default_name , file_scope };
+      updateFullPathName(f);
+      file_names_.insert_or_assign(id, f);
+    }
   }
+
+  std::string Filenames::getFullPathName(const std::string& id) const
+  {
+    return file_names_.at(id).full_path_;
+  }
+
+  void Filenames::setRootPath(const std::string& dir, FileScope file_scope)
+  {
+    for (auto& f : file_names_)
+    {
+      if (f.second.file_scope_ == file_scope)
+      {
+        f.second.root_path_ = dir;
+        updateFullPathName(f.second);
+      }
+    }
+  }
+
+  void Filenames::setFileVariant(const std::string& variant, FileScope file_scope)
+  {
+    for (auto& f : file_names_)
+    {
+      if (f.second.file_scope_ == file_scope)
+      {
+        f.second.file_variant_ = variant;
+        updateFullPathName(f.second);
+      }
+    }
+  }
+
+  void Filenames::setFullPathName(const std::string& id, const std::string& full_path)
+  {
+    if (file_names_.find(id) == file_names_.end())
+    {
+      addFileName(id, "", FileScope::EFileScopeUnspecified);
+    }
+    file_names_.at(id).full_path_override_ = true;
+    file_names_.at(id).full_path_ = full_path;
+  }
+
+  void Filenames::updateFullPathName(FileName& filename)
+  {
+    if (!filename.full_path_override_)
+    {
+      filename.full_path_.clear();
+      if (!filename.root_path_.empty())
+      {
+        filename.full_path_ += filename.root_path_ + "/";
+      }
+      if (!filename.file_variant_.empty())
+      {
+        filename.full_path_ += filename.file_variant_;
+      }
+      filename.full_path_ += filename.default_name_;
+    }
+  }
+
+  void Filenames::merge(const Filenames& other)
+  {
+    for (const auto& p : other.file_names_)
+      file_names_.emplace(p.first, p.second);
+  }
+
 }

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -46,10 +46,10 @@ namespace SmartPeak
   }
 
   void Filenames::setRootPaths(
-    const std::string& main_dir,
-    const std::string& mzml_input_path,
-    const std::string& input_path,
-    const std::string& output_path
+    const std::filesystem::path& main_dir,
+    const std::filesystem::path& mzml_input_path,
+    const std::filesystem::path& input_path,
+    const std::filesystem::path& output_path
   )
   {
     mzml_input_path_ = mzml_input_path;

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -37,11 +37,12 @@ namespace SmartPeak
     const std::string& output_sample_name
   )
   {
-    updateFileVariant(input_mzML_filename, FileScope::EFileScopeMzMLInput);
-    updateFileVariant(input_inj_name, FileScope::EFileScopeInjectionInput);
-    updateFileVariant(input_sample_name, FileScope::EFileScopeSampleGroupInput);
-    updateFileVariant(output_sample_name, FileScope::EFileScopeSampleGroupOutput);
-    updateFileVariant(output_inj_name, FileScope::EFileScopeInjectionOutput);
+    input_mzML_filename_ = input_mzML_filename;
+    input_inj_name_ = input_inj_name;
+    output_inj_name_ = output_inj_name;
+    input_sample_name_ = input_sample_name;
+    output_sample_name_ = output_sample_name;
+    updateFileVariants();
   }
 
   void Filenames::setRootPaths(
@@ -55,12 +56,7 @@ namespace SmartPeak
     input_path_ = input_path;
     output_path_ = output_path;
     main_dir_ = main_dir;
-    updateRootPath(main_dir, FileScope::EFileScopeMain);
-    updateRootPath(mzml_input_path, FileScope::EFileScopeMzMLInput);
-    updateRootPath(input_path, FileScope::EFileScopeInjectionInput);
-    updateRootPath(input_path, FileScope::EFileScopeSampleGroupInput);
-    updateRootPath(output_path, FileScope::EFileScopeSampleGroupOutput);
-    updateRootPath(output_path, FileScope::EFileScopeInjectionOutput);
+    updateRootPaths();
   }
 
   void Filenames::addFileName(const std::string& id, const std::string& default_name, FileScope file_scope)
@@ -68,8 +64,9 @@ namespace SmartPeak
     if (file_names_.find(id) == file_names_.end())
     {
       FileName f{ default_name , file_scope };
-      updateFullPathName(f);
       file_names_.insert_or_assign(id, f);
+      updateRootPaths();
+      updateFileVariants();
     }
   }
 
@@ -78,7 +75,17 @@ namespace SmartPeak
     return file_names_.at(id).full_path_.generic_string();
   }
 
-  void Filenames::updateRootPath(const std::string& dir, FileScope file_scope)
+  void Filenames::updateRootPaths()
+  {
+    updateRootPath(main_dir_, FileScope::EFileScopeMain);
+    updateRootPath(mzml_input_path_, FileScope::EFileScopeMzMLInput);
+    updateRootPath(input_path_, FileScope::EFileScopeInjectionInput);
+    updateRootPath(input_path_, FileScope::EFileScopeSampleGroupInput);
+    updateRootPath(output_path_, FileScope::EFileScopeSampleGroupOutput);
+    updateRootPath(output_path_, FileScope::EFileScopeInjectionOutput);
+  }
+
+  void Filenames::updateRootPath(const std::filesystem::path& dir, FileScope file_scope)
   {
     for (auto& f : file_names_)
     {
@@ -88,6 +95,15 @@ namespace SmartPeak
         updateFullPathName(f.second);
       }
     }
+  }
+
+  void Filenames::updateFileVariants()
+  {
+    updateFileVariant(input_mzML_filename_, FileScope::EFileScopeMzMLInput);
+    updateFileVariant(input_inj_name_, FileScope::EFileScopeInjectionInput);
+    updateFileVariant(input_sample_name_, FileScope::EFileScopeSampleGroupInput);
+    updateFileVariant(output_sample_name_, FileScope::EFileScopeSampleGroupOutput);
+    updateFileVariant(output_inj_name_, FileScope::EFileScopeInjectionOutput);
   }
 
   void Filenames::updateFileVariant(const std::string& variant, FileScope file_scope)

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -31,6 +31,20 @@
 namespace SmartPeak
 {
 
+
+  std::map<std::string, Filenames::Tag> Filenames::string_to_tag_ =
+  {
+    { "MAIN_DIR", Filenames::Tag::MAIN_DIR },
+    { "MZML_INPUT_PATH", Filenames::Tag::MZML_INPUT_PATH },
+    { "FEATURES_INPUT_PATH", Filenames::Tag::FEATURES_INPUT_PATH },
+    { "FEATURES_OUTPUT_PATH", Filenames::Tag::FEATURES_OUTPUT_PATH },
+    { "INPUT_MZML_FILENAME", Filenames::Tag::INPUT_MZML_FILENAME },
+    { "INPUT_INJECTION_NAME", Filenames::Tag::INPUT_INJECTION_NAME },
+    { "OUTPUT_INJECTION_NAME", Filenames::Tag::OUTPUT_INJECTION_NAME },
+    { "INPUT_GROUP_NAME", Filenames::Tag::INPUT_GROUP_NAME },
+    { "OUTPUT_GROUP_NAME", Filenames::Tag::OUTPUT_GROUP_NAME }
+  };
+
   void Filenames::addFileName(const std::string& id, const std::string& name_pattern)
   {
     if (file_names_.find(id) == file_names_.end())
@@ -72,11 +86,12 @@ namespace SmartPeak
       std::regex search_regex("\\$\\{([^}]*)\\}");
       std::smatch match;
       std::string search_string = file_pattern;
-      while (std::regex_search(search_string, match, search_regex)) {
+      while (std::regex_search(search_string, match, search_regex))
+      {
         std::string replace_with;
-        if (tags_.count(match.str(1)))
+        if (string_to_tag_.count(match.str(1)))
         {
-          replace_with = tags_[match.str(1)];
+          replace_with = tags_[string_to_tag_[match.str(1)]];
         }
         std::regex replace_regex(std::string("\\$\\{") + match.str(1) + std::string("\\}"));
         file_pattern = std::regex_replace(file_pattern, replace_regex, replace_with);
@@ -103,9 +118,9 @@ namespace SmartPeak
     return file_ids;
   }
 
-  void Filenames::setTag(const std::string& tag_id, const std::string& value)
+  void Filenames::setTag(Tag tag, const std::string& value)
   {
-    tags_[tag_id] = value;
+    tags_[tag] = value;
     updateFullPaths();
   }
 

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -75,7 +75,7 @@ namespace SmartPeak
 
   std::string Filenames::getFullPathName(const std::string& id) const
   {
-    return file_names_.at(id).full_path_;
+    return file_names_.at(id).full_path_.generic_string();
   }
 
   void Filenames::updateRootPath(const std::string& dir, FileScope file_scope)
@@ -119,11 +119,11 @@ namespace SmartPeak
       filename.full_path_.clear();
       if (!filename.root_path_.empty())
       {
-        filename.full_path_ += filename.root_path_ + "/";
+        filename.full_path_ = filename.root_path_;
       }
       if (!filename.file_variant_.empty())
       {
-        filename.full_path_ += filename.file_variant_;
+        filename.full_path_ /= filename.file_variant_;
       }
       filename.full_path_ += filename.default_name_;
     }

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -157,4 +157,13 @@ namespace SmartPeak
     updateFileVariants();
   }
 
+  std::vector<std::string> Filenames::getFileIds() const
+  {
+    std::vector<std::string> file_ids;
+    for (const auto& key : file_names_)
+    {
+      file_ids.push_back(key.first);
+    }
+    return file_ids;
+  }
 }

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -118,7 +118,7 @@ namespace SmartPeak
     }
   }
 
-  void Filenames::setFullPathName(const std::string& id, const std::string& full_path)
+  void Filenames::setFullPathName(const std::string& id, const std::filesystem::path& full_path)
   {
     if (file_names_.find(id) == file_names_.end())
     {

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -29,11 +29,7 @@
 
 namespace SmartPeak
 {
-  void Filenames::setPathsAndNames(
-    const std::string& main_dir,
-    const std::string& mzml_input_path,
-    const std::string& features_input_path,
-    const std::string& output_path,
+  void Filenames::setFileVariants(
     const std::string& input_mzML_filename,
     const std::string& input_inj_name,
     const std::string& output_inj_name,
@@ -46,10 +42,6 @@ namespace SmartPeak
     setFileVariant(input_sample_name, FileScope::EFileScopeSampleGroupInput);
     setFileVariant(output_sample_name, FileScope::EFileScopeSampleGroupOutput);
     setFileVariant(output_inj_name, FileScope::EFileScopeInjectionOutput);
-    setRootPaths(main_dir,
-                mzml_input_path,
-                features_input_path,
-                output_path);
   }
 
   void Filenames::setRootPaths(

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -70,7 +70,7 @@ namespace SmartPeak
     }
   }
 
-  std::string Filenames::getFullPath(const std::string& id) const
+  std::filesystem::path Filenames::getFullPath(const std::string& id) const
   {
     return file_names_.at(id).full_path_.generic_string();
   }
@@ -153,6 +153,8 @@ namespace SmartPeak
   {
     for (const auto& p : other.file_names_)
       file_names_.emplace(p.first, p.second);
+    updateRootPaths();
+    updateFileVariants();
   }
 
 }

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -70,7 +70,7 @@ namespace SmartPeak
     }
   }
 
-  std::string Filenames::getFullPathName(const std::string& id) const
+  std::string Filenames::getFullPath(const std::string& id) const
   {
     return file_names_.at(id).full_path_.generic_string();
   }
@@ -92,7 +92,7 @@ namespace SmartPeak
       if (f.second.file_scope_ == file_scope)
       {
         f.second.root_path_ = dir;
-        updateFullPathName(f.second);
+        updateFullPath(f.second);
       }
     }
   }
@@ -113,12 +113,12 @@ namespace SmartPeak
       if (f.second.file_scope_ == file_scope)
       {
         f.second.file_variant_ = variant;
-        updateFullPathName(f.second);
+        updateFullPath(f.second);
       }
     }
   }
 
-  void Filenames::setFullPathName(const std::string& id, const std::filesystem::path& full_path)
+  void Filenames::setFullPath(const std::string& id, const std::filesystem::path& full_path)
   {
     if (file_names_.find(id) == file_names_.end())
     {
@@ -128,7 +128,7 @@ namespace SmartPeak
     file_names_.at(id).full_path_ = full_path;
   }
 
-  void Filenames::updateFullPathName(FileName& filename)
+  void Filenames::updateFullPath(FileName& filename)
   {
     if (!filename.full_path_override_)
     {

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -140,8 +140,12 @@ namespace SmartPeak
       if (!filename.file_variant_.empty())
       {
         filename.full_path_ /= filename.file_variant_;
+        filename.full_path_ += filename.default_name_;
       }
-      filename.full_path_ += filename.default_name_;
+      else
+      {
+        filename.full_path_ /= filename.default_name_;
+      }
     }
   }
 

--- a/src/smartpeak/source/core/Filenames.cpp
+++ b/src/smartpeak/source/core/Filenames.cpp
@@ -37,30 +37,30 @@ namespace SmartPeak
     const std::string& output_sample_name
   )
   {
-    setFileVariant(input_mzML_filename, FileScope::EFileScopeMzMLInput);
-    setFileVariant(input_inj_name, FileScope::EFileScopeInjectionInput);
-    setFileVariant(input_sample_name, FileScope::EFileScopeSampleGroupInput);
-    setFileVariant(output_sample_name, FileScope::EFileScopeSampleGroupOutput);
-    setFileVariant(output_inj_name, FileScope::EFileScopeInjectionOutput);
+    updateFileVariant(input_mzML_filename, FileScope::EFileScopeMzMLInput);
+    updateFileVariant(input_inj_name, FileScope::EFileScopeInjectionInput);
+    updateFileVariant(input_sample_name, FileScope::EFileScopeSampleGroupInput);
+    updateFileVariant(output_sample_name, FileScope::EFileScopeSampleGroupOutput);
+    updateFileVariant(output_inj_name, FileScope::EFileScopeInjectionOutput);
   }
 
   void Filenames::setRootPaths(
     const std::string& main_dir,
     const std::string& mzml_input_path,
-    const std::string& features_input_path,
+    const std::string& input_path,
     const std::string& output_path
   )
   {
     mzml_input_path_ = mzml_input_path;
-    features_input_path_ = features_input_path;
+    input_path_ = input_path;
     output_path_ = output_path;
     main_dir_ = main_dir;
-    setRootPath(main_dir, FileScope::EFileScopeMain);
-    setRootPath(mzml_input_path, FileScope::EFileScopeMzMLInput);
-    setRootPath(features_input_path, FileScope::EFileScopeInjectionInput);
-    setRootPath(features_input_path, FileScope::EFileScopeSampleGroupInput);
-    setRootPath(output_path, FileScope::EFileScopeSampleGroupOutput);
-    setRootPath(output_path, FileScope::EFileScopeInjectionOutput);
+    updateRootPath(main_dir, FileScope::EFileScopeMain);
+    updateRootPath(mzml_input_path, FileScope::EFileScopeMzMLInput);
+    updateRootPath(input_path, FileScope::EFileScopeInjectionInput);
+    updateRootPath(input_path, FileScope::EFileScopeSampleGroupInput);
+    updateRootPath(output_path, FileScope::EFileScopeSampleGroupOutput);
+    updateRootPath(output_path, FileScope::EFileScopeInjectionOutput);
   }
 
   void Filenames::addFileName(const std::string& id, const std::string& default_name, FileScope file_scope)
@@ -78,7 +78,7 @@ namespace SmartPeak
     return file_names_.at(id).full_path_;
   }
 
-  void Filenames::setRootPath(const std::string& dir, FileScope file_scope)
+  void Filenames::updateRootPath(const std::string& dir, FileScope file_scope)
   {
     for (auto& f : file_names_)
     {
@@ -90,7 +90,7 @@ namespace SmartPeak
     }
   }
 
-  void Filenames::setFileVariant(const std::string& variant, FileScope file_scope)
+  void Filenames::updateFileVariant(const std::string& variant, FileScope file_scope)
   {
     for (auto& f : file_names_)
     {

--- a/src/smartpeak/source/core/RawDataProcessor.cpp
+++ b/src/smartpeak/source/core/RawDataProcessor.cpp
@@ -156,7 +156,7 @@ namespace SmartPeak
 
     // # load chromatograms
     OpenMS::MSExperiment chromatograms;
-    if (filenames.getFullPathName("mzML_i").size()) {
+    if (filenames.getFullPath("mzML_i").size()) {
       if (params_I.at("mzML").size()) {
         // # convert parameters
         std::map<std::string, CastValue> mzML_params;
@@ -167,8 +167,8 @@ namespace SmartPeak
         }
         // Deal with ChromeleonFile format
         if (mzML_params.count("format") && mzML_params.at("format").s_ == "ChromeleonFile") {
-          const size_t pos = filenames.getFullPathName("mzML_i").rfind(".");
-          std::string txt_name = filenames.getFullPathName("mzML_i");
+          const size_t pos = filenames.getFullPath("mzML_i").rfind(".");
+          std::string txt_name = filenames.getFullPath("mzML_i");
           if (pos != std::string::npos) {
             txt_name.replace(txt_name.cbegin() + pos + 1, txt_name.cend(), "txt"); // replace extension
           }
@@ -184,8 +184,8 @@ namespace SmartPeak
         // Deal with .mzXML format
         else if (mzML_params.count("format") && mzML_params.at("format").s_ == "XML") 
         {
-          const size_t pos = filenames.getFullPathName("mzML_i").rfind(".");
-          std::string txt_name = filenames.getFullPathName("mzML_i");
+          const size_t pos = filenames.getFullPath("mzML_i").rfind(".");
+          std::string txt_name = filenames.getFullPath("mzML_i");
           if (pos != std::string::npos) {
             txt_name.replace(txt_name.cbegin() + pos + 1, txt_name.cend(), "xml"); // replace extension
           }
@@ -196,15 +196,15 @@ namespace SmartPeak
         else 
         {
           OpenMS::FileHandler fh;
-          LOGI << "Loading: " << filenames.getFullPathName("mzML_i");
-          fh.loadExperiment(filenames.getFullPathName("mzML_i"), chromatograms);
+          LOGI << "Loading: " << filenames.getFullPath("mzML_i");
+          fh.loadExperiment(filenames.getFullPath("mzML_i"), chromatograms);
         }
       }
       else 
       {
         OpenMS::FileHandler fh;
-        LOGI << "Loading: " << filenames.getFullPathName("mzML_i");
-        fh.loadExperiment(filenames.getFullPathName("mzML_i"), chromatograms); //TODO:try-catch (SIGABRT)
+        LOGI << "Loading: " << filenames.getFullPath("mzML_i");
+        fh.loadExperiment(filenames.getFullPath("mzML_i"), chromatograms); //TODO:try-catch (SIGABRT)
       }
     }
 
@@ -330,9 +330,9 @@ namespace SmartPeak
   {
     LOGD << "START storeMzML";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Storing: " << filenames.getFullPathName("mzML_i");
+    LOGI << "Storing: " << filenames.getFullPath("mzML_i");
 
-    if (filenames.getFullPathName("mzML_i").empty()) {
+    if (filenames.getFullPath("mzML_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END storeMzML";
       return;
@@ -341,11 +341,11 @@ namespace SmartPeak
     try {
       OpenMS::MzMLFile mzmlfile;
       if (rawDataHandler_IO.getChromatogramMap().size()) {
-        mzmlfile.store(filenames.getFullPathName("mzML_i"), rawDataHandler_IO.getChromatogramMap());
+        mzmlfile.store(filenames.getFullPath("mzML_i"), rawDataHandler_IO.getChromatogramMap());
       }
       else 
       {
-        mzmlfile.store(filenames.getFullPathName("mzML_i"), rawDataHandler_IO.getExperiment());
+        mzmlfile.store(filenames.getFullPath("mzML_i"), rawDataHandler_IO.getExperiment());
       }
     }
     catch (const std::exception& e) {
@@ -368,15 +368,15 @@ namespace SmartPeak
   {
     LOGD << "START LoadFeatures";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Loading: " << filenames.getFullPathName("featureXML_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureXML_i");
 
-    if (filenames.getFullPathName("featureXML_i").empty()) {
+    if (filenames.getFullPath("featureXML_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END LoadFeatures";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.getFullPathName("featureXML_i"))) {
+    if (!InputDataValidation::fileExists(filenames.getFullPath("featureXML_i"))) {
       LOGE << "File not found";
       LOGD << "END LoadFeatures";
       return;
@@ -384,7 +384,7 @@ namespace SmartPeak
 
     try {
       OpenMS::FeatureXMLFile featurexml;
-      featurexml.load(filenames.getFullPathName("featureXML_i"), rawDataHandler_IO.getFeatureMapHistory());
+      featurexml.load(filenames.getFullPath("featureXML_i"), rawDataHandler_IO.getFeatureMapHistory());
       // NOTE: setPrimaryMSRunPath() is needed for calculate_calibration
       rawDataHandler_IO.getFeatureMapHistory().setPrimaryMSRunPath({ rawDataHandler_IO.getMetaData().getFilename() });
       rawDataHandler_IO.makeFeatureMapFromHistory();
@@ -413,9 +413,9 @@ namespace SmartPeak
   {
     LOGD << "START storeFeatureMap";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Storing: " << filenames.getFullPathName("featureXML_o");
+    LOGI << "Storing: " << filenames.getFullPath("featureXML_o");
 
-    if (filenames.getFullPathName("featureXML_o").empty()) {
+    if (filenames.getFullPath("featureXML_o").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END storeFeatureMap";
       return;
@@ -424,7 +424,7 @@ namespace SmartPeak
     try {
       // Store outfile as featureXML
       OpenMS::FeatureXMLFile featurexml;
-      featurexml.store(filenames.getFullPathName("featureXML_o"), rawDataHandler_IO.getFeatureMapHistory());
+      featurexml.store(filenames.getFullPath("featureXML_o"), rawDataHandler_IO.getFeatureMapHistory());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -446,15 +446,15 @@ namespace SmartPeak
   {
     LOGD << "START LoadAnnotations";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Loading: " << filenames.getFullPathName("mzTab_i");
+    LOGI << "Loading: " << filenames.getFullPath("mzTab_i");
 
-    if (filenames.getFullPathName("mzTab_i").empty()) {
+    if (filenames.getFullPath("mzTab_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END LoadAnnotations";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.getFullPathName("mzTab_i"))) {
+    if (!InputDataValidation::fileExists(filenames.getFullPath("mzTab_i"))) {
       LOGE << "File not found";
       LOGD << "END LoadAnnotations";
       return;
@@ -462,7 +462,7 @@ namespace SmartPeak
 
     try {
       OpenMS::MzTabFile mztabfile;
-      mztabfile.load(filenames.getFullPathName("mzTab_i"), rawDataHandler_IO.getMzTab());
+      mztabfile.load(filenames.getFullPath("mzTab_i"), rawDataHandler_IO.getMzTab());
       rawDataHandler_IO.updateFeatureMapHistory();
     }
     catch (const std::exception& e) {
@@ -487,9 +487,9 @@ namespace SmartPeak
   {
     LOGD << "START StoreAnnotations";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Storing: " << filenames.getFullPathName("mzTab_o");
+    LOGI << "Storing: " << filenames.getFullPath("mzTab_o");
 
-    if (filenames.getFullPathName("mzTab_o").empty()) {
+    if (filenames.getFullPath("mzTab_o").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END StoreAnnotations";
       return;
@@ -498,7 +498,7 @@ namespace SmartPeak
     try {
       // Store outfile as mzTab
       OpenMS::MzTabFile mztabfile;
-      mztabfile.store(filenames.getFullPathName("mzTab_o"), rawDataHandler_IO.getMzTab());
+      mztabfile.store(filenames.getFullPath("mzTab_o"), rawDataHandler_IO.getMzTab());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -786,7 +786,7 @@ namespace SmartPeak
     RawDataHandler& rawDataHandler = application_handler->sequenceHandler_.getSequence().at(0).getRawData();
     transitions_observable_ = &(application_handler->sequenceHandler_);
     Filenames filenames;
-    filenames.setFullPathName("traML_csv_i", filename);
+    filenames.setFullPath("traML_csv_i", filename);
     process(rawDataHandler, {}, filenames);
     return true;
   }
@@ -833,16 +833,16 @@ namespace SmartPeak
 
     const std::string format = format_param->getValueAsString();
 
-    LOGI << "Loading " << filenames.getFullPathName("traML_csv_i");
+    LOGI << "Loading " << filenames.getFullPath("traML_csv_i");
     LOGI << "Format: " << format;
 
-    if (filenames.getFullPathName("traML_csv_i").empty()) {
+    if (filenames.getFullPath("traML_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END loadTraML";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.getFullPathName("traML_csv_i"))) {
+    if (!InputDataValidation::fileExists(filenames.getFullPath("traML_csv_i"))) {
       LOGE << "File not found";
       LOGD << "END loadTraML";
       return;
@@ -855,7 +855,7 @@ namespace SmartPeak
         rawDataHandler_IO.getTargetedExperiment().clear(true);
         OpenMS::TransitionTSVFile tsvfile;
         tsvfile.convertTSVToTargetedExperiment(
-          filenames.getFullPathName("traML_csv_i").c_str(),
+          filenames.getFullPath("traML_csv_i").c_str(),
           OpenMS::FileTypes::TRAML,
           rawDataHandler_IO.getTargetedExperiment()
         );
@@ -866,7 +866,7 @@ namespace SmartPeak
         // Transitions are appended to the existing experiment in OpenMS
         rawDataHandler_IO.getTargetedExperiment().clear(true);
         OpenMS::TraMLFile tramlfile;
-        tramlfile.load(filenames.getFullPathName("traML_csv_i"), rawDataHandler_IO.getTargetedExperiment());
+        tramlfile.load(filenames.getFullPath("traML_csv_i"), rawDataHandler_IO.getTargetedExperiment());
         if (transitions_observable_) transitions_observable_->notifyTransitionsUpdated();
       }
       else 
@@ -897,37 +897,37 @@ namespace SmartPeak
   {
     LOGD << "START loadFeatureFilter";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Loading: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureFilterComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureFilterComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureFilterComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureFilterComponents_csv_i").empty() &&
-        filenames.getFullPathName("featureFilterComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureFilterComponents_csv_i").empty() &&
+        filenames.getFullPath("featureFilterComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureFilter";
       return;
     }
 
-    if (filenames.getFullPathName("featureFilterComponents_csv_i").size() &&
-        !InputDataValidation::fileExists(filenames.getFullPathName("featureFilterComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureFilterComponents_csv_i");
+    if (filenames.getFullPath("featureFilterComponents_csv_i").size() &&
+        !InputDataValidation::fileExists(filenames.getFullPath("featureFilterComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureFilterComponents_csv_i");
       LOGD << "END loadFeatureFilter";
       return;
     }
 
-    if (filenames.getFullPathName("featureFilterComponentGroups_csv_i").size() &&
-        !InputDataValidation::fileExists(filenames.getFullPathName("featureFilterComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureFilterComponentGroups_csv_i");
+    if (filenames.getFullPath("featureFilterComponentGroups_csv_i").size() &&
+        !InputDataValidation::fileExists(filenames.getFullPath("featureFilterComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureFilterComponentGroups_csv_i");
       LOGD << "END loadFeatureFilter";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPathName("featureFilterComponents_csv_i"), rawDataHandler_IO.getFeatureFilter(), false);
+      if (filenames.getFullPath("featureFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureFilterComponents_csv_i"), rawDataHandler_IO.getFeatureFilter(), false);
       }
-      if (filenames.getFullPathName("featureFilterComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPathName("featureFilterComponentGroups_csv_i"), rawDataHandler_IO.getFeatureFilter(), true);
+      if (filenames.getFullPath("featureFilterComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPath("featureFilterComponentGroups_csv_i"), rawDataHandler_IO.getFeatureFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -955,37 +955,37 @@ namespace SmartPeak
   {
     LOGD << "START loadFeatureQC";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureQCComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureQCComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureQCComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureQCComponents_csv_i").empty() &&
-        filenames.getFullPathName("featureQCComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureQCComponents_csv_i").empty() &&
+        filenames.getFullPath("featureQCComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureQC";
       return;
     }
 
-    if (filenames.getFullPathName("featureQCComponents_csv_i").size() &&
-        !InputDataValidation::fileExists(filenames.getFullPathName("featureQCComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureQCComponents_csv_i");
+    if (filenames.getFullPath("featureQCComponents_csv_i").size() &&
+        !InputDataValidation::fileExists(filenames.getFullPath("featureQCComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureQCComponents_csv_i");
       LOGD << "END loadFeatureQC";
       return;
     }
 
-    if (filenames.getFullPathName("featureQCComponentGroups_csv_i").size() &&
-        !InputDataValidation::fileExists(filenames.getFullPathName("featureQCComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureQCComponentGroups_csv_i");
+    if (filenames.getFullPath("featureQCComponentGroups_csv_i").size() &&
+        !InputDataValidation::fileExists(filenames.getFullPath("featureQCComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureQCComponentGroups_csv_i");
       LOGD << "END loadFeatureQC";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPathName("featureQCComponents_csv_i"), rawDataHandler_IO.getFeatureQC(), false);
+      if (filenames.getFullPath("featureQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureQCComponents_csv_i"), rawDataHandler_IO.getFeatureQC(), false);
       }
-      if (filenames.getFullPathName("featureQCComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPathName("featureQCComponentGroups_csv_i"), rawDataHandler_IO.getFeatureQC(), true);
+      if (filenames.getFullPath("featureQCComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPath("featureQCComponentGroups_csv_i"), rawDataHandler_IO.getFeatureQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1013,11 +1013,11 @@ namespace SmartPeak
   {
     LOGD << "START storeFeatureFilter";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Storing: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureFilterComponentGroups_csv_i");
+    LOGI << "Storing: " << filenames.getFullPath("featureFilterComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureFilterComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureFilterComponents_csv_i").empty() &&
-      filenames.getFullPathName("featureFilterComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureFilterComponents_csv_i").empty() &&
+      filenames.getFullPath("featureFilterComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureFilter";
       return;
@@ -1025,11 +1025,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPathName("featureFilterComponents_csv_i"), rawDataHandler_IO.getFeatureFilter(), false);
+      if (filenames.getFullPath("featureFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureFilterComponents_csv_i"), rawDataHandler_IO.getFeatureFilter(), false);
       }
-      if (filenames.getFullPathName("featureFilterComponentGroups_csv_i").size()) {
-        featureQCFile.store(filenames.getFullPathName("featureFilterComponentGroups_csv_i"), rawDataHandler_IO.getFeatureFilter(), true);
+      if (filenames.getFullPath("featureFilterComponentGroups_csv_i").size()) {
+        featureQCFile.store(filenames.getFullPath("featureFilterComponentGroups_csv_i"), rawDataHandler_IO.getFeatureFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1054,11 +1054,11 @@ namespace SmartPeak
   {
     LOGD << "START storeFeatureQC";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureQCComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureQCComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureQCComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureQCComponents_csv_i").empty() &&
-      filenames.getFullPathName("featureQCComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureQCComponents_csv_i").empty() &&
+      filenames.getFullPath("featureQCComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureQC";
       return;
@@ -1066,11 +1066,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPathName("featureQCComponents_csv_i"), rawDataHandler_IO.getFeatureQC(), false);
+      if (filenames.getFullPath("featureQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureQCComponents_csv_i"), rawDataHandler_IO.getFeatureQC(), false);
       }
-      if (filenames.getFullPathName("featureQCComponentGroups_csv_i").size()) {
-        featureQCFile.store(filenames.getFullPathName("featureQCComponentGroups_csv_i"), rawDataHandler_IO.getFeatureQC(), true);
+      if (filenames.getFullPath("featureQCComponentGroups_csv_i").size()) {
+        featureQCFile.store(filenames.getFullPath("featureQCComponentGroups_csv_i"), rawDataHandler_IO.getFeatureQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1095,7 +1095,7 @@ namespace SmartPeak
     }
     RawDataHandler& rawDataHandler = application_handler->sequenceHandler_.getSequence().at(0).getRawData();
     Filenames filenames;
-    filenames.setFullPathName("referenceData_csv_i", filename);
+    filenames.setFullPath("referenceData_csv_i", filename);
     process(rawDataHandler, {}, filenames);
     return true;
   }
@@ -1108,21 +1108,21 @@ namespace SmartPeak
   {
     LOGD << "START loadValidationData";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Loading: " << filenames.getFullPathName("referenceData_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("referenceData_csv_i");
 
-    if (filenames.getFullPathName("referenceData_csv_i").empty()) {
+    if (filenames.getFullPath("referenceData_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END loadValidationData";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.getFullPathName("referenceData_csv_i"))) {
+    if (!InputDataValidation::fileExists(filenames.getFullPath("referenceData_csv_i"))) {
       LOGE << "File not found";
       LOGD << "END loadValidationData";
       return;
     }
 
-    io::CSVReader<17, io::trim_chars<>, io::no_quote_escape<','>> in(filenames.getFullPathName("referenceData_csv_i"));
+    io::CSVReader<17, io::trim_chars<>, io::no_quote_escape<','>> in(filenames.getFullPath("referenceData_csv_i"));
 
     const std::string s_sample_index{ "sample_index" };
     const std::string s_original_filename{ "original_filename" };
@@ -1252,7 +1252,7 @@ namespace SmartPeak
     RawDataHandler& rawDataHandler = application_handler->sequenceHandler_.getSequence().at(0).getRawData();
     parameters_observable_ = &(application_handler->sequenceHandler_);
     Filenames filenames;
-    filenames.setFullPathName("parameters_csv_i", filename);
+    filenames.setFullPath("parameters_csv_i", filename);
     process(rawDataHandler, {}, filenames);
     return true;
   }
@@ -1265,22 +1265,22 @@ namespace SmartPeak
   {
     LOGD << "START readRawDataProcessingParameters";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Loading: " << filenames.getFullPathName("parameters_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("parameters_csv_i");
 
-    if (filenames.getFullPathName("parameters_csv_i").empty()) {
+    if (filenames.getFullPath("parameters_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END readRawDataProcessingParameters";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.getFullPathName("parameters_csv_i"))) {
+    if (!InputDataValidation::fileExists(filenames.getFullPath("parameters_csv_i"))) {
       LOGE << "File not found";
       LOGD << "END readRawDataProcessingParameters";
       return;
     }
 
     try {
-      ParametersParser::read(filenames.getFullPathName("parameters_csv_i"), rawDataHandler_IO.getParameters());
+      ParametersParser::read(filenames.getFullPath("parameters_csv_i"), rawDataHandler_IO.getParameters());
       sanitizeParameters(rawDataHandler_IO.getParameters());
       if (parameters_observable_) parameters_observable_->notifyParametersUpdated();
     }
@@ -1353,7 +1353,7 @@ namespace SmartPeak
     }
     RawDataHandler& rawDataHandler = application_handler->sequenceHandler_.getSequence().at(0).getRawData();
     Filenames filenames;
-    filenames.setFullPathName("parameters_csv_i", filename);
+    filenames.setFullPath("parameters_csv_i", filename);
     process(rawDataHandler, {}, filenames);
     return true;
   }
@@ -1368,14 +1368,14 @@ namespace SmartPeak
     Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Storing " << filename_;
 
-    if (filenames.getFullPathName("parameters_csv_i").empty()) {
+    if (filenames.getFullPath("parameters_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END readRawDataProcessingParameters";
       return;
     }
 
     try {
-      ParametersParser::write(filenames.getFullPathName("parameters_csv_i"), rawDataHandler_IO.getParameters());
+      ParametersParser::write(filenames.getFullPath("parameters_csv_i"), rawDataHandler_IO.getParameters());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -2433,8 +2433,8 @@ namespace SmartPeak
       params.setValue("output_format", "traML");
       params.setValue("deisotoping:use_deisotoper", "true");
       targeted_spectra_extractor.setParameters(params);
-      LOGI << "Storing: " << filenames.getFullPathName("traML_csv_o");
-      targeted_spectra_extractor.storeSpectraTraML(filenames.getFullPathName("traML_csv_o"), ms1_merged_features, ms2_merged_features);
+      LOGI << "Storing: " << filenames.getFullPath("traML_csv_o");
+      targeted_spectra_extractor.storeSpectraTraML(filenames.getFullPath("traML_csv_o"), ms1_merged_features, ms2_merged_features);
 
       // build MS1/MS2 features
       OpenMS::FeatureMap ms1_ms2_features;

--- a/src/smartpeak/source/core/RawDataProcessor.cpp
+++ b/src/smartpeak/source/core/RawDataProcessor.cpp
@@ -135,6 +135,11 @@ namespace SmartPeak
     return ParameterSet(param_struct);
   }
 
+  void LoadRawData::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("mzML_i", ".mzML", Filenames::FileScope::EFileScopeMzMLInput);
+  };
+
   void LoadRawData::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
@@ -150,7 +155,7 @@ namespace SmartPeak
 
     // # load chromatograms
     OpenMS::MSExperiment chromatograms;
-    if (filenames.mzML_i.size()) {
+    if (filenames.getFullPathName("mzML_i").size()) {
       if (params_I.at("mzML").size()) {
         // # convert parameters
         std::map<std::string, CastValue> mzML_params;
@@ -161,8 +166,8 @@ namespace SmartPeak
         }
         // Deal with ChromeleonFile format
         if (mzML_params.count("format") && mzML_params.at("format").s_ == "ChromeleonFile") {
-          const size_t pos = filenames.mzML_i.rfind(".");
-          std::string txt_name = filenames.mzML_i;
+          const size_t pos = filenames.getFullPathName("mzML_i").rfind(".");
+          std::string txt_name = filenames.getFullPathName("mzML_i");
           if (pos != std::string::npos) {
             txt_name.replace(txt_name.cbegin() + pos + 1, txt_name.cend(), "txt"); // replace extension
           }
@@ -178,8 +183,8 @@ namespace SmartPeak
         // Deal with .mzXML format
         else if (mzML_params.count("format") && mzML_params.at("format").s_ == "XML") 
         {
-          const size_t pos = filenames.mzML_i.rfind(".");
-          std::string txt_name = filenames.mzML_i;
+          const size_t pos = filenames.getFullPathName("mzML_i").rfind(".");
+          std::string txt_name = filenames.getFullPathName("mzML_i");
           if (pos != std::string::npos) {
             txt_name.replace(txt_name.cbegin() + pos + 1, txt_name.cend(), "xml"); // replace extension
           }
@@ -190,15 +195,15 @@ namespace SmartPeak
         else 
         {
           OpenMS::FileHandler fh;
-          LOGI << "Loading: " << filenames.mzML_i;
-          fh.loadExperiment(filenames.mzML_i, chromatograms);
+          LOGI << "Loading: " << filenames.getFullPathName("mzML_i");
+          fh.loadExperiment(filenames.getFullPathName("mzML_i"), chromatograms);
         }
       }
       else 
       {
         OpenMS::FileHandler fh;
-        LOGI << "Loading: " << filenames.mzML_i;
-        fh.loadExperiment(filenames.mzML_i, chromatograms); //TODO:try-catch (SIGABRT)
+        LOGI << "Loading: " << filenames.getFullPathName("mzML_i");
+        fh.loadExperiment(filenames.getFullPathName("mzML_i"), chromatograms); //TODO:try-catch (SIGABRT)
       }
     }
 
@@ -311,6 +316,11 @@ namespace SmartPeak
     LOGD << "END extractMetaData";
   }
 
+  void StoreRawData::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("mzML_i", ".mzML", Filenames::FileScope::EFileScopeMzMLInput);
+  };
+
   void StoreRawData::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
@@ -318,9 +328,9 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeMzML";
-    LOGI << "Storing: " << filenames.mzML_i;
+    LOGI << "Storing: " << filenames.getFullPathName("mzML_i");
 
-    if (filenames.mzML_i.empty()) {
+    if (filenames.getFullPathName("mzML_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END storeMzML";
       return;
@@ -329,11 +339,11 @@ namespace SmartPeak
     try {
       OpenMS::MzMLFile mzmlfile;
       if (rawDataHandler_IO.getChromatogramMap().size()) {
-        mzmlfile.store(filenames.mzML_i, rawDataHandler_IO.getChromatogramMap());
+        mzmlfile.store(filenames.getFullPathName("mzML_i"), rawDataHandler_IO.getChromatogramMap());
       }
       else 
       {
-        mzmlfile.store(filenames.mzML_i, rawDataHandler_IO.getExperiment());
+        mzmlfile.store(filenames.getFullPathName("mzML_i"), rawDataHandler_IO.getExperiment());
       }
     }
     catch (const std::exception& e) {
@@ -343,6 +353,11 @@ namespace SmartPeak
     LOGD << "END storeMzML";
   }
 
+  void LoadFeatures::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureXML_i", ".featureXML", Filenames::FileScope::EFileScopeInjectionInput);
+  };
+
   void LoadFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
@@ -350,15 +365,15 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START LoadFeatures";
-    LOGI << "Loading: " << filenames.featureXML_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureXML_i");
 
-    if (filenames.featureXML_i.empty()) {
+    if (filenames.getFullPathName("featureXML_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END LoadFeatures";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.featureXML_i)) {
+    if (!InputDataValidation::fileExists(filenames.getFullPathName("featureXML_i"))) {
       LOGE << "File not found";
       LOGD << "END LoadFeatures";
       return;
@@ -366,7 +381,7 @@ namespace SmartPeak
 
     try {
       OpenMS::FeatureXMLFile featurexml;
-      featurexml.load(filenames.featureXML_i, rawDataHandler_IO.getFeatureMapHistory());
+      featurexml.load(filenames.getFullPathName("featureXML_i"), rawDataHandler_IO.getFeatureMapHistory());
       // NOTE: setPrimaryMSRunPath() is needed for calculate_calibration
       rawDataHandler_IO.getFeatureMapHistory().setPrimaryMSRunPath({ rawDataHandler_IO.getMetaData().getFilename() });
       rawDataHandler_IO.makeFeatureMapFromHistory();
@@ -382,6 +397,11 @@ namespace SmartPeak
     LOGD << "END LoadFeatures";
   }
 
+  void StoreFeatures::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureXML_o", ".featureXML", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
@@ -389,9 +409,9 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureMap";
-    LOGI << "Storing: " << filenames.featureXML_o;
+    LOGI << "Storing: " << filenames.getFullPathName("featureXML_o");
 
-    if (filenames.featureXML_o.empty()) {
+    if (filenames.getFullPathName("featureXML_o").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END storeFeatureMap";
       return;
@@ -400,7 +420,7 @@ namespace SmartPeak
     try {
       // Store outfile as featureXML
       OpenMS::FeatureXMLFile featurexml;
-      featurexml.store(filenames.featureXML_o, rawDataHandler_IO.getFeatureMapHistory());
+      featurexml.store(filenames.getFullPathName("featureXML_o"), rawDataHandler_IO.getFeatureMapHistory());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -409,6 +429,11 @@ namespace SmartPeak
     LOGD << "END storeFeatureMap";
   }
 
+  void LoadAnnotations::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("mzTab_i", ".mzTab", Filenames::FileScope::EFileScopeInjectionInput);
+  };
+
   void LoadAnnotations::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
@@ -416,15 +441,15 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START LoadAnnotations";
-    LOGI << "Loading: " << filenames.mzTab_i;
+    LOGI << "Loading: " << filenames.getFullPathName("mzTab_i");
 
-    if (filenames.mzTab_i.empty()) {
+    if (filenames.getFullPathName("mzTab_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END LoadAnnotations";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.mzTab_i)) {
+    if (!InputDataValidation::fileExists(filenames.getFullPathName("mzTab_i"))) {
       LOGE << "File not found";
       LOGD << "END LoadAnnotations";
       return;
@@ -432,7 +457,7 @@ namespace SmartPeak
 
     try {
       OpenMS::MzTabFile mztabfile;
-      mztabfile.load(filenames.mzTab_i, rawDataHandler_IO.getMzTab());
+      mztabfile.load(filenames.getFullPathName("mzTab_i"), rawDataHandler_IO.getMzTab());
       rawDataHandler_IO.updateFeatureMapHistory();
     }
     catch (const std::exception& e) {
@@ -444,6 +469,11 @@ namespace SmartPeak
     LOGD << "END LoadAnnotations";
   }
 
+  void StoreAnnotations::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("mzTab_o", ".mzTab", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreAnnotations::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
@@ -451,9 +481,9 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START StoreAnnotations";
-    LOGI << "Storing: " << filenames.mzTab_o;
+    LOGI << "Storing: " << filenames.getFullPathName("mzTab_o");
 
-    if (filenames.mzTab_o.empty()) {
+    if (filenames.getFullPathName("mzTab_o").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END StoreAnnotations";
       return;
@@ -462,7 +492,7 @@ namespace SmartPeak
     try {
       // Store outfile as mzTab
       OpenMS::MzTabFile mztabfile;
-      mztabfile.store(filenames.mzTab_o, rawDataHandler_IO.getMzTab());
+      mztabfile.store(filenames.getFullPathName("mzTab_o"), rawDataHandler_IO.getMzTab());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -745,7 +775,7 @@ namespace SmartPeak
     RawDataHandler& rawDataHandler = application_handler->sequenceHandler_.getSequence().at(0).getRawData();
     transitions_observable_ = &(application_handler->sequenceHandler_);
     Filenames filenames;
-    filenames.traML_csv_i = filename;
+    filenames.setFullPathName("traML_csv_i", filename);
     process(rawDataHandler, {}, filenames);
     return true;
   }
@@ -764,6 +794,11 @@ namespace SmartPeak
     }} });
     return ParameterSet(param_struct);
   }
+
+  void LoadTransitions::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("traML_csv_i", "traML.csv", Filenames::FileScope::EFileScopeMain);
+  };
 
   void LoadTransitions::process(
     RawDataHandler& rawDataHandler_IO,
@@ -787,16 +822,16 @@ namespace SmartPeak
 
     const std::string format = format_param->getValueAsString();
 
-    LOGI << "Loading " << filenames.traML_csv_i;
+    LOGI << "Loading " << filenames.getFullPathName("traML_csv_i");
     LOGI << "Format: " << format;
 
-    if (filenames.traML_csv_i.empty()) {
+    if (filenames.getFullPathName("traML_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END loadTraML";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.traML_csv_i)) {
+    if (!InputDataValidation::fileExists(filenames.getFullPathName("traML_csv_i"))) {
       LOGE << "File not found";
       LOGD << "END loadTraML";
       return;
@@ -809,7 +844,7 @@ namespace SmartPeak
         rawDataHandler_IO.getTargetedExperiment().clear(true);
         OpenMS::TransitionTSVFile tsvfile;
         tsvfile.convertTSVToTargetedExperiment(
-          filenames.traML_csv_i.c_str(),
+          filenames.getFullPathName("traML_csv_i").c_str(),
           OpenMS::FileTypes::TRAML,
           rawDataHandler_IO.getTargetedExperiment()
         );
@@ -820,7 +855,7 @@ namespace SmartPeak
         // Transitions are appended to the existing experiment in OpenMS
         rawDataHandler_IO.getTargetedExperiment().clear(true);
         OpenMS::TraMLFile tramlfile;
-        tramlfile.load(filenames.traML_csv_i, rawDataHandler_IO.getTargetedExperiment());
+        tramlfile.load(filenames.getFullPathName("traML_csv_i"), rawDataHandler_IO.getTargetedExperiment());
         if (transitions_observable_) transitions_observable_->notifyTransitionsUpdated();
       }
       else 
@@ -837,6 +872,12 @@ namespace SmartPeak
     LOGD << "END loadTraML";
   }
 
+  void LoadFeatureFiltersRDP::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureFilterComponents_csv_i", "featureFilterComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureFilterComponentGroups_csv_i", "featureFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   void LoadFeatureFiltersRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
@@ -844,37 +885,37 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureFilter";
-    LOGI << "Loading: " << filenames.featureFilterComponents_csv_i << " and " <<
-      filenames.featureFilterComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureFilterComponentGroups_csv_i");
 
-    if (filenames.featureFilterComponents_csv_i.empty() &&
-        filenames.featureFilterComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureFilterComponents_csv_i").empty() &&
+        filenames.getFullPathName("featureFilterComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureFilter";
       return;
     }
 
-    if (filenames.featureFilterComponents_csv_i.size() &&
-        !InputDataValidation::fileExists(filenames.featureFilterComponents_csv_i)) {
-      LOGE << "File not found: " << filenames.featureFilterComponents_csv_i;
+    if (filenames.getFullPathName("featureFilterComponents_csv_i").size() &&
+        !InputDataValidation::fileExists(filenames.getFullPathName("featureFilterComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureFilterComponents_csv_i");
       LOGD << "END loadFeatureFilter";
       return;
     }
 
-    if (filenames.featureFilterComponentGroups_csv_i.size() &&
-        !InputDataValidation::fileExists(filenames.featureFilterComponentGroups_csv_i)) {
-      LOGE << "File not found: " << filenames.featureFilterComponentGroups_csv_i;
+    if (filenames.getFullPathName("featureFilterComponentGroups_csv_i").size() &&
+        !InputDataValidation::fileExists(filenames.getFullPathName("featureFilterComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureFilterComponentGroups_csv_i");
       LOGD << "END loadFeatureFilter";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureFilterComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.featureFilterComponents_csv_i, rawDataHandler_IO.getFeatureFilter(), false);
+      if (filenames.getFullPathName("featureFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPathName("featureFilterComponents_csv_i"), rawDataHandler_IO.getFeatureFilter(), false);
       }
-      if (filenames.featureFilterComponentGroups_csv_i.size()) {
-        featureQCFile.load(filenames.featureFilterComponentGroups_csv_i, rawDataHandler_IO.getFeatureFilter(), true);
+      if (filenames.getFullPathName("featureFilterComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPathName("featureFilterComponentGroups_csv_i"), rawDataHandler_IO.getFeatureFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -888,6 +929,12 @@ namespace SmartPeak
     LOGD << "END loadFeatureFilter";
   }
 
+  void LoadFeatureQCsRDP::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureQCComponents_csv_i", "featureQCComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureQCComponentGroups_csv_i", "featureQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   void LoadFeatureQCsRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
@@ -895,37 +942,37 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureQC";
-    LOGI << "Loading: " << filenames.featureQCComponents_csv_i << " and " <<
-      filenames.featureQCComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureQCComponentGroups_csv_i");
 
-    if (filenames.featureQCComponents_csv_i.empty() &&
-        filenames.featureQCComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureQCComponents_csv_i").empty() &&
+        filenames.getFullPathName("featureQCComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureQC";
       return;
     }
 
-    if (filenames.featureQCComponents_csv_i.size() &&
-        !InputDataValidation::fileExists(filenames.featureQCComponents_csv_i)) {
-      LOGE << "File not found: " << filenames.featureQCComponents_csv_i;
+    if (filenames.getFullPathName("featureQCComponents_csv_i").size() &&
+        !InputDataValidation::fileExists(filenames.getFullPathName("featureQCComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureQCComponents_csv_i");
       LOGD << "END loadFeatureQC";
       return;
     }
 
-    if (filenames.featureQCComponentGroups_csv_i.size() &&
-        !InputDataValidation::fileExists(filenames.featureQCComponentGroups_csv_i)) {
-      LOGE << "File not found: " << filenames.featureQCComponentGroups_csv_i;
+    if (filenames.getFullPathName("featureQCComponentGroups_csv_i").size() &&
+        !InputDataValidation::fileExists(filenames.getFullPathName("featureQCComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureQCComponentGroups_csv_i");
       LOGD << "END loadFeatureQC";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureQCComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.featureQCComponents_csv_i, rawDataHandler_IO.getFeatureQC(), false);
+      if (filenames.getFullPathName("featureQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPathName("featureQCComponents_csv_i"), rawDataHandler_IO.getFeatureQC(), false);
       }
-      if (filenames.featureQCComponentGroups_csv_i.size()) {
-        featureQCFile.load(filenames.featureQCComponentGroups_csv_i, rawDataHandler_IO.getFeatureQC(), true);
+      if (filenames.getFullPathName("featureQCComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPathName("featureQCComponentGroups_csv_i"), rawDataHandler_IO.getFeatureQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -939,6 +986,12 @@ namespace SmartPeak
     LOGD << "END loadFeatureQC";
   }
 
+  void StoreFeatureFiltersRDP::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureFilterComponents_csv_i", "featureFilterComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureFilterComponentGroups_csv_i", "featureFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   void StoreFeatureFiltersRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
@@ -946,11 +999,11 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureFilter";
-    LOGI << "Storing: " << filenames.featureFilterComponents_csv_i << " and " <<
-      filenames.featureFilterComponentGroups_csv_i;
+    LOGI << "Storing: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureFilterComponentGroups_csv_i");
 
-    if (filenames.featureFilterComponents_csv_i.empty() &&
-      filenames.featureFilterComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureFilterComponents_csv_i").empty() &&
+      filenames.getFullPathName("featureFilterComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureFilter";
       return;
@@ -958,11 +1011,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureFilterComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.featureFilterComponents_csv_i, rawDataHandler_IO.getFeatureFilter(), false);
+      if (filenames.getFullPathName("featureFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPathName("featureFilterComponents_csv_i"), rawDataHandler_IO.getFeatureFilter(), false);
       }
-      if (filenames.featureFilterComponentGroups_csv_i.size()) {
-        featureQCFile.store(filenames.featureFilterComponentGroups_csv_i, rawDataHandler_IO.getFeatureFilter(), true);
+      if (filenames.getFullPathName("featureFilterComponentGroups_csv_i").size()) {
+        featureQCFile.store(filenames.getFullPathName("featureFilterComponentGroups_csv_i"), rawDataHandler_IO.getFeatureFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -973,6 +1026,12 @@ namespace SmartPeak
     LOGD << "END storeFeatureFilter";
   }
 
+  void StoreFeatureQCsRDP::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureQCComponents_csv_i", "featureQCComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureQCComponentGroups_csv_i", "featureQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   void StoreFeatureQCsRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
@@ -980,11 +1039,11 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureQC";
-    LOGI << "Loading: " << filenames.featureQCComponents_csv_i << " and " <<
-      filenames.featureQCComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureQCComponentGroups_csv_i");
 
-    if (filenames.featureQCComponents_csv_i.empty() &&
-      filenames.featureQCComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureQCComponents_csv_i").empty() &&
+      filenames.getFullPathName("featureQCComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureQC";
       return;
@@ -992,11 +1051,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureQCComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.featureQCComponents_csv_i, rawDataHandler_IO.getFeatureQC(), false);
+      if (filenames.getFullPathName("featureQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPathName("featureQCComponents_csv_i"), rawDataHandler_IO.getFeatureQC(), false);
       }
-      if (filenames.featureQCComponentGroups_csv_i.size()) {
-        featureQCFile.store(filenames.featureQCComponentGroups_csv_i, rawDataHandler_IO.getFeatureQC(), true);
+      if (filenames.getFullPathName("featureQCComponentGroups_csv_i").size()) {
+        featureQCFile.store(filenames.getFullPathName("featureQCComponentGroups_csv_i"), rawDataHandler_IO.getFeatureQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1007,6 +1066,11 @@ namespace SmartPeak
     LOGD << "END storeFeatureQC";
   }
 
+  void LoadValidationData::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("referenceData_csv_i", "referenceData.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   bool LoadValidationData::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
@@ -1016,7 +1080,7 @@ namespace SmartPeak
     }
     RawDataHandler& rawDataHandler = application_handler->sequenceHandler_.getSequence().at(0).getRawData();
     Filenames filenames;
-    filenames.referenceData_csv_i = filename;
+    filenames.setFullPathName("referenceData_csv_i", filename);
     process(rawDataHandler, {}, filenames);
     return true;
   }
@@ -1028,21 +1092,21 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadValidationData";
-    LOGI << "Loading: " << filenames.referenceData_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("referenceData_csv_i");
 
-    if (filenames.referenceData_csv_i.empty()) {
+    if (filenames.getFullPathName("referenceData_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END loadValidationData";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.referenceData_csv_i)) {
+    if (!InputDataValidation::fileExists(filenames.getFullPathName("referenceData_csv_i"))) {
       LOGE << "File not found";
       LOGD << "END loadValidationData";
       return;
     }
 
-    io::CSVReader<17, io::trim_chars<>, io::no_quote_escape<','>> in(filenames.referenceData_csv_i);
+    io::CSVReader<17, io::trim_chars<>, io::no_quote_escape<','>> in(filenames.getFullPathName("referenceData_csv_i"));
 
     const std::string s_sample_index{ "sample_index" };
     const std::string s_original_filename{ "original_filename" };
@@ -1157,6 +1221,11 @@ namespace SmartPeak
     LOGD << "END loadValidationData";
   }
 
+  void LoadParameters::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("parameters_csv_i", "parameters.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   bool LoadParameters::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
@@ -1167,7 +1236,7 @@ namespace SmartPeak
     RawDataHandler& rawDataHandler = application_handler->sequenceHandler_.getSequence().at(0).getRawData();
     parameters_observable_ = &(application_handler->sequenceHandler_);
     Filenames filenames;
-    filenames.parameters_csv_i = filename;
+    filenames.setFullPathName("parameters_csv_i", filename);
     process(rawDataHandler, {}, filenames);
     return true;
   }
@@ -1179,22 +1248,22 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START readRawDataProcessingParameters";
-    LOGI << "Loading: " << filenames.parameters_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("parameters_csv_i");
 
-    if (filenames.parameters_csv_i.empty()) {
+    if (filenames.getFullPathName("parameters_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END readRawDataProcessingParameters";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.parameters_csv_i)) {
+    if (!InputDataValidation::fileExists(filenames.getFullPathName("parameters_csv_i"))) {
       LOGE << "File not found";
       LOGD << "END readRawDataProcessingParameters";
       return;
     }
 
     try {
-      ParametersParser::read(filenames.parameters_csv_i, rawDataHandler_IO.getParameters());
+      ParametersParser::read(filenames.getFullPathName("parameters_csv_i"), rawDataHandler_IO.getParameters());
       sanitizeParameters(rawDataHandler_IO.getParameters());
       if (parameters_observable_) parameters_observable_->notifyParametersUpdated();
     }
@@ -1253,6 +1322,11 @@ namespace SmartPeak
     LOGD << "END sanitizeRawDataProcessorParameters";
   }
 
+  void StoreParameters::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("parameters_csv_i", "parameters.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   bool StoreParameters::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
@@ -1262,7 +1336,7 @@ namespace SmartPeak
     }
     RawDataHandler& rawDataHandler = application_handler->sequenceHandler_.getSequence().at(0).getRawData();
     Filenames filenames;
-    filenames.parameters_csv_i = filename;
+    filenames.setFullPathName("parameters_csv_i", filename);
     process(rawDataHandler, {}, filenames);
     return true;
   }
@@ -1276,14 +1350,14 @@ namespace SmartPeak
     LOGD << "START StoreParameters";
     LOGI << "Storing " << filename_;
 
-    if (filenames.parameters_csv_i.empty()) {
+    if (filenames.getFullPathName("parameters_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END readRawDataProcessingParameters";
       return;
     }
 
     try {
-      ParametersParser::write(filenames.parameters_csv_i, rawDataHandler_IO.getParameters());
+      ParametersParser::write(filenames.getFullPathName("parameters_csv_i"), rawDataHandler_IO.getParameters());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -2249,6 +2323,11 @@ namespace SmartPeak
     return ParameterSet({ oms_params });
   }
 
+  void DDA::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("traML_csv_o", ".traML", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void DDA::process(RawDataHandler& rawDataHandler_IO, const ParameterSet& params_I, const Filenames& filenames) const
   {
     LOGD << "START DDA";
@@ -2302,8 +2381,8 @@ namespace SmartPeak
       params.setValue("output_format", "traML");
       params.setValue("deisotoping:use_deisotoper", "true");
       targeted_spectra_extractor.setParameters(params);
-      LOGI << "Storing: " << filenames.traML_csv_o;
-      targeted_spectra_extractor.storeSpectraTraML(filenames.traML_csv_o, ms1_merged_features, ms2_merged_features);
+      LOGI << "Storing: " << filenames.getFullPathName("traML_csv_o");
+      targeted_spectra_extractor.storeSpectraTraML(filenames.getFullPathName("traML_csv_o"), ms1_merged_features, ms2_merged_features);
 
       // build MS1/MS2 features
       OpenMS::FeatureMap ms1_ms2_features;

--- a/src/smartpeak/source/core/RawDataProcessor.cpp
+++ b/src/smartpeak/source/core/RawDataProcessor.cpp
@@ -776,7 +776,7 @@ namespace SmartPeak
     LOGD << "END quantifyComponents";
   }
 
-  bool LoadTransitions::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadTransitions::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -1086,7 +1086,7 @@ namespace SmartPeak
     filenames.addFileName("referenceData_csv_i", "referenceData.csv", Filenames::FileScope::EFileScopeMain);
   };
 
-  bool LoadValidationData::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadValidationData::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -1242,7 +1242,7 @@ namespace SmartPeak
     filenames.addFileName("parameters_csv_i", "parameters.csv", Filenames::FileScope::EFileScopeMain);
   };
 
-  bool LoadParameters::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadParameters::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -1344,7 +1344,7 @@ namespace SmartPeak
     filenames.addFileName("parameters_csv_i", "parameters.csv", Filenames::FileScope::EFileScopeMain);
   };
 
-  bool StoreParameters::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool StoreParameters::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {

--- a/src/smartpeak/source/core/RawDataProcessor.cpp
+++ b/src/smartpeak/source/core/RawDataProcessor.cpp
@@ -143,11 +143,11 @@ namespace SmartPeak
   void LoadRawData::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadMSExperiment";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Note: unlike other processors,
     // we don't want to complete user parameters with schema
@@ -325,11 +325,11 @@ namespace SmartPeak
   void StoreRawData::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeMzML";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Storing: " << filenames.getFullPathName("mzML_i");
 
     if (filenames.getFullPathName("mzML_i").empty()) {
@@ -363,11 +363,11 @@ namespace SmartPeak
   void LoadFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START LoadFeatures";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Loading: " << filenames.getFullPathName("featureXML_i");
 
     if (filenames.getFullPathName("featureXML_i").empty()) {
@@ -408,11 +408,11 @@ namespace SmartPeak
   void StoreFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureMap";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Storing: " << filenames.getFullPathName("featureXML_o");
 
     if (filenames.getFullPathName("featureXML_o").empty()) {
@@ -441,11 +441,11 @@ namespace SmartPeak
   void LoadAnnotations::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START LoadAnnotations";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Loading: " << filenames.getFullPathName("mzTab_i");
 
     if (filenames.getFullPathName("mzTab_i").empty()) {
@@ -482,11 +482,11 @@ namespace SmartPeak
   void StoreAnnotations::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START StoreAnnotations";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Storing: " << filenames.getFullPathName("mzTab_o");
 
     if (filenames.getFullPathName("mzTab_o").empty()) {
@@ -516,11 +516,11 @@ namespace SmartPeak
   void PickMRMFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START PickMRMFeatures";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     OpenMS::MRMFeatureFinderScoring featureFinder;
     Utilities::setUserParameters(featureFinder, params_I);
 
@@ -560,11 +560,11 @@ namespace SmartPeak
   void FilterFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START filterFeatures";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Feature Filter input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -593,11 +593,11 @@ namespace SmartPeak
   void CheckFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START checkFeatures";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Feature Checker input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -618,11 +618,11 @@ namespace SmartPeak
   void SelectFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START selectFeatures";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "selectFeatures input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     const bool qmip_params_passed_but_empty =
@@ -696,11 +696,11 @@ namespace SmartPeak
   void ValidateFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START validateFeatures";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     // Complete user parameters with schema
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -727,11 +727,11 @@ namespace SmartPeak
   void PlotFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START PlotFeatures (NOT IMPLEMENTED)";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     // TODO: Uncomment once FeaturePlotter is ready
 
     // if (FeaturePlotter_params_I.empty() || filename.empty())
@@ -757,11 +757,11 @@ namespace SmartPeak
   void QuantifyFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START quantifyComponents";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Processing # quantitation methods: " << rawDataHandler_IO.getQuantitationMethods().size();
 
     try {
@@ -814,11 +814,11 @@ namespace SmartPeak
   void LoadTransitions::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadTraML";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     // Complete user parameters with schema
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -892,11 +892,11 @@ namespace SmartPeak
   void LoadFeatureFiltersRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadFeatureFilter";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Loading: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureFilterComponentGroups_csv_i");
 
@@ -950,11 +950,11 @@ namespace SmartPeak
   void LoadFeatureQCsRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadFeatureQC";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureQCComponentGroups_csv_i");
 
@@ -1008,11 +1008,11 @@ namespace SmartPeak
   void StoreFeatureFiltersRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureFilter";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Storing: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureFilterComponentGroups_csv_i");
 
@@ -1049,11 +1049,11 @@ namespace SmartPeak
   void StoreFeatureQCsRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureQC";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureQCComponentGroups_csv_i");
 
@@ -1103,11 +1103,11 @@ namespace SmartPeak
   void LoadValidationData::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadValidationData";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Loading: " << filenames.getFullPathName("referenceData_csv_i");
 
     if (filenames.getFullPathName("referenceData_csv_i").empty()) {
@@ -1260,11 +1260,11 @@ namespace SmartPeak
   void LoadParameters::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START readRawDataProcessingParameters";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Loading: " << filenames.getFullPathName("parameters_csv_i");
 
     if (filenames.getFullPathName("parameters_csv_i").empty()) {
@@ -1361,11 +1361,11 @@ namespace SmartPeak
   void StoreParameters::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START StoreParameters";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Storing " << filename_;
 
     if (filenames.getFullPathName("parameters_csv_i").empty()) {
@@ -1409,11 +1409,11 @@ namespace SmartPeak
   void MapChromatograms::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START MapChromatograms";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     // Set up MRMMapping and parse the MRMMapping params
     OpenMS::MRMMapping mrmmapper;
     Utilities::setUserParameters(mrmmapper, params_I);
@@ -1430,11 +1430,11 @@ namespace SmartPeak
   void ExtractChromatogramWindows::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START ExtractChromatogramWindows";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     for (const OpenMS::MRMFeatureQC::ComponentQCs& transition_filters : rawDataHandler_IO.getFeatureFilter().component_qcs) {
       for (OpenMS::MSChromatogram& ch : rawDataHandler_IO.getChromatogramMap().getChromatograms()) {
@@ -1496,11 +1496,11 @@ namespace SmartPeak
   void ExtractSpectraWindows::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START ExtractSpectraWindows";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     // Complete user parameters with schema
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -1560,11 +1560,11 @@ namespace SmartPeak
   void FitFeaturesEMG::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START FitFeaturesEMG";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     OpenMS::EmgGradientDescent emg;
     Utilities::setUserParameters(emg, params_I);
 
@@ -1701,11 +1701,11 @@ namespace SmartPeak
   void FilterFeaturesRSDs::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START filterFeaturesRSDs";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Feature Filter input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1734,11 +1734,11 @@ namespace SmartPeak
   void CheckFeaturesRSDs::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START checkFeaturesRSDs";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Feature Checker input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1765,11 +1765,11 @@ namespace SmartPeak
   void FilterFeaturesBackgroundInterferences::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START filterFeaturesBackgroundInterferences";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Feature Filter input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1798,11 +1798,11 @@ namespace SmartPeak
   void CheckFeaturesBackgroundInterferences::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START checkFeaturesBackgroundInterferences";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Feature Checker input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1828,11 +1828,11 @@ namespace SmartPeak
   void MergeSpectra::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START MergeSpectra";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2001,11 +2001,11 @@ namespace SmartPeak
 
   void PickMS1Features::process(RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START PickMS1Features";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2177,11 +2177,11 @@ namespace SmartPeak
 
   void SearchAccurateMass::process(RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START SearchAccurateMass";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "SearchAccurateMass input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::AccurateMassSearchEngine ams;
@@ -2246,11 +2246,11 @@ namespace SmartPeak
 
   void MergeFeatures::process(RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START MergeFeatures";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "MergeFeatures input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     try {
@@ -2339,11 +2339,11 @@ namespace SmartPeak
   }
   void SearchSpectrum::process(RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START SearchSpectrum";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2378,11 +2378,11 @@ namespace SmartPeak
 
   void DDA::process(RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START DDA";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2462,11 +2462,11 @@ namespace SmartPeak
 
   void ClearData::process(RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START ClearData";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     rawDataHandler_IO.clearNonSharedData();
     LOGD << "END ClearData";
   }
@@ -2495,11 +2495,11 @@ namespace SmartPeak
   void CalculateMDVs::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START CalculateMDVs";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2563,11 +2563,11 @@ namespace SmartPeak
   void IsotopicCorrections::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START IsotopicCorrections";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2627,11 +2627,11 @@ namespace SmartPeak
   void CalculateIsotopicPurities::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START calculateIsotopicPurities";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2717,11 +2717,11 @@ namespace SmartPeak
   void CalculateMDVAccuracies::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START CalculateMDVAccuracies";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2811,11 +2811,11 @@ namespace SmartPeak
   void PickMS2Features::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START PickMS2Features";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);

--- a/src/smartpeak/source/core/RawDataProcessor.cpp
+++ b/src/smartpeak/source/core/RawDataProcessor.cpp
@@ -143,10 +143,11 @@ namespace SmartPeak
   void LoadRawData::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadMSExperiment";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Note: unlike other processors,
     // we don't want to complete user parameters with schema
@@ -324,10 +325,11 @@ namespace SmartPeak
   void StoreRawData::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeMzML";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Storing: " << filenames.getFullPathName("mzML_i");
 
     if (filenames.getFullPathName("mzML_i").empty()) {
@@ -361,10 +363,11 @@ namespace SmartPeak
   void LoadFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START LoadFeatures";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Loading: " << filenames.getFullPathName("featureXML_i");
 
     if (filenames.getFullPathName("featureXML_i").empty()) {
@@ -405,10 +408,11 @@ namespace SmartPeak
   void StoreFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureMap";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Storing: " << filenames.getFullPathName("featureXML_o");
 
     if (filenames.getFullPathName("featureXML_o").empty()) {
@@ -437,10 +441,11 @@ namespace SmartPeak
   void LoadAnnotations::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START LoadAnnotations";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Loading: " << filenames.getFullPathName("mzTab_i");
 
     if (filenames.getFullPathName("mzTab_i").empty()) {
@@ -477,10 +482,11 @@ namespace SmartPeak
   void StoreAnnotations::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START StoreAnnotations";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Storing: " << filenames.getFullPathName("mzTab_o");
 
     if (filenames.getFullPathName("mzTab_o").empty()) {
@@ -510,11 +516,11 @@ namespace SmartPeak
   void PickMRMFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START PickMRMFeatures";
-
+    Filenames filenames = prepareFileNames(filenames_override);
     OpenMS::MRMFeatureFinderScoring featureFinder;
     Utilities::setUserParameters(featureFinder, params_I);
 
@@ -554,10 +560,11 @@ namespace SmartPeak
   void FilterFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START filterFeatures";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Feature Filter input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -586,10 +593,11 @@ namespace SmartPeak
   void CheckFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START checkFeatures";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Feature Checker input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -610,10 +618,11 @@ namespace SmartPeak
   void SelectFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START selectFeatures";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "selectFeatures input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     const bool qmip_params_passed_but_empty =
@@ -687,11 +696,11 @@ namespace SmartPeak
   void ValidateFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START validateFeatures";
-
+    Filenames filenames = prepareFileNames(filenames_override);
     // Complete user parameters with schema
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -718,10 +727,11 @@ namespace SmartPeak
   void PlotFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START PlotFeatures (NOT IMPLEMENTED)";
+    Filenames filenames = prepareFileNames(filenames_override);
     // TODO: Uncomment once FeaturePlotter is ready
 
     // if (FeaturePlotter_params_I.empty() || filename.empty())
@@ -747,10 +757,11 @@ namespace SmartPeak
   void QuantifyFeatures::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START quantifyComponents";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Processing # quantitation methods: " << rawDataHandler_IO.getQuantitationMethods().size();
 
     try {
@@ -803,11 +814,11 @@ namespace SmartPeak
   void LoadTransitions::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadTraML";
-
+    Filenames filenames = prepareFileNames(filenames_override);
     // Complete user parameters with schema
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -881,10 +892,11 @@ namespace SmartPeak
   void LoadFeatureFiltersRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadFeatureFilter";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Loading: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureFilterComponentGroups_csv_i");
 
@@ -938,10 +950,11 @@ namespace SmartPeak
   void LoadFeatureQCsRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadFeatureQC";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureQCComponentGroups_csv_i");
 
@@ -995,10 +1008,11 @@ namespace SmartPeak
   void StoreFeatureFiltersRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureFilter";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Storing: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureFilterComponentGroups_csv_i");
 
@@ -1035,10 +1049,11 @@ namespace SmartPeak
   void StoreFeatureQCsRDP::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureQC";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureQCComponentGroups_csv_i");
 
@@ -1088,10 +1103,11 @@ namespace SmartPeak
   void LoadValidationData::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadValidationData";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Loading: " << filenames.getFullPathName("referenceData_csv_i");
 
     if (filenames.getFullPathName("referenceData_csv_i").empty()) {
@@ -1244,10 +1260,11 @@ namespace SmartPeak
   void LoadParameters::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START readRawDataProcessingParameters";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Loading: " << filenames.getFullPathName("parameters_csv_i");
 
     if (filenames.getFullPathName("parameters_csv_i").empty()) {
@@ -1344,10 +1361,11 @@ namespace SmartPeak
   void StoreParameters::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START StoreParameters";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Storing " << filename_;
 
     if (filenames.getFullPathName("parameters_csv_i").empty()) {
@@ -1391,11 +1409,11 @@ namespace SmartPeak
   void MapChromatograms::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START MapChromatograms";
-
+    Filenames filenames = prepareFileNames(filenames_override);
     // Set up MRMMapping and parse the MRMMapping params
     OpenMS::MRMMapping mrmmapper;
     Utilities::setUserParameters(mrmmapper, params_I);
@@ -1412,10 +1430,11 @@ namespace SmartPeak
   void ExtractChromatogramWindows::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START ExtractChromatogramWindows";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     for (const OpenMS::MRMFeatureQC::ComponentQCs& transition_filters : rawDataHandler_IO.getFeatureFilter().component_qcs) {
       for (OpenMS::MSChromatogram& ch : rawDataHandler_IO.getChromatogramMap().getChromatograms()) {
@@ -1474,10 +1493,14 @@ namespace SmartPeak
     return FIAMSParameters();
   }
 
-  void ExtractSpectraWindows::process(RawDataHandler& rawDataHandler_IO, const ParameterSet& params_I, const Filenames& filenames) const
+  void ExtractSpectraWindows::process(
+    RawDataHandler& rawDataHandler_IO,
+    const ParameterSet& params_I,
+    const Filenames& filenames_override
+  ) const
   {
     LOGD << "START ExtractSpectraWindows";
-
+    Filenames filenames = prepareFileNames(filenames_override);
     // Complete user parameters with schema
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -1537,11 +1560,11 @@ namespace SmartPeak
   void FitFeaturesEMG::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START FitFeaturesEMG";
-
+    Filenames filenames = prepareFileNames(filenames_override);
     OpenMS::EmgGradientDescent emg;
     Utilities::setUserParameters(emg, params_I);
 
@@ -1678,10 +1701,11 @@ namespace SmartPeak
   void FilterFeaturesRSDs::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START filterFeaturesRSDs";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Feature Filter input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1710,10 +1734,11 @@ namespace SmartPeak
   void CheckFeaturesRSDs::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START checkFeaturesRSDs";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Feature Checker input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1740,10 +1765,11 @@ namespace SmartPeak
   void FilterFeaturesBackgroundInterferences::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START filterFeaturesBackgroundInterferences";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Feature Filter input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1772,10 +1798,11 @@ namespace SmartPeak
   void CheckFeaturesBackgroundInterferences::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START checkFeaturesBackgroundInterferences";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Feature Checker input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1798,9 +1825,14 @@ namespace SmartPeak
     return FIAMSParameters();
   }
 
-  void MergeSpectra::process(RawDataHandler& rawDataHandler_IO, const ParameterSet& params_I, const Filenames& filenames) const
+  void MergeSpectra::process(
+    RawDataHandler& rawDataHandler_IO,
+    const ParameterSet& params_I,
+    const Filenames& filenames_override
+  ) const
   {
     LOGD << "START MergeSpectra";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -1967,9 +1999,13 @@ namespace SmartPeak
     return parameters;
   }
 
-  void PickMS1Features::process(RawDataHandler& rawDataHandler_IO, const ParameterSet& params_I, const Filenames& filenames) const
+  void PickMS1Features::process(RawDataHandler& rawDataHandler_IO,
+    const ParameterSet& params_I,
+    const Filenames& filenames_override
+  ) const
   {
     LOGD << "START PickMS1Features";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2139,9 +2175,13 @@ namespace SmartPeak
     return ParameterSet({ oms_params });
   }
 
-  void SearchAccurateMass::process(RawDataHandler& rawDataHandler_IO, const ParameterSet& params_I, const Filenames& filenames) const
+  void SearchAccurateMass::process(RawDataHandler& rawDataHandler_IO,
+    const ParameterSet& params_I,
+    const Filenames& filenames_override
+  ) const
   {
     LOGD << "START SearchAccurateMass";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "SearchAccurateMass input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::AccurateMassSearchEngine ams;
@@ -2204,9 +2244,13 @@ namespace SmartPeak
     LOGD << "END SearchAccurateMass";
   }
 
-  void MergeFeatures::process(RawDataHandler& rawDataHandler_IO, const ParameterSet& params_I, const Filenames& filenames) const
+  void MergeFeatures::process(RawDataHandler& rawDataHandler_IO,
+    const ParameterSet& params_I,
+    const Filenames& filenames_override
+  ) const
   {
     LOGD << "START MergeFeatures";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "MergeFeatures input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     try {
@@ -2293,9 +2337,13 @@ namespace SmartPeak
     OpenMS::TargetedSpectraExtractor oms_params;
     return ParameterSet({ oms_params });
   }
-  void SearchSpectrum::process(RawDataHandler& rawDataHandler_IO, const ParameterSet& params_I, const Filenames& filenames) const
+  void SearchSpectrum::process(RawDataHandler& rawDataHandler_IO,
+    const ParameterSet& params_I,
+    const Filenames& filenames_override
+  ) const
   {
     LOGD << "START SearchSpectrum";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2328,9 +2376,13 @@ namespace SmartPeak
     filenames.addFileName("traML_csv_o", ".traML", Filenames::FileScope::EFileScopeInjectionOutput);
   };
 
-  void DDA::process(RawDataHandler& rawDataHandler_IO, const ParameterSet& params_I, const Filenames& filenames) const
+  void DDA::process(RawDataHandler& rawDataHandler_IO,
+    const ParameterSet& params_I,
+    const Filenames& filenames_override
+  ) const
   {
     LOGD << "START DDA";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2408,9 +2460,13 @@ namespace SmartPeak
     LOGD << "END DDA";
   }
 
-  void ClearData::process(RawDataHandler& rawDataHandler_IO, const ParameterSet& params_I, const Filenames& filenames) const
+  void ClearData::process(RawDataHandler& rawDataHandler_IO,
+    const ParameterSet& params_I,
+    const Filenames& filenames_override
+  ) const
   {
     LOGD << "START ClearData";
+    Filenames filenames = prepareFileNames(filenames_override);
     rawDataHandler_IO.clearNonSharedData();
     LOGD << "END ClearData";
   }
@@ -2439,10 +2495,11 @@ namespace SmartPeak
   void CalculateMDVs::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START CalculateMDVs";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2506,10 +2563,11 @@ namespace SmartPeak
   void IsotopicCorrections::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START IsotopicCorrections";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2569,10 +2627,11 @@ namespace SmartPeak
   void CalculateIsotopicPurities::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START calculateIsotopicPurities";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2658,10 +2717,11 @@ namespace SmartPeak
   void CalculateMDVAccuracies::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START CalculateMDVAccuracies";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2751,10 +2811,11 @@ namespace SmartPeak
   void PickMS2Features::process(
     RawDataHandler& rawDataHandler_IO,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START PickMS2Features";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);

--- a/src/smartpeak/source/core/RawDataProcessor.cpp
+++ b/src/smartpeak/source/core/RawDataProcessor.cpp
@@ -137,7 +137,7 @@ namespace SmartPeak
 
   void LoadRawData::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("mzML_i", ".mzML", Filenames::FileScope::EFileScopeMzMLInput);
+    filenames.addFileName("mzML_i", "${MZML_INPUT_PATH}/${INPUT_MZML_FILENAME}.mzML");
   };
 
   void LoadRawData::process(
@@ -319,7 +319,7 @@ namespace SmartPeak
 
   void StoreRawData::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("mzML_i", ".mzML", Filenames::FileScope::EFileScopeMzMLInput);
+    filenames.addFileName("mzML_i", "${MZML_INPUT_PATH}/${INPUT_MZML_FILENAME}.mzML");
   };
 
   void StoreRawData::process(
@@ -356,7 +356,7 @@ namespace SmartPeak
 
   void LoadFeatures::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureXML_i", ".featureXML", Filenames::FileScope::EFileScopeInjectionInput);
+    filenames.addFileName("featureXML_i", "${FEATURES_INPUT_PATH}/${INPUT_INJECTION_NAME}.featureXML");
   };
 
   void LoadFeatures::process(
@@ -394,7 +394,7 @@ namespace SmartPeak
 
   void StoreFeatures::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureXML_o", ".featureXML", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureXML_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}.featureXML");
   };
 
   void StoreFeatures::process(
@@ -426,7 +426,7 @@ namespace SmartPeak
 
   void LoadAnnotations::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("mzTab_i", ".mzTab", Filenames::FileScope::EFileScopeInjectionInput);
+    filenames.addFileName("mzTab_i", "${FEATURES_INPUT_PATH}/${INPUT_INJECTION_NAME}.mzTab");
   };
 
   void LoadAnnotations::process(
@@ -460,7 +460,7 @@ namespace SmartPeak
 
   void StoreAnnotations::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("mzTab_o", ".mzTab", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("mzTab_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}.mzTab");
   };
 
   void StoreAnnotations::process(
@@ -791,7 +791,7 @@ namespace SmartPeak
 
   void LoadTransitions::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("traML_csv_i", "traML.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("traML_csv_i", "${MAIN_DIR}/traML.csv");
   };
 
   void LoadTransitions::process(
@@ -868,8 +868,8 @@ namespace SmartPeak
 
   void LoadFeatureFiltersRDP::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureFilterComponents_csv_i", "featureFilterComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureFilterComponentGroups_csv_i", "featureFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureFilterComponents_csv_i", "${MAIN_DIR}/featureFilterComponents.csv");
+    filenames.addFileName("featureFilterComponentGroups_csv_i", "${MAIN_DIR}/featureFilterComponentGroups.csv");
   };
 
   void LoadFeatureFiltersRDP::process(
@@ -909,8 +909,8 @@ namespace SmartPeak
 
   void LoadFeatureQCsRDP::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureQCComponents_csv_i", "featureQCComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureQCComponentGroups_csv_i", "featureQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureQCComponents_csv_i", "${MAIN_DIR}/featureQCComponents.csv");
+    filenames.addFileName("featureQCComponentGroups_csv_i", "${MAIN_DIR}/featureQCComponentGroups.csv");
   };
 
   void LoadFeatureQCsRDP::process(
@@ -950,8 +950,8 @@ namespace SmartPeak
 
   void StoreFeatureFiltersRDP::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureFilterComponents_csv_i", "featureFilterComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureFilterComponentGroups_csv_i", "featureFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureFilterComponents_csv_i", "${MAIN_DIR}/featureFilterComponents.csv");
+    filenames.addFileName("featureFilterComponentGroups_csv_i", "${MAIN_DIR}/featureFilterComponentGroups.csv");
   };
 
   void StoreFeatureFiltersRDP::process(
@@ -988,8 +988,8 @@ namespace SmartPeak
 
   void StoreFeatureQCsRDP::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureQCComponents_csv_i", "featureQCComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureQCComponentGroups_csv_i", "featureQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureQCComponents_csv_i", "${MAIN_DIR}/featureQCComponents.csv");
+    filenames.addFileName("featureQCComponentGroups_csv_i", "${MAIN_DIR}/featureQCComponentGroups.csv");
   };
 
   void StoreFeatureQCsRDP::process(
@@ -1026,7 +1026,7 @@ namespace SmartPeak
 
   void LoadValidationData::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("referenceData_csv_i", "referenceData.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("referenceData_csv_i", "${MAIN_DIR}/referenceData.csv");
   };
 
   bool LoadValidationData::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
@@ -1175,7 +1175,7 @@ namespace SmartPeak
 
   void LoadParameters::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("parameters_csv_i", "parameters.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("parameters_csv_i", "${MAIN_DIR}/parameters.csv");
   };
 
   bool LoadParameters::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
@@ -1270,7 +1270,7 @@ namespace SmartPeak
 
   void StoreParameters::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("parameters_csv_i", "parameters.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("parameters_csv_i", "${MAIN_DIR}/parameters.csv");
   };
 
   bool StoreParameters::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
@@ -2302,7 +2302,7 @@ namespace SmartPeak
 
   void DDA::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("traML_csv_o", ".traML", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("traML_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}.traML");
   };
 
   void DDA::process(RawDataHandler& rawDataHandler_IO,

--- a/src/smartpeak/source/core/RawDataProcessor.cpp
+++ b/src/smartpeak/source/core/RawDataProcessor.cpp
@@ -135,7 +135,7 @@ namespace SmartPeak
     return ParameterSet(param_struct);
   }
 
-  void LoadRawData::getInputsOutputs(Filenames& filenames) const
+  void LoadRawData::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("mzML_i", "${MZML_INPUT_PATH}/${INPUT_MZML_FILENAME}.mzML");
   };
@@ -147,7 +147,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadMSExperiment";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Note: unlike other processors,
     // we don't want to complete user parameters with schema
@@ -317,7 +317,7 @@ namespace SmartPeak
     LOGD << "END extractMetaData";
   }
 
-  void StoreRawData::getInputsOutputs(Filenames& filenames) const
+  void StoreRawData::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("mzML_i", "${MZML_INPUT_PATH}/${INPUT_MZML_FILENAME}.mzML");
   };
@@ -329,7 +329,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeMzML";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStore(filenames, "mzML_i"))
     {
@@ -354,7 +354,7 @@ namespace SmartPeak
     LOGD << "END storeMzML";
   }
 
-  void LoadFeatures::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatures::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureXML_i", "${FEATURES_INPUT_PATH}/${INPUT_INJECTION_NAME}.featureXML");
   };
@@ -366,7 +366,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START LoadFeatures";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoad(filenames, "featureXML_i"))
     {
@@ -392,7 +392,7 @@ namespace SmartPeak
     LOGD << "END LoadFeatures";
   }
 
-  void StoreFeatures::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatures::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureXML_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}.featureXML");
   };
@@ -404,7 +404,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureMap";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStore(filenames, "featureXML_o"))
     {
@@ -424,7 +424,7 @@ namespace SmartPeak
     LOGD << "END storeFeatureMap";
   }
 
-  void LoadAnnotations::getInputsOutputs(Filenames& filenames) const
+  void LoadAnnotations::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("mzTab_i", "${FEATURES_INPUT_PATH}/${INPUT_INJECTION_NAME}.mzTab");
   };
@@ -436,7 +436,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START LoadAnnotations";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoad(filenames, "mzTab_i"))
     {
@@ -458,7 +458,7 @@ namespace SmartPeak
     LOGD << "END LoadAnnotations";
   }
 
-  void StoreAnnotations::getInputsOutputs(Filenames& filenames) const
+  void StoreAnnotations::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("mzTab_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}.mzTab");
   };
@@ -470,7 +470,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START StoreAnnotations";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStore(filenames, "mzTab_o"))
     {
@@ -503,7 +503,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START PickMRMFeatures";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     OpenMS::MRMFeatureFinderScoring featureFinder;
     Utilities::setUserParameters(featureFinder, params_I);
 
@@ -547,7 +547,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START filterFeatures";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "Feature Filter input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -580,7 +580,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START checkFeatures";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "Feature Checker input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -605,7 +605,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START selectFeatures";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "selectFeatures input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     const bool qmip_params_passed_but_empty =
@@ -683,7 +683,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START validateFeatures";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     // Complete user parameters with schema
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -714,7 +714,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START PlotFeatures (NOT IMPLEMENTED)";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     // TODO: Uncomment once FeaturePlotter is ready
 
     // if (FeaturePlotter_params_I.empty() || filename.empty())
@@ -744,7 +744,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START quantifyComponents";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "Processing # quantitation methods: " << rawDataHandler_IO.getQuantitationMethods().size();
 
     try {
@@ -789,7 +789,7 @@ namespace SmartPeak
     return ParameterSet(param_struct);
   }
 
-  void LoadTransitions::getInputsOutputs(Filenames& filenames) const
+  void LoadTransitions::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("traML_csv_i", "${MAIN_DIR}/traML.csv");
   };
@@ -801,7 +801,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadTraML";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     // Complete user parameters with schema
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -866,7 +866,7 @@ namespace SmartPeak
     LOGD << "END loadTraML";
   }
 
-  void LoadFeatureFiltersRDP::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatureFiltersRDP::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureFilterComponents_csv_i", "${MAIN_DIR}/featureFilterComponents.csv");
     filenames.addFileName("featureFilterComponentGroups_csv_i", "${MAIN_DIR}/featureFilterComponentGroups.csv");
@@ -879,7 +879,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureFilter";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureFilterComponents_csv_i", "featureFilterComponentGroups_csv_i"))
     {
@@ -907,7 +907,7 @@ namespace SmartPeak
     LOGD << "END loadFeatureFilter";
   }
 
-  void LoadFeatureQCsRDP::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatureQCsRDP::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureQCComponents_csv_i", "${MAIN_DIR}/featureQCComponents.csv");
     filenames.addFileName("featureQCComponentGroups_csv_i", "${MAIN_DIR}/featureQCComponentGroups.csv");
@@ -920,7 +920,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureQC";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureQCComponents_csv_i", "featureQCComponentGroups_csv_i"))
     {
@@ -948,7 +948,7 @@ namespace SmartPeak
     LOGD << "END loadFeatureQC";
   }
 
-  void StoreFeatureFiltersRDP::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatureFiltersRDP::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureFilterComponents_csv_i", "${MAIN_DIR}/featureFilterComponents.csv");
     filenames.addFileName("featureFilterComponentGroups_csv_i", "${MAIN_DIR}/featureFilterComponentGroups.csv");
@@ -961,7 +961,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureFilter";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureFilterComponents_csv_i", "featureFilterComponentGroups_csv_i"))
     {
@@ -986,7 +986,7 @@ namespace SmartPeak
     LOGD << "END storeFeatureFilter";
   }
 
-  void StoreFeatureQCsRDP::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatureQCsRDP::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureQCComponents_csv_i", "${MAIN_DIR}/featureQCComponents.csv");
     filenames.addFileName("featureQCComponentGroups_csv_i", "${MAIN_DIR}/featureQCComponentGroups.csv");
@@ -999,7 +999,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureQC";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureQCComponents_csv_i", "featureQCComponentGroups_csv_i"))
     {
@@ -1024,7 +1024,7 @@ namespace SmartPeak
     LOGD << "END storeFeatureQC";
   }
 
-  void LoadValidationData::getInputsOutputs(Filenames& filenames) const
+  void LoadValidationData::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("referenceData_csv_i", "${MAIN_DIR}/referenceData.csv");
   };
@@ -1050,7 +1050,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadValidationData";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoad(filenames, "referenceData_csv_i"))
     {
@@ -1173,7 +1173,7 @@ namespace SmartPeak
     LOGD << "END loadValidationData";
   }
 
-  void LoadParameters::getInputsOutputs(Filenames& filenames) const
+  void LoadParameters::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("parameters_csv_i", "${MAIN_DIR}/parameters.csv");
   };
@@ -1200,7 +1200,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START readRawDataProcessingParameters";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoad(filenames, "parameters_csv_i"))
     {
@@ -1268,7 +1268,7 @@ namespace SmartPeak
     LOGD << "END sanitizeRawDataProcessorParameters";
   }
 
-  void StoreParameters::getInputsOutputs(Filenames& filenames) const
+  void StoreParameters::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("parameters_csv_i", "${MAIN_DIR}/parameters.csv");
   };
@@ -1294,7 +1294,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START StoreParameters";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "Storing " << filename_;
 
     if (filenames.getFullPath("parameters_csv_i").empty()) {
@@ -1342,7 +1342,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START MapChromatograms";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     // Set up MRMMapping and parse the MRMMapping params
     OpenMS::MRMMapping mrmmapper;
     Utilities::setUserParameters(mrmmapper, params_I);
@@ -1363,7 +1363,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START ExtractChromatogramWindows";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     for (const OpenMS::MRMFeatureQC::ComponentQCs& transition_filters : rawDataHandler_IO.getFeatureFilter().component_qcs) {
       for (OpenMS::MSChromatogram& ch : rawDataHandler_IO.getChromatogramMap().getChromatograms()) {
@@ -1429,7 +1429,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START ExtractSpectraWindows";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     // Complete user parameters with schema
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -1493,7 +1493,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START FitFeaturesEMG";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     OpenMS::EmgGradientDescent emg;
     Utilities::setUserParameters(emg, params_I);
 
@@ -1634,7 +1634,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START filterFeaturesRSDs";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "Feature Filter input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1667,7 +1667,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START checkFeaturesRSDs";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "Feature Checker input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1698,7 +1698,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START filterFeaturesBackgroundInterferences";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "Feature Filter input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1731,7 +1731,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START checkFeaturesBackgroundInterferences";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "Feature Checker input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1761,7 +1761,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START MergeSpectra";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -1934,7 +1934,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START PickMS1Features";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2110,7 +2110,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START SearchAccurateMass";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "SearchAccurateMass input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     OpenMS::AccurateMassSearchEngine ams;
@@ -2179,7 +2179,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START MergeFeatures";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     LOGI << "MergeFeatures input size: " << rawDataHandler_IO.getFeatureMap().size();
 
     try {
@@ -2272,7 +2272,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START SearchSpectrum";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2300,7 +2300,7 @@ namespace SmartPeak
     return ParameterSet({ oms_params });
   }
 
-  void DDA::getInputsOutputs(Filenames& filenames) const
+  void DDA::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("traML_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}.traML");
   };
@@ -2311,7 +2311,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START DDA";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2395,7 +2395,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START ClearData";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
     rawDataHandler_IO.clearNonSharedData();
     LOGD << "END ClearData";
   }
@@ -2428,7 +2428,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START CalculateMDVs";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2496,7 +2496,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START IsotopicCorrections";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2560,7 +2560,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START calculateIsotopicPurities";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2650,7 +2650,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START CalculateMDVAccuracies";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);
@@ -2744,7 +2744,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START PickMS2Features";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Complete user parameters with schema
     ParameterSet params(params_I);

--- a/src/smartpeak/source/core/SampleGroupProcessor.cpp
+++ b/src/smartpeak/source/core/SampleGroupProcessor.cpp
@@ -58,7 +58,7 @@ namespace SmartPeak
     const Filenames& filenames_I
   ) const
   {
-    LOGD << "START SelectDilutionsParser";
+    LOGD << "START SelectDilutions";
     Filenames filenames = prepareFileNames(filenames_I);
 
     ParameterSet params(params_I);
@@ -135,7 +135,7 @@ namespace SmartPeak
       }
     }
     sampleGroupHandler_IO.setFeatureMap(new_feature_map);
-    LOGD << "END SelectDilutionsParser";
+    LOGD << "END SelectDilutions";
   }
 
   ParameterSet MergeInjections::getParameterSchema() const
@@ -694,7 +694,7 @@ namespace SmartPeak
 
   void LoadFeaturesSampleGroup::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureXMLSampleGroup_i", ".featureXML");
+    filenames.addFileName("featureXMLSampleGroup_i", "${FEATURES_INPUT_PATH}/${INPUT_GROUP_NAME}.featureXML");
   };
 
   void LoadFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO,

--- a/src/smartpeak/source/core/SampleGroupProcessor.cpp
+++ b/src/smartpeak/source/core/SampleGroupProcessor.cpp
@@ -46,6 +46,11 @@ namespace SmartPeak
     return ParameterSet(param_struct);
   }
 
+  void SelectDilutions::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("selectDilutions_csv_i", "selectDilutions.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   void SelectDilutions::process(
     SampleGroupHandler& sampleGroupHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -61,11 +66,11 @@ namespace SmartPeak
     std::map<std::string, int> select_dilution_map;
     try
     {
-      SelectDilutionsParser::read(filenames.selectDilutions_csv_i, select_dilution_map);
+      SelectDilutionsParser::read(filenames.getFullPathName("selectDilutions_csv_i"), select_dilution_map);
     }
     catch (const std::exception& e)
     {
-      LOGE << "Failed to read select dilutions file [" << filenames.selectDilutions_csv_i << "] : " << e.what();
+      LOGE << "Failed to read select dilutions file [" << filenames.getFullPathName("selectDilutions_csv_i") << "] : " << e.what();
       return;
     }
 
@@ -685,18 +690,23 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void LoadFeaturesSampleGroup::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureXMLSampleGroup_i", ".featureXML", Filenames::FileScope::EFileScopeSampleGroupInput);
+  };
+
   void LoadFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO, const SequenceHandler& sequenceHandler_I, const ParameterSet& params_I, const Filenames& filenames) const
   {
     LOGD << "START LoadFeaturesSampleGroup";
-    LOGI << "Loading: " << filenames.featureXMLSampleGroup_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureXMLSampleGroup_i");
 
-    if (filenames.featureXMLSampleGroup_i.empty()) {
+    if (filenames.getFullPathName("featureXMLSampleGroup_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END LoadFeaturesSampleGroup";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.featureXMLSampleGroup_i)) {
+    if (!InputDataValidation::fileExists(filenames.getFullPathName("featureXMLSampleGroup_i"))) {
       LOGE << "File not found";
       LOGD << "END LoadFeaturesSampleGroup";
       return;
@@ -704,7 +714,7 @@ namespace SmartPeak
 
     try {
       OpenMS::FeatureXMLFile featurexml;
-      featurexml.load(filenames.featureXMLSampleGroup_i, sampleGroupHandler_IO.getFeatureMap());
+      featurexml.load(filenames.getFullPathName("featureXMLSampleGroup_i"), sampleGroupHandler_IO.getFeatureMap());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -720,12 +730,17 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void StoreFeaturesSampleGroup::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureXMLSampleGroup_o", ".featureXML", Filenames::FileScope::EFileScopeSampleGroupOutput);
+  };
+
   void StoreFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO, const SequenceHandler& sequenceHandler_I, const ParameterSet& params_I, const Filenames& filenames) const
   {
     LOGD << "START storeFeaturesSampleGroup";
-    LOGI << "Storing: " << filenames.featureXMLSampleGroup_o;
+    LOGI << "Storing: " << filenames.getFullPathName("featureXMLSampleGroup_o");
 
-    if (filenames.featureXMLSampleGroup_o.empty()) {
+    if (filenames.getFullPathName("featureXMLSampleGroup_o").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END storeFeaturesSampleGroup";
       return;
@@ -734,7 +749,7 @@ namespace SmartPeak
     try {
       // Store outfile as featureXML
       OpenMS::FeatureXMLFile featurexml;
-      featurexml.store(filenames.featureXMLSampleGroup_o, sampleGroupHandler_IO.getFeatureMap());
+      featurexml.store(filenames.getFullPathName("featureXMLSampleGroup_o"), sampleGroupHandler_IO.getFeatureMap());
     }
     catch (const std::exception& e) {
       LOGE << e.what();

--- a/src/smartpeak/source/core/SampleGroupProcessor.cpp
+++ b/src/smartpeak/source/core/SampleGroupProcessor.cpp
@@ -46,7 +46,7 @@ namespace SmartPeak
     return ParameterSet(param_struct);
   }
 
-  void SelectDilutions::getInputsOutputs(Filenames& filenames) const
+  void SelectDilutions::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("selectDilutions_csv_i", "${MAIN_DIR}/selectDilutions.csv");
   };
@@ -59,7 +59,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START SelectDilutions";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -199,7 +199,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START MergeInjections";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // Check the parameters
     if (params_I.at("MergeInjections").empty() && params_I.at("MergeInjections").empty()) {
@@ -692,7 +692,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void LoadFeaturesSampleGroup::getInputsOutputs(Filenames& filenames) const
+  void LoadFeaturesSampleGroup::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureXMLSampleGroup_i", "${FEATURES_INPUT_PATH}/${INPUT_GROUP_NAME}.featureXML");
   };
@@ -704,7 +704,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START LoadFeaturesSampleGroup";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoad(filenames, "featureXMLSampleGroup_i"))
     {
@@ -730,7 +730,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void StoreFeaturesSampleGroup::getInputsOutputs(Filenames& filenames) const
+  void StoreFeaturesSampleGroup::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureXMLSampleGroup_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_GROUP_NAME}.featureXML");
   };
@@ -742,7 +742,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeaturesSampleGroup";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStore(filenames, "featureXMLSampleGroup_o"))
     {

--- a/src/smartpeak/source/core/SampleGroupProcessor.cpp
+++ b/src/smartpeak/source/core/SampleGroupProcessor.cpp
@@ -55,11 +55,11 @@ namespace SmartPeak
     SampleGroupHandler& sampleGroupHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START SelectDilutionsParser";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -195,11 +195,11 @@ namespace SmartPeak
     SampleGroupHandler& sampleGroupHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START MergeInjections";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     // Check the parameters
     if (params_I.at("MergeInjections").empty() && params_I.at("MergeInjections").empty()) {
@@ -700,11 +700,11 @@ namespace SmartPeak
   void LoadFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START LoadFeaturesSampleGroup";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Loading: " << filenames.getFullPathName("featureXMLSampleGroup_i");
 
     if (filenames.getFullPathName("featureXMLSampleGroup_i").empty()) {
@@ -745,11 +745,11 @@ namespace SmartPeak
   void StoreFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeaturesSampleGroup";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
     LOGI << "Storing: " << filenames.getFullPathName("featureXMLSampleGroup_o");
 
     if (filenames.getFullPathName("featureXMLSampleGroup_o").empty()) {

--- a/src/smartpeak/source/core/SampleGroupProcessor.cpp
+++ b/src/smartpeak/source/core/SampleGroupProcessor.cpp
@@ -67,11 +67,11 @@ namespace SmartPeak
     std::map<std::string, int> select_dilution_map;
     try
     {
-      SelectDilutionsParser::read(filenames.getFullPath("selectDilutions_csv_i"), select_dilution_map);
+      SelectDilutionsParser::read(filenames.getFullPath("selectDilutions_csv_i").generic_string(), select_dilution_map);
     }
     catch (const std::exception& e)
     {
-      LOGE << "Failed to read select dilutions file [" << filenames.getFullPath("selectDilutions_csv_i") << "] : " << e.what();
+      LOGE << "Failed to read select dilutions file [" << filenames.getFullPath("selectDilutions_csv_i").generic_string() << "] : " << e.what();
       return;
     }
 
@@ -705,23 +705,16 @@ namespace SmartPeak
   {
     LOGD << "START LoadFeaturesSampleGroup";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Loading: " << filenames.getFullPath("featureXMLSampleGroup_i");
 
-    if (filenames.getFullPath("featureXMLSampleGroup_i").empty()) {
-      LOGE << "Filename is empty";
-      LOGD << "END LoadFeaturesSampleGroup";
-      return;
-    }
-
-    if (!InputDataValidation::fileExists(filenames.getFullPath("featureXMLSampleGroup_i"))) {
-      LOGE << "File not found";
-      LOGD << "END LoadFeaturesSampleGroup";
+    if (!InputDataValidation::prepareToLoad(filenames, "featureXMLSampleGroup_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::FeatureXMLFile featurexml;
-      featurexml.load(filenames.getFullPath("featureXMLSampleGroup_i"), sampleGroupHandler_IO.getFeatureMap());
+      featurexml.load(filenames.getFullPath("featureXMLSampleGroup_i").generic_string(), sampleGroupHandler_IO.getFeatureMap());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -750,18 +743,17 @@ namespace SmartPeak
   {
     LOGD << "START storeFeaturesSampleGroup";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Storing: " << filenames.getFullPath("featureXMLSampleGroup_o");
 
-    if (filenames.getFullPath("featureXMLSampleGroup_o").empty()) {
-      LOGE << "Filename is empty";
-      LOGD << "END storeFeaturesSampleGroup";
+    if (!InputDataValidation::prepareToStore(filenames, "featureXMLSampleGroup_o"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       // Store outfile as featureXML
       OpenMS::FeatureXMLFile featurexml;
-      featurexml.store(filenames.getFullPath("featureXMLSampleGroup_o"), sampleGroupHandler_IO.getFeatureMap());
+      featurexml.store(filenames.getFullPath("featureXMLSampleGroup_o").generic_string(), sampleGroupHandler_IO.getFeatureMap());
     }
     catch (const std::exception& e) {
       LOGE << e.what();

--- a/src/smartpeak/source/core/SampleGroupProcessor.cpp
+++ b/src/smartpeak/source/core/SampleGroupProcessor.cpp
@@ -48,7 +48,7 @@ namespace SmartPeak
 
   void SelectDilutions::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("selectDilutions_csv_i", "selectDilutions.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("selectDilutions_csv_i", "${MAIN_DIR}/selectDilutions.csv");
   };
 
   void SelectDilutions::process(
@@ -694,7 +694,7 @@ namespace SmartPeak
 
   void LoadFeaturesSampleGroup::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureXMLSampleGroup_i", ".featureXML", Filenames::FileScope::EFileScopeSampleGroupInput);
+    filenames.addFileName("featureXMLSampleGroup_i", ".featureXML");
   };
 
   void LoadFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO,
@@ -732,7 +732,7 @@ namespace SmartPeak
 
   void StoreFeaturesSampleGroup::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureXMLSampleGroup_o", ".featureXML", Filenames::FileScope::EFileScopeSampleGroupOutput);
+    filenames.addFileName("featureXMLSampleGroup_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_GROUP_NAME}.featureXML");
   };
 
   void StoreFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO,

--- a/src/smartpeak/source/core/SampleGroupProcessor.cpp
+++ b/src/smartpeak/source/core/SampleGroupProcessor.cpp
@@ -67,11 +67,11 @@ namespace SmartPeak
     std::map<std::string, int> select_dilution_map;
     try
     {
-      SelectDilutionsParser::read(filenames.getFullPathName("selectDilutions_csv_i"), select_dilution_map);
+      SelectDilutionsParser::read(filenames.getFullPath("selectDilutions_csv_i"), select_dilution_map);
     }
     catch (const std::exception& e)
     {
-      LOGE << "Failed to read select dilutions file [" << filenames.getFullPathName("selectDilutions_csv_i") << "] : " << e.what();
+      LOGE << "Failed to read select dilutions file [" << filenames.getFullPath("selectDilutions_csv_i") << "] : " << e.what();
       return;
     }
 
@@ -705,15 +705,15 @@ namespace SmartPeak
   {
     LOGD << "START LoadFeaturesSampleGroup";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Loading: " << filenames.getFullPathName("featureXMLSampleGroup_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureXMLSampleGroup_i");
 
-    if (filenames.getFullPathName("featureXMLSampleGroup_i").empty()) {
+    if (filenames.getFullPath("featureXMLSampleGroup_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END LoadFeaturesSampleGroup";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.getFullPathName("featureXMLSampleGroup_i"))) {
+    if (!InputDataValidation::fileExists(filenames.getFullPath("featureXMLSampleGroup_i"))) {
       LOGE << "File not found";
       LOGD << "END LoadFeaturesSampleGroup";
       return;
@@ -721,7 +721,7 @@ namespace SmartPeak
 
     try {
       OpenMS::FeatureXMLFile featurexml;
-      featurexml.load(filenames.getFullPathName("featureXMLSampleGroup_i"), sampleGroupHandler_IO.getFeatureMap());
+      featurexml.load(filenames.getFullPath("featureXMLSampleGroup_i"), sampleGroupHandler_IO.getFeatureMap());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -750,9 +750,9 @@ namespace SmartPeak
   {
     LOGD << "START storeFeaturesSampleGroup";
     Filenames filenames = prepareFileNames(filenames_I);
-    LOGI << "Storing: " << filenames.getFullPathName("featureXMLSampleGroup_o");
+    LOGI << "Storing: " << filenames.getFullPath("featureXMLSampleGroup_o");
 
-    if (filenames.getFullPathName("featureXMLSampleGroup_o").empty()) {
+    if (filenames.getFullPath("featureXMLSampleGroup_o").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END storeFeaturesSampleGroup";
       return;
@@ -761,7 +761,7 @@ namespace SmartPeak
     try {
       // Store outfile as featureXML
       OpenMS::FeatureXMLFile featurexml;
-      featurexml.store(filenames.getFullPathName("featureXMLSampleGroup_o"), sampleGroupHandler_IO.getFeatureMap());
+      featurexml.store(filenames.getFullPath("featureXMLSampleGroup_o"), sampleGroupHandler_IO.getFeatureMap());
     }
     catch (const std::exception& e) {
       LOGE << e.what();

--- a/src/smartpeak/source/core/SampleGroupProcessor.cpp
+++ b/src/smartpeak/source/core/SampleGroupProcessor.cpp
@@ -55,10 +55,11 @@ namespace SmartPeak
     SampleGroupHandler& sampleGroupHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START SelectDilutionsParser";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     ParameterSet params(params_I);
     params.merge(getParameterSchema());
@@ -194,10 +195,11 @@ namespace SmartPeak
     SampleGroupHandler& sampleGroupHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START MergeInjections";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     // Check the parameters
     if (params_I.at("MergeInjections").empty() && params_I.at("MergeInjections").empty()) {
@@ -695,9 +697,14 @@ namespace SmartPeak
     filenames.addFileName("featureXMLSampleGroup_i", ".featureXML", Filenames::FileScope::EFileScopeSampleGroupInput);
   };
 
-  void LoadFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO, const SequenceHandler& sequenceHandler_I, const ParameterSet& params_I, const Filenames& filenames) const
+  void LoadFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO,
+    const SequenceHandler& sequenceHandler_I,
+    const ParameterSet& params_I,
+    const Filenames& filenames_override
+  ) const
   {
     LOGD << "START LoadFeaturesSampleGroup";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Loading: " << filenames.getFullPathName("featureXMLSampleGroup_i");
 
     if (filenames.getFullPathName("featureXMLSampleGroup_i").empty()) {
@@ -735,9 +742,14 @@ namespace SmartPeak
     filenames.addFileName("featureXMLSampleGroup_o", ".featureXML", Filenames::FileScope::EFileScopeSampleGroupOutput);
   };
 
-  void StoreFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO, const SequenceHandler& sequenceHandler_I, const ParameterSet& params_I, const Filenames& filenames) const
+  void StoreFeaturesSampleGroup::process(SampleGroupHandler& sampleGroupHandler_IO,
+    const SequenceHandler& sequenceHandler_I,
+    const ParameterSet& params_I,
+    const Filenames& filenames_override
+  ) const
   {
     LOGD << "START storeFeaturesSampleGroup";
+    Filenames filenames = prepareFileNames(filenames_override);
     LOGI << "Storing: " << filenames.getFullPathName("featureXMLSampleGroup_o");
 
     if (filenames.getFullPathName("featureXMLSampleGroup_o").empty()) {

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -45,7 +45,7 @@ namespace SmartPeak
   bool CreateSequence::buildStaticFilenames(ApplicationHandler* application_handler, Filenames& filenames)
   {
     application_handler->main_dir_ = std::filesystem::path(application_handler->sequence_pathname_).remove_filename().generic_string();
-    filenames.setTag("MAIN_DIR", application_handler->main_dir_.generic_string());
+    filenames.setTag(Filenames::Tag::MAIN_DIR, application_handler->main_dir_.generic_string());
     filenames.setFullPath("sequence_csv_i", application_handler->sequence_pathname_);
 
     LOGN << "\n\n"

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -57,26 +57,23 @@ namespace SmartPeak
     return is_valid;
   }
 
-  bool CreateSequence::buildStaticFilenames(ApplicationHandler* application_handler, Filenames& f)
+  bool CreateSequence::buildStaticFilenames(ApplicationHandler* application_handler, Filenames& filenames)
   {
     application_handler->main_dir_ = std::filesystem::path(application_handler->sequence_pathname_).remove_filename().generic_string();
-    f.setRootPaths(application_handler->main_dir_, "", "", "");
-    f.setFullPathName("sequence_csv_i", application_handler->sequence_pathname_);
+    filenames.setRootPaths(application_handler->main_dir_, "", "", "");
+    filenames.setFullPathName("sequence_csv_i", application_handler->sequence_pathname_);
 
     LOGN << "\n\n"
       "The following list of file was searched for:\n";
     std::vector<InputDataValidation::FilenameInfo> is_valid;
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("sequence_csv_i"), "sequence", true));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("parameters_csv_i"), "parameters", true));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("traML_csv_i"), "traml", true));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponents_csv_i"), "featureFilter", false));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponentGroups_csv_i"), "featureFilterGroups", false));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponents_csv_i"), "featureQC", false));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponentGroups_csv_i"), "featureQCGroups", false));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("quantitationMethods_csv_i"), "quantitationMethods", false));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("standardsConcentrations_csv_i"), "standardsConcentrations", false));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("referenceData_csv_i"), "referenceData", false));
-
+    is_valid.push_back(InputDataValidation::processorInputAreReady(*this, "sequence", filenames, true));
+    is_valid.push_back(InputDataValidation::processorInputAreReady(LoadParameters(), "parameters", filenames, true));
+    is_valid.push_back(InputDataValidation::processorInputAreReady(LoadTransitions(), "traml", filenames, true));
+    is_valid.push_back(InputDataValidation::processorInputAreReady(LoadFeatureFilters(), "featureFilter", filenames, false));
+    is_valid.push_back(InputDataValidation::processorInputAreReady(LoadFeatureQCs(), "featureQC", filenames, false));
+    is_valid.push_back(InputDataValidation::processorInputAreReady(LoadQuantitationMethods(), "quantitationMethods", filenames, false));
+    is_valid.push_back(InputDataValidation::processorInputAreReady(LoadStandardsConcentrations(), "standardsConcentrations", filenames, false));
+    is_valid.push_back(InputDataValidation::processorInputAreReady(LoadValidationData(), "referenceData", filenames, false));
     std::cout << "\n\n";
 
     const bool requiredPathnamesAreValidBool = requiredPathnamesAreValid(is_valid);

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -99,7 +99,7 @@ namespace SmartPeak
     return true;
   }
 
-  bool CreateSequence::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool CreateSequence::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     application_handler->sequence_pathname_ = filename;
     application_handler->mzML_dir_.clear();
@@ -483,7 +483,7 @@ namespace SmartPeak
     }
   }
 
-  bool LoadWorkflow::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadWorkflow::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     filename_ = filename;
     process();
@@ -499,7 +499,7 @@ namespace SmartPeak
   {
     // TODO: move to parameters at some point
     LOGD << "START LoadWorkflow";
-    LOGI << "Loading " << filename_;
+    LOGI << "Loading " << filename_.generic_string();
 
     if (filename_.empty()) {
       LOGE << "Filename is empty";
@@ -515,7 +515,7 @@ namespace SmartPeak
 
     std::vector<std::string> res;
     try {
-      io::CSVReader<1, io::trim_chars<>, io::no_quote_escape<','>> in(filename_);
+      io::CSVReader<1, io::trim_chars<>, io::no_quote_escape<','>> in(filename_.generic_string());
       const std::string s_command_name{ "command_name" };
       in.read_header(
         io::ignore_extra_column,
@@ -543,7 +543,7 @@ namespace SmartPeak
     LOGD << "END LoadWorkflow";
   }
 
-  bool StoreWorkflow::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool StoreWorkflow::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     filename_ = filename;
     process();
@@ -553,10 +553,10 @@ namespace SmartPeak
   void StoreWorkflow::process()
   {
     LOGD << "START StoreWorkflow";
-    LOGI << "Storing " << filename_;
+    LOGI << "Storing " << filename_.generic_string();
 
     std::vector<std::string> headers = { "command_name" };
-    CSVWriter writer(filename_, ",");
+    CSVWriter writer(filename_.generic_string(), ",");
     const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
     if (cnt < headers.size()) {

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -45,7 +45,7 @@ namespace SmartPeak
   bool CreateSequence::buildStaticFilenames(ApplicationHandler* application_handler, Filenames& filenames)
   {
     application_handler->main_dir_ = std::filesystem::path(application_handler->sequence_pathname_).remove_filename().generic_string();
-    filenames.setRootPaths(application_handler->main_dir_, "", "", "");
+    filenames.setTag("MAIN_DIR", application_handler->main_dir_.generic_string());
     filenames.setFullPath("sequence_csv_i", application_handler->sequence_pathname_);
 
     LOGN << "\n\n"
@@ -97,7 +97,7 @@ namespace SmartPeak
 
   void CreateSequence::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("sequence_csv_i", "sequence.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("sequence_csv_i", "${MAIN_DIR}/sequence.csv");
   };
 
   void CreateSequence::process()
@@ -464,7 +464,7 @@ namespace SmartPeak
 
   void LoadWorkflow::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("workflow_csv_i", "workflow.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("workflow_csv_i", "${MAIN_DIR}/workflow.csv");
   };
 
   void LoadWorkflow::process()

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -95,7 +95,7 @@ namespace SmartPeak
     }
   }
 
-  void CreateSequence::getInputsOutputs(Filenames& filenames) const
+  void CreateSequence::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("sequence_csv_i", "${MAIN_DIR}/sequence.csv");
   };
@@ -103,7 +103,7 @@ namespace SmartPeak
   void CreateSequence::process()
   {
     LOGD << "START createSequence";
-    filenames_ = prepareFileNames(filenames_);
+    filenames_ = prepareFilenames(filenames_);
 
     SequenceParser::readSequenceFile(*sequenceHandler_IO, filenames_.getFullPath("sequence_csv_i"), delimiter);
     if (sequenceHandler_IO->getSequence().empty()) {
@@ -462,7 +462,7 @@ namespace SmartPeak
     return true;
   }
 
-  void LoadWorkflow::getInputsOutputs(Filenames& filenames) const
+  void LoadWorkflow::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("workflow_csv_i", "${MAIN_DIR}/workflow.csv");
   };
@@ -471,7 +471,7 @@ namespace SmartPeak
   {
     // TODO: move to parameters at some point
     LOGD << "START LoadWorkflow";
-    filenames_ = prepareFileNames(filenames_);
+    filenames_ = prepareFilenames(filenames_);
     if (!InputDataValidation::prepareToLoad(filenames_, "workflow_csv_i"))
     {
       LOGD << "END " << getName();

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -62,44 +62,48 @@ namespace SmartPeak
     // clearNonExistantFilename(f.sequence_csv_i);   // The file must exist
     // clearNonExistantFilename(f.parameters_csv_i); // The file must exist
     // clearNonExistantFilename(f.traML_csv_i);      // The file must exist
-    clearNonExistantFilename(f.featureFilterComponents_csv_i);
-    clearNonExistantFilename(f.featureFilterComponentGroups_csv_i);
-    clearNonExistantFilename(f.featureQCComponents_csv_i);
-    clearNonExistantFilename(f.featureQCComponentGroups_csv_i);
-    clearNonExistantFilename(f.quantitationMethods_csv_i);
-    clearNonExistantFilename(f.standardsConcentrations_csv_i);
-    clearNonExistantFilename(f.referenceData_csv_i);
+    // TODO add another property to the Files and clear based on that information
+    clearNonExistantFilename(f, "featureFilterComponents_csv_i");
+    clearNonExistantFilename(f, "featureFilterComponentGroups_csv_i");
+    clearNonExistantFilename(f, "featureQCComponents_csv_i");
+    clearNonExistantFilename(f, "featureQCComponentGroups_csv_i");
+    clearNonExistantFilename(f, "quantitationMethods_csv_i");
+    clearNonExistantFilename(f, "standardsConcentrations_csv_i");
+    clearNonExistantFilename(f, "referenceData_csv_i");
   }
 
-  void CreateSequence::clearNonExistantFilename(std::string& filename)
+  void CreateSequence::clearNonExistantFilename(Filenames& f, const std::string& file_id)
   {
+    const auto& filename = f.getFullPathName(file_id);
     if (InputDataValidation::fileExists(filename) == false) {
-      filename.clear();
+      f.setFullPathName(file_id, "");
     }
   }
 
   bool CreateSequence::buildStaticFilenames(ApplicationHandler* application_handler)
   {
+    getInputsOutputs(application_handler->static_filenames_);
     Filenames& f = application_handler->static_filenames_;
     application_handler->main_dir_ = std::filesystem::path(application_handler->sequence_pathname_).remove_filename().generic_string();
-    f = Filenames::getDefaultStaticFilenames(application_handler->main_dir_);
+    f.setRootPaths(application_handler->main_dir_, "", "", "");
     clearNonExistantDefaultGeneratedFilenames(f);
-    f.sequence_csv_i = application_handler->sequence_pathname_;
+    f.setFullPathName("sequence_csv_i", application_handler->sequence_pathname_);
 
     LOGN << "\n\n"
       "The following list of file was searched for:\n";
     std::vector<InputDataValidation::FilenameInfo> is_valid;
-    is_valid.push_back(InputDataValidation::isValidFilename(f.sequence_csv_i, "sequence"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.parameters_csv_i, "parameters"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.traML_csv_i, "traml"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.featureFilterComponents_csv_i, "featureFilter"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.featureFilterComponentGroups_csv_i, "featureFilterGroups"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.featureQCComponents_csv_i, "featureQC"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.featureQCComponentGroups_csv_i, "featureQCGroups"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.quantitationMethods_csv_i, "quantitationMethods"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.standardsConcentrations_csv_i, "standardsConcentrations"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.referenceData_csv_i, "referenceData"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.selectDilutions_csv_i, "selectDilutions"));
+    // TODO add another property to the Files and check validity based on that information
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("sequence_csv_i"), "sequence"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("parameters_csv_i"), "parameters"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("traML_csv_i"), "traml"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponents_csv_i"), "featureFilter"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponentGroups_csv_i"), "featureFilterGroups"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponents_csv_i"), "featureQC"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponentGroups_csv_i"), "featureQCGroups"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("quantitationMethods_csv_i"), "quantitationMethods"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("standardsConcentrations_csv_i"), "standardsConcentrations"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("referenceData_csv_i"), "referenceData"));
+//    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("selectDilutions_csv_i"), "selectDilutions"));
 
     std::cout << "\n\n";
 
@@ -112,8 +116,7 @@ namespace SmartPeak
     { return arg.validity != InputDataValidation::FilenameInfo::invalid; });
 
     if (!requiredPathnamesAreValidBool || !otherPathnamesAreFine) {
-      LOGF << "\n\nERROR!!!\n"
-        "One or more pathnames are not valid.\n";
+      LOGE << "One or more pathnames are not valid.\n";
       if (!requiredPathnamesAreValidBool) {
         LOGF << "\n\n"
           "Make sure that the following required pathnames are provided:\n"
@@ -152,11 +155,46 @@ namespace SmartPeak
     }
   }
 
+  void CreateSequence::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("sequence_csv_i", "sequence.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("workflow_csv_i", "workflow.csv", Filenames::FileScope::EFileScopeMain);
+    LoadWorkflow loadWorkflow(*sequenceHandler_IO);
+    loadWorkflow.getInputsOutputs(filenames);
+    LoadParameters loadParameters;
+    loadParameters.getInputsOutputs(filenames);
+    LoadTransitions loadTransitions;
+    loadTransitions.getInputsOutputs(filenames);
+    // raw data files (i.e., mzML, trafo, etc., will be loaded dynamically)
+    LoadValidationData loadValidationData;
+    loadValidationData.getInputsOutputs(filenames);
+    LoadQuantitationMethods loadQuantitationMethods;
+    loadQuantitationMethods.getInputsOutputs(filenames);
+    LoadStandardsConcentrations loadStandardsConcentrations;
+    loadStandardsConcentrations.getInputsOutputs(filenames);
+    LoadFeatureFilters loadFeatureFilters;
+    loadFeatureFilters.getInputsOutputs(filenames);
+    LoadFeatureQCs loadFeatureQCs;
+    loadFeatureQCs.getInputsOutputs(filenames);
+    LoadFeatureRSDFilters loadFeatureRSDFilters;
+    loadFeatureRSDFilters.getInputsOutputs(filenames);
+    LoadFeatureRSDQCs loadFeatureRSDQCs;
+    loadFeatureRSDQCs.getInputsOutputs(filenames);
+    LoadFeatureBackgroundFilters loadFeatureBackgroundFilters;
+    loadFeatureBackgroundFilters.getInputsOutputs(filenames);
+    LoadFeatureBackgroundQCs loadFeatureBackgroundQCs;
+    loadFeatureBackgroundQCs.getInputsOutputs(filenames);
+    LoadFeatureFiltersRDP loadFeatureFiltersRDP;
+    loadFeatureFiltersRDP.getInputsOutputs(filenames);
+    LoadFeatureQCsRDP loadFeatureQCsRDP;
+    loadFeatureQCsRDP.getInputsOutputs(filenames);
+  };
+
   void CreateSequence::process()
   {
     LOGD << "START createSequence";
 
-    SequenceParser::readSequenceFile(*sequenceHandler_IO, filenames_.sequence_csv_i, delimiter);
+    SequenceParser::readSequenceFile(*sequenceHandler_IO, filenames_.getFullPathName("sequence_csv_i"), delimiter);
     if (sequenceHandler_IO->getSequence().empty()) {
       LOGE << "Empty sequence. Returning";
       LOGD << "END createSequence";
@@ -165,7 +203,8 @@ namespace SmartPeak
 
     // load workflow
     LoadWorkflow loadWorkflow(*sequenceHandler_IO);
-    loadWorkflow.filename_ = filenames_.workflow_csv_i;
+    loadWorkflow.getInputsOutputs(filenames_);
+    loadWorkflow.filename_ = filenames_.getFullPathName("workflow_csv_i");
     loadWorkflow.process();
 
     // TODO: Given that the raw data is shared between all injections, it could
@@ -175,40 +214,51 @@ namespace SmartPeak
 
     // load rawDataHandler files (applies to the whole session)
     LoadParameters loadParameters;
+    loadParameters.getInputsOutputs(filenames_);
     loadParameters.parameters_observable_ = sequenceHandler_IO;
     loadParameters.process(rawDataHandler, {}, filenames_);
     LoadTransitions loadTransitions;
+    loadTransitions.getInputsOutputs(filenames_);
     loadTransitions.transitions_observable_ = sequenceHandler_IO;
     loadTransitions.process(rawDataHandler, {}, filenames_);
     // raw data files (i.e., mzML, trafo, etc., will be loaded dynamically)
     LoadValidationData loadValidationData;
+    loadValidationData.getInputsOutputs(filenames_);
     loadValidationData.process(rawDataHandler, {}, filenames_);
     // raw data files (i.e., mzML, trafo, etc., will be loaded dynamically)
 
     // load sequenceSegmentHandler files
     for (SequenceSegmentHandler& sequenceSegmentHandler: sequenceHandler_IO->getSequenceSegments()) {
       LoadQuantitationMethods loadQuantitationMethods;
+      loadQuantitationMethods.getInputsOutputs(filenames_);
       loadQuantitationMethods.sequence_segment_observable_ = sequenceHandler_IO;
       loadQuantitationMethods.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadStandardsConcentrations loadStandardsConcentrations;
+      loadStandardsConcentrations.getInputsOutputs(filenames_);
       loadStandardsConcentrations.sequence_segment_observable_ = sequenceHandler_IO;
       loadStandardsConcentrations.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureFilters loadFeatureFilters;
+      loadFeatureFilters.getInputsOutputs(filenames_);
       loadFeatureFilters.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureFilters.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureQCs loadFeatureQCs;
+      loadFeatureQCs.getInputsOutputs(filenames_);
       loadFeatureQCs.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureQCs.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureRSDFilters loadFeatureRSDFilters;
+      loadFeatureRSDFilters.getInputsOutputs(filenames_);
       loadFeatureRSDFilters.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureRSDFilters.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureRSDQCs loadFeatureRSDQCs;
+      loadFeatureRSDQCs.getInputsOutputs(filenames_);
       loadFeatureRSDQCs.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureRSDQCs.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureBackgroundFilters loadFeatureBackgroundFilters;
+      loadFeatureBackgroundFilters.getInputsOutputs(filenames_);
       loadFeatureBackgroundFilters.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureBackgroundFilters.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureBackgroundQCs loadFeatureBackgroundQCs;
+      loadFeatureBackgroundQCs.getInputsOutputs(filenames_);
       loadFeatureBackgroundQCs.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureBackgroundQCs.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
     }
@@ -512,6 +562,11 @@ namespace SmartPeak
     process();
     return true;
   }
+
+  void LoadWorkflow::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("workflow_csv_i", "workflow.csv", Filenames::FileScope::EFileScopeMain);
+  };
 
   void LoadWorkflow::process()
   {

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -57,10 +57,8 @@ namespace SmartPeak
     return is_valid;
   }
 
-  bool CreateSequence::buildStaticFilenames(ApplicationHandler* application_handler)
+  bool CreateSequence::buildStaticFilenames(ApplicationHandler* application_handler, Filenames& f)
   {
-    getInputsOutputs(application_handler->static_filenames_);
-    Filenames& f = application_handler->static_filenames_;
     application_handler->main_dir_ = std::filesystem::path(application_handler->sequence_pathname_).remove_filename().generic_string();
     f.setRootPaths(application_handler->main_dir_, "", "", "");
     f.setFullPathName("sequence_csv_i", application_handler->sequence_pathname_);
@@ -68,8 +66,6 @@ namespace SmartPeak
     LOGN << "\n\n"
       "The following list of file was searched for:\n";
     std::vector<InputDataValidation::FilenameInfo> is_valid;
-    // TODO add another property to the Files and check validity based on that information
-    /*
     is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("sequence_csv_i"), "sequence", true));
     is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("parameters_csv_i"), "parameters", true));
     is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("traML_csv_i"), "traml", true));
@@ -103,7 +99,6 @@ namespace SmartPeak
       LOGN << "Apply the fixes and reload the sequence file.\n";
       return false;
     }
-    */
     return true;
   }
 
@@ -114,10 +109,9 @@ namespace SmartPeak
     application_handler->features_in_dir_.clear();
     application_handler->features_out_dir_.clear();
     LOGI << "Pathnames for 'mzML', 'INPUT features' and 'OUTPUT features' reset.";
-    const bool pathnamesAreCorrect = buildStaticFilenames(application_handler);
+    const bool pathnamesAreCorrect = buildStaticFilenames(application_handler, filenames_);
     if (pathnamesAreCorrect) {
       application_handler->sequenceHandler_.clear();
-      filenames_ = application_handler->static_filenames_;
       delimiter = ",";
       checkConsistency = false; // NOTE: Requires a lot of time on large sequences with a large number of components
       process();

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -140,6 +140,7 @@ namespace SmartPeak
   void CreateSequence::process()
   {
     LOGD << "START createSequence";
+    filenames_ = prepareFileNames(filenames_);
 
     SequenceParser::readSequenceFile(*sequenceHandler_IO, filenames_.getFullPathName("sequence_csv_i"), delimiter);
     if (sequenceHandler_IO->getSequence().empty()) {
@@ -150,7 +151,6 @@ namespace SmartPeak
 
     // load workflow
     LoadWorkflow loadWorkflow(*sequenceHandler_IO);
-    loadWorkflow.getInputsOutputs(filenames_);
     loadWorkflow.filename_ = filenames_.getFullPathName("workflow_csv_i");
     loadWorkflow.process();
 

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -514,7 +514,7 @@ namespace SmartPeak
 
   void processInjection(
     InjectionHandler& injection,
-    const Filenames& filenames,
+    const Filenames& filenames_override,
     const std::vector<std::shared_ptr<RawDataProcessor>>& methods
   )
   {
@@ -526,7 +526,7 @@ namespace SmartPeak
       p->process( //TODO: (SIGABRT)
         injection.getRawData(),
         injection.getRawData().getParameters(),
-        filenames
+        filenames_override
       );
     }
   }

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -56,53 +56,28 @@ namespace SmartPeak
     return is_valid;
   }
 
-  void CreateSequence::clearNonExistantDefaultGeneratedFilenames(Filenames& f)
-  {
-    // clearNonExistantFilename(f.sequence_csv_i);   // The file must exist
-    // clearNonExistantFilename(f.parameters_csv_i); // The file must exist
-    // clearNonExistantFilename(f.traML_csv_i);      // The file must exist
-    // TODO add another property to the Files and clear based on that information
-    clearNonExistantFilename(f, "featureFilterComponents_csv_i");
-    clearNonExistantFilename(f, "featureFilterComponentGroups_csv_i");
-    clearNonExistantFilename(f, "featureQCComponents_csv_i");
-    clearNonExistantFilename(f, "featureQCComponentGroups_csv_i");
-    clearNonExistantFilename(f, "quantitationMethods_csv_i");
-    clearNonExistantFilename(f, "standardsConcentrations_csv_i");
-    clearNonExistantFilename(f, "referenceData_csv_i");
-  }
-
-  void CreateSequence::clearNonExistantFilename(Filenames& f, const std::string& file_id)
-  {
-    const auto& filename = f.getFullPathName(file_id);
-    if (InputDataValidation::fileExists(filename) == false) {
-      f.setFullPathName(file_id, "");
-    }
-  }
-
   bool CreateSequence::buildStaticFilenames(ApplicationHandler* application_handler)
   {
     getInputsOutputs(application_handler->static_filenames_);
     Filenames& f = application_handler->static_filenames_;
     application_handler->main_dir_ = application_handler->sequence_pathname_.substr(0, application_handler->sequence_pathname_.find_last_of('/'));
     f.setRootPaths(application_handler->main_dir_, "", "", "");
-    clearNonExistantDefaultGeneratedFilenames(f);
     f.setFullPathName("sequence_csv_i", application_handler->sequence_pathname_);
 
     LOGN << "\n\n"
       "The following list of file was searched for:\n";
     std::vector<InputDataValidation::FilenameInfo> is_valid;
     // TODO add another property to the Files and check validity based on that information
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("sequence_csv_i"), "sequence"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("parameters_csv_i"), "parameters"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("traML_csv_i"), "traml"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponents_csv_i"), "featureFilter"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponentGroups_csv_i"), "featureFilterGroups"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponents_csv_i"), "featureQC"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponentGroups_csv_i"), "featureQCGroups"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("quantitationMethods_csv_i"), "quantitationMethods"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("standardsConcentrations_csv_i"), "standardsConcentrations"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("referenceData_csv_i"), "referenceData"));
-//    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("selectDilutions_csv_i"), "selectDilutions"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("sequence_csv_i"), "sequence", true));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("parameters_csv_i"), "parameters", true));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("traML_csv_i"), "traml", true));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponents_csv_i"), "featureFilter", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponentGroups_csv_i"), "featureFilterGroups", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponents_csv_i"), "featureQC", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponentGroups_csv_i"), "featureQCGroups", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("quantitationMethods_csv_i"), "quantitationMethods", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("standardsConcentrations_csv_i"), "standardsConcentrations", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("referenceData_csv_i"), "referenceData", false));
 
     std::cout << "\n\n";
 

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -57,53 +57,28 @@ namespace SmartPeak
     return is_valid;
   }
 
-  void CreateSequence::clearNonExistantDefaultGeneratedFilenames(Filenames& f)
-  {
-    // clearNonExistantFilename(f.sequence_csv_i);   // The file must exist
-    // clearNonExistantFilename(f.parameters_csv_i); // The file must exist
-    // clearNonExistantFilename(f.traML_csv_i);      // The file must exist
-    // TODO add another property to the Files and clear based on that information
-    clearNonExistantFilename(f, "featureFilterComponents_csv_i");
-    clearNonExistantFilename(f, "featureFilterComponentGroups_csv_i");
-    clearNonExistantFilename(f, "featureQCComponents_csv_i");
-    clearNonExistantFilename(f, "featureQCComponentGroups_csv_i");
-    clearNonExistantFilename(f, "quantitationMethods_csv_i");
-    clearNonExistantFilename(f, "standardsConcentrations_csv_i");
-    clearNonExistantFilename(f, "referenceData_csv_i");
-  }
-
-  void CreateSequence::clearNonExistantFilename(Filenames& f, const std::string& file_id)
-  {
-    const auto& filename = f.getFullPathName(file_id);
-    if (InputDataValidation::fileExists(filename) == false) {
-      f.setFullPathName(file_id, "");
-    }
-  }
-
   bool CreateSequence::buildStaticFilenames(ApplicationHandler* application_handler)
   {
     getInputsOutputs(application_handler->static_filenames_);
     Filenames& f = application_handler->static_filenames_;
     application_handler->main_dir_ = std::filesystem::path(application_handler->sequence_pathname_).remove_filename().generic_string();
     f.setRootPaths(application_handler->main_dir_, "", "", "");
-    clearNonExistantDefaultGeneratedFilenames(f);
     f.setFullPathName("sequence_csv_i", application_handler->sequence_pathname_);
 
     LOGN << "\n\n"
       "The following list of file was searched for:\n";
     std::vector<InputDataValidation::FilenameInfo> is_valid;
     // TODO add another property to the Files and check validity based on that information
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("sequence_csv_i"), "sequence"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("parameters_csv_i"), "parameters"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("traML_csv_i"), "traml"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponents_csv_i"), "featureFilter"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponentGroups_csv_i"), "featureFilterGroups"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponents_csv_i"), "featureQC"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponentGroups_csv_i"), "featureQCGroups"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("quantitationMethods_csv_i"), "quantitationMethods"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("standardsConcentrations_csv_i"), "standardsConcentrations"));
-    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("referenceData_csv_i"), "referenceData"));
-//    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("selectDilutions_csv_i"), "selectDilutions"));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("sequence_csv_i"), "sequence", true));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("parameters_csv_i"), "parameters", true));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("traML_csv_i"), "traml", true));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponents_csv_i"), "featureFilter", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureFilterComponentGroups_csv_i"), "featureFilterGroups", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponents_csv_i"), "featureQC", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("featureQCComponentGroups_csv_i"), "featureQCGroups", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("quantitationMethods_csv_i"), "quantitationMethods", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("standardsConcentrations_csv_i"), "standardsConcentrations", false));
+    is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("referenceData_csv_i"), "referenceData", false));
 
     std::cout << "\n\n";
 

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -69,6 +69,7 @@ namespace SmartPeak
       "The following list of file was searched for:\n";
     std::vector<InputDataValidation::FilenameInfo> is_valid;
     // TODO add another property to the Files and check validity based on that information
+    /*
     is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("sequence_csv_i"), "sequence", true));
     is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("parameters_csv_i"), "parameters", true));
     is_valid.push_back(InputDataValidation::isValidFilename(f.getFullPathName("traML_csv_i"), "traml", true));
@@ -102,7 +103,7 @@ namespace SmartPeak
       LOGN << "Apply the fixes and reload the sequence file.\n";
       return false;
     }
-
+    */
     return true;
   }
 
@@ -134,35 +135,6 @@ namespace SmartPeak
   {
     filenames.addFileName("sequence_csv_i", "sequence.csv", Filenames::FileScope::EFileScopeMain);
     filenames.addFileName("workflow_csv_i", "workflow.csv", Filenames::FileScope::EFileScopeMain);
-    LoadWorkflow loadWorkflow(*sequenceHandler_IO);
-    loadWorkflow.getInputsOutputs(filenames);
-    LoadParameters loadParameters;
-    loadParameters.getInputsOutputs(filenames);
-    LoadTransitions loadTransitions;
-    loadTransitions.getInputsOutputs(filenames);
-    // raw data files (i.e., mzML, trafo, etc., will be loaded dynamically)
-    LoadValidationData loadValidationData;
-    loadValidationData.getInputsOutputs(filenames);
-    LoadQuantitationMethods loadQuantitationMethods;
-    loadQuantitationMethods.getInputsOutputs(filenames);
-    LoadStandardsConcentrations loadStandardsConcentrations;
-    loadStandardsConcentrations.getInputsOutputs(filenames);
-    LoadFeatureFilters loadFeatureFilters;
-    loadFeatureFilters.getInputsOutputs(filenames);
-    LoadFeatureQCs loadFeatureQCs;
-    loadFeatureQCs.getInputsOutputs(filenames);
-    LoadFeatureRSDFilters loadFeatureRSDFilters;
-    loadFeatureRSDFilters.getInputsOutputs(filenames);
-    LoadFeatureRSDQCs loadFeatureRSDQCs;
-    loadFeatureRSDQCs.getInputsOutputs(filenames);
-    LoadFeatureBackgroundFilters loadFeatureBackgroundFilters;
-    loadFeatureBackgroundFilters.getInputsOutputs(filenames);
-    LoadFeatureBackgroundQCs loadFeatureBackgroundQCs;
-    loadFeatureBackgroundQCs.getInputsOutputs(filenames);
-    LoadFeatureFiltersRDP loadFeatureFiltersRDP;
-    loadFeatureFiltersRDP.getInputsOutputs(filenames);
-    LoadFeatureQCsRDP loadFeatureQCsRDP;
-    loadFeatureQCsRDP.getInputsOutputs(filenames);
   };
 
   void CreateSequence::process()
@@ -189,51 +161,40 @@ namespace SmartPeak
 
     // load rawDataHandler files (applies to the whole session)
     LoadParameters loadParameters;
-    loadParameters.getInputsOutputs(filenames_);
     loadParameters.parameters_observable_ = sequenceHandler_IO;
     loadParameters.process(rawDataHandler, {}, filenames_);
     LoadTransitions loadTransitions;
-    loadTransitions.getInputsOutputs(filenames_);
     loadTransitions.transitions_observable_ = sequenceHandler_IO;
     loadTransitions.process(rawDataHandler, {}, filenames_);
     // raw data files (i.e., mzML, trafo, etc., will be loaded dynamically)
     LoadValidationData loadValidationData;
-    loadValidationData.getInputsOutputs(filenames_);
     loadValidationData.process(rawDataHandler, {}, filenames_);
     // raw data files (i.e., mzML, trafo, etc., will be loaded dynamically)
 
     // load sequenceSegmentHandler files
     for (SequenceSegmentHandler& sequenceSegmentHandler: sequenceHandler_IO->getSequenceSegments()) {
       LoadQuantitationMethods loadQuantitationMethods;
-      loadQuantitationMethods.getInputsOutputs(filenames_);
       loadQuantitationMethods.sequence_segment_observable_ = sequenceHandler_IO;
       loadQuantitationMethods.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadStandardsConcentrations loadStandardsConcentrations;
-      loadStandardsConcentrations.getInputsOutputs(filenames_);
       loadStandardsConcentrations.sequence_segment_observable_ = sequenceHandler_IO;
       loadStandardsConcentrations.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureFilters loadFeatureFilters;
-      loadFeatureFilters.getInputsOutputs(filenames_);
       loadFeatureFilters.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureFilters.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureQCs loadFeatureQCs;
-      loadFeatureQCs.getInputsOutputs(filenames_);
       loadFeatureQCs.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureQCs.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureRSDFilters loadFeatureRSDFilters;
-      loadFeatureRSDFilters.getInputsOutputs(filenames_);
       loadFeatureRSDFilters.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureRSDFilters.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureRSDQCs loadFeatureRSDQCs;
-      loadFeatureRSDQCs.getInputsOutputs(filenames_);
       loadFeatureRSDQCs.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureRSDQCs.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureBackgroundFilters loadFeatureBackgroundFilters;
-      loadFeatureBackgroundFilters.getInputsOutputs(filenames_);
       loadFeatureBackgroundFilters.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureBackgroundFilters.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
       LoadFeatureBackgroundQCs loadFeatureBackgroundQCs;
-      loadFeatureBackgroundQCs.getInputsOutputs(filenames_);
       loadFeatureBackgroundQCs.sequence_segment_observable_ = sequenceHandler_IO;
       loadFeatureBackgroundQCs.process(sequenceSegmentHandler, SequenceHandler(), {}, filenames_);
     }
@@ -514,7 +475,7 @@ namespace SmartPeak
 
   void processInjection(
     InjectionHandler& injection,
-    const Filenames& filenames_override,
+    const Filenames& filenames_I,
     const std::vector<std::shared_ptr<RawDataProcessor>>& methods
   )
   {
@@ -526,7 +487,7 @@ namespace SmartPeak
       p->process( //TODO: (SIGABRT)
         injection.getRawData(),
         injection.getRawData().getParameters(),
-        filenames_override
+        filenames_I
       );
     }
   }

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -61,7 +61,7 @@ namespace SmartPeak
   {
     application_handler->main_dir_ = std::filesystem::path(application_handler->sequence_pathname_).remove_filename().generic_string();
     filenames.setRootPaths(application_handler->main_dir_, "", "", "");
-    filenames.setFullPathName("sequence_csv_i", application_handler->sequence_pathname_);
+    filenames.setFullPath("sequence_csv_i", application_handler->sequence_pathname_);
 
     LOGN << "\n\n"
       "The following list of file was searched for:\n";
@@ -133,7 +133,7 @@ namespace SmartPeak
     LOGD << "START createSequence";
     filenames_ = prepareFileNames(filenames_);
 
-    SequenceParser::readSequenceFile(*sequenceHandler_IO, filenames_.getFullPathName("sequence_csv_i"), delimiter);
+    SequenceParser::readSequenceFile(*sequenceHandler_IO, filenames_.getFullPath("sequence_csv_i"), delimiter);
     if (sequenceHandler_IO->getSequence().empty()) {
       LOGE << "Empty sequence. Returning";
       LOGD << "END createSequence";
@@ -142,7 +142,7 @@ namespace SmartPeak
 
     // load workflow
     LoadWorkflow loadWorkflow(*sequenceHandler_IO);
-    loadWorkflow.filename_ = filenames_.getFullPathName("workflow_csv_i");
+    loadWorkflow.filename_ = filenames_.getFullPath("workflow_csv_i");
     loadWorkflow.process();
 
     // TODO: Given that the raw data is shared between all injections, it could

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -64,11 +64,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START optimizeCalibrationCurves";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     std::vector<size_t> standards_indices;
     // get all standards
@@ -180,11 +180,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadStandardsConcentrations";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("standardsConcentrations_csv_i");
 
@@ -243,11 +243,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadQuantitationMethods";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("quantitationMethods_csv_i");
 
@@ -290,11 +290,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeQuantitationMethods";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Storing: " << filenames.getFullPathName("quantitationMethods_csv_o");
 
@@ -348,15 +348,21 @@ namespace SmartPeak
     return true;
   }
 
+  void LoadFeatureFilters::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureFilterComponents_csv_i", "featureFilterComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureFilterComponentGroups_csv_i", "featureFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   void LoadFeatureFilters::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadFeatureFilter";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureFilterComponentGroups_csv_i");
@@ -433,15 +439,21 @@ namespace SmartPeak
     return true;
   }
 
+  void LoadFeatureQCs::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureQCComponents_csv_i", "featureQCComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureQCComponentGroups_csv_i", "featureQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   void LoadFeatureQCs::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadFeatureQC";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureQCComponentGroups_csv_i");
@@ -503,11 +515,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureFilter";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Storing: " << filenames.getFullPathName("featureFilterComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureFilterComponentGroups_csv_o");
@@ -551,11 +563,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureQC";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureQCComponentGroups_csv_o");
@@ -624,11 +636,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadFeatureRSDFilter";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureRSDFilterComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i");
@@ -715,11 +727,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadFeatureRSDQC";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureRSDQCComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureRSDQCComponentGroups_csv_i");
@@ -781,11 +793,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureRSDFilter";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Storing: " << filenames.getFullPathName("featureRSDFilterComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureRSDFilterComponentGroups_csv_o");
@@ -829,11 +841,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureRSDQC";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureRSDQCComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureRSDQCComponentGroups_csv_o");
@@ -902,11 +914,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadFeatureBackgroundFilter";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundFilterComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i");
@@ -993,11 +1005,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadFeatureBackgroundQC";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundQCComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i");
@@ -1059,11 +1071,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureBackgroundFilter";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Storing: " << filenames.getFullPathName("featureBackgroundFilterComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_o");
@@ -1107,11 +1119,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureBackgroundQC";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundQCComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_o");
@@ -1149,11 +1161,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START estimateFeatureFilterValues";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
 
     std::vector<size_t> standards_indices, qcs_indices;
@@ -1210,11 +1222,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START estimateFeatureQCValues";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
 
     std::vector<size_t> standards_indices, qcs_indices;
@@ -1271,11 +1283,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START TransferLOQToFeatureFilters";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
 
     // check if there are any quantitation methods
@@ -1303,11 +1315,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START TransferLOQToFeatureQCs";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
 
     // check if there are any quantitation methods
@@ -1335,11 +1347,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START EstimateFeatureRSDs";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
 
     // get all QCs
@@ -1384,11 +1396,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START EstimateFeatureBackgroundInterferences";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
 
     // get all Blanks
@@ -1441,11 +1453,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadFeatureRSDEstimation";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureRSDEstimationComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i");
@@ -1506,11 +1518,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureRSDEstimation";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Storing: " << filenames.getFullPathName("featureRSDEstimationComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_o");
@@ -1554,11 +1566,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START loadFeatureBackgroundEstimation";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i");
@@ -1619,11 +1631,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames_override
+    const Filenames& filenames_I
   ) const
   {
     LOGD << "START storeFeatureBackgroundEstimation";
-    Filenames filenames = prepareFileNames(filenames_override);
+    Filenames filenames = prepareFileNames(filenames_I);
 
     LOGI << "Storing: " << filenames.getFullPathName("featureBackgroundEstimationComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_o");

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -173,7 +173,7 @@ namespace SmartPeak
 
   void LoadStandardsConcentrations::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("standardsConcentrations_csv_i", "standardsConcentrations.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("standardsConcentrations_csv_i", "${MAIN_DIR}/standardsConcentrations.csv");
   };
 
   void LoadStandardsConcentrations::process(
@@ -212,7 +212,7 @@ namespace SmartPeak
 
   void LoadQuantitationMethods::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("quantitationMethods_csv_i", "quantitationMethods.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("quantitationMethods_csv_i", "${MAIN_DIR}/quantitationMethods.csv");
   };
 
   bool LoadQuantitationMethods::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
@@ -267,7 +267,7 @@ namespace SmartPeak
 
   void StoreQuantitationMethods::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("quantitationMethods_csv_o", "_quantitationMethods.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("quantitationMethods_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_quantitationMethods.csv");
   };
 
   void StoreQuantitationMethods::process(
@@ -332,8 +332,8 @@ namespace SmartPeak
 
   void LoadFeatureFilters::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureFilterComponents_csv_i", "featureFilterComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureFilterComponentGroups_csv_i", "featureFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureFilterComponents_csv_i", "${MAIN_DIR}/featureFilterComponents.csv");
+    filenames.addFileName("featureFilterComponentGroups_csv_i", "${MAIN_DIR}/featureFilterComponentGroups.csv");
   };
 
   void LoadFeatureFilters::process(
@@ -405,8 +405,8 @@ namespace SmartPeak
 
   void LoadFeatureQCs::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureQCComponents_csv_i", "featureQCComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureQCComponentGroups_csv_i", "featureQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureQCComponents_csv_i", "${MAIN_DIR}/featureQCComponents.csv");
+    filenames.addFileName("featureQCComponentGroups_csv_i", "${MAIN_DIR}/featureQCComponentGroups.csv");
   };
 
   void LoadFeatureQCs::process(
@@ -453,8 +453,8 @@ namespace SmartPeak
 
   void StoreFeatureFilters::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureFilterComponents_csv_o", "_featureFilterComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
-    filenames.addFileName("featureFilterComponentGroups_csv_o", "_featureFilterComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureFilterComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureFilterComponents.csv");
+    filenames.addFileName("featureFilterComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureFilterComponentGroups.csv");
   };
 
   void StoreFeatureFilters::process(
@@ -497,8 +497,8 @@ namespace SmartPeak
 
   void StoreFeatureQCs::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureQCComponents_csv_o", "_featureQCComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
-    filenames.addFileName("featureQCComponentGroups_csv_o", "_featureQCComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureQCComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureQCComponents.csv");
+    filenames.addFileName("featureQCComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureQCComponentGroups.csv");
   };
 
   void StoreFeatureQCs::process(
@@ -541,8 +541,8 @@ namespace SmartPeak
 
   void LoadFeatureRSDFilters::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureRSDFilterComponents_csv_i", "featureRSDFilterComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureRSDFilterComponentGroups_csv_i", "featureRSDFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureRSDFilterComponents_csv_i", "${MAIN_DIR}/featureRSDFilterComponents.csv");
+    filenames.addFileName("featureRSDFilterComponentGroups_csv_i", "${MAIN_DIR}/featureRSDFilterComponentGroups.csv");
   };
 
   bool LoadFeatureRSDFilters::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
@@ -621,8 +621,8 @@ namespace SmartPeak
 
   void LoadFeatureRSDQCs::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureRSDQCComponents_csv_i", "featureRSDQCComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureRSDQCComponentGroups_csv_i", "featureRSDQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureRSDQCComponents_csv_i", "${MAIN_DIR}/featureRSDQCComponents.csv");
+    filenames.addFileName("featureRSDQCComponentGroups_csv_i", "${MAIN_DIR}/featureRSDQCComponentGroups.csv");
   };
 
   bool LoadFeatureRSDQCs::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
@@ -694,8 +694,8 @@ namespace SmartPeak
 
   void StoreFeatureRSDFilters::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureRSDFilterComponents_csv_o", "_featureRSDFilterComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
-    filenames.addFileName("featureRSDFilterComponentGroups_csv_o", "_featureRSDFilterComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureRSDFilterComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDFilterComponents.csv");
+    filenames.addFileName("featureRSDFilterComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDFilterComponentGroups.csv");
   };
 
   void StoreFeatureRSDFilters::process(
@@ -738,8 +738,8 @@ namespace SmartPeak
 
   void StoreFeatureRSDQCs::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureRSDQCComponents_csv_o", "_featureRSDQCComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
-    filenames.addFileName("featureRSDQCComponentGroups_csv_o", "_featureRSDQCComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureRSDQCComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDQCComponents.csv");
+    filenames.addFileName("featureRSDQCComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDQCComponentGroups.csv");
   };
 
   void StoreFeatureRSDQCs::process(
@@ -782,8 +782,8 @@ namespace SmartPeak
 
   void LoadFeatureBackgroundFilters::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureBackgroundFilterComponents_csv_i", "featureBackgroundFilterComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureBackgroundFilterComponentGroups_csv_i", "featureBackgroundFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureBackgroundFilterComponents_csv_i", "${MAIN_DIR}/featureBackgroundFilterComponents.csv");
+    filenames.addFileName("featureBackgroundFilterComponentGroups_csv_i", "${MAIN_DIR}/featureBackgroundFilterComponentGroups.csv");
   };
 
   bool LoadFeatureBackgroundFilters::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
@@ -855,8 +855,8 @@ namespace SmartPeak
 
   void LoadFeatureBackgroundQCs::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureBackgroundQCComponents_csv_i", "featureBackgroundQCComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureBackgroundQCComponentGroups_csv_i", "featureBackgroundQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureBackgroundQCComponents_csv_i", "${MAIN_DIR}/featureBackgroundQCComponents.csv");
+    filenames.addFileName("featureBackgroundQCComponentGroups_csv_i", "${MAIN_DIR}/featureBackgroundQCComponentGroups.csv");
   };
 
   bool LoadFeatureBackgroundQCs::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
@@ -928,8 +928,8 @@ namespace SmartPeak
 
   void StoreFeatureBackgroundFilters::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureBackgroundFilterComponents_csv_o", "_featureBackgroundFilterComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
-    filenames.addFileName("featureBackgroundFilterComponentGroups_csv_o", "_featureBackgroundFilterComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureBackgroundFilterComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundFilterComponents.csv");
+    filenames.addFileName("featureBackgroundFilterComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundFilterComponentGroups.csv");
   };
 
   void StoreFeatureBackgroundFilters::process(
@@ -972,8 +972,8 @@ namespace SmartPeak
 
   void StoreFeatureBackgroundQCs::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureBackgroundQCComponents_csv_o", "_featureBackgroundQCComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
-    filenames.addFileName("featureBackgroundQCComponentGroups_csv_o", "_featureBackgroundQCComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureBackgroundQCComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundQCComponents.csv");
+    filenames.addFileName("featureBackgroundQCComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundQCComponentGroups.csv");
   };
 
   void StoreFeatureBackgroundQCs::process(
@@ -1302,8 +1302,8 @@ namespace SmartPeak
 
   void LoadFeatureRSDEstimations::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureRSDEstimationComponents_csv_i", "featureRSDEstimationComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureRSDEstimationComponentGroups_csv_i", "featureRSDEstimationComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureRSDEstimationComponents_csv_i", "${MAIN_DIR}/featureRSDEstimationComponents.csv");
+    filenames.addFileName("featureRSDEstimationComponentGroups_csv_i", "${MAIN_DIR}/featureRSDEstimationComponentGroups.csv");
   };
 
   void LoadFeatureRSDEstimations::process(
@@ -1349,8 +1349,8 @@ namespace SmartPeak
 
   void StoreFeatureRSDEstimations::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureRSDEstimationComponents_csv_o", "_featureRSDEstimationComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
-    filenames.addFileName("featureRSDEstimationComponentGroups_csv_o", "_featureRSDEstimationComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureRSDEstimationComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDEstimationComponents.csv");
+    filenames.addFileName("featureRSDEstimationComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDEstimationComponentGroups.csv");
   };
 
   void StoreFeatureRSDEstimations::process(
@@ -1393,8 +1393,8 @@ namespace SmartPeak
 
   void LoadFeatureBackgroundEstimations::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureBackgroundEstimationComponents_csv_i", "featureBackgroundEstimationComponents.csv", Filenames::FileScope::EFileScopeMain);
-    filenames.addFileName("featureBackgroundEstimationComponentGroups_csv_i", "featureBackgroundEstimationComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureBackgroundEstimationComponents_csv_i", "${MAIN_DIR}/featureBackgroundEstimationComponents.csv");
+    filenames.addFileName("featureBackgroundEstimationComponentGroups_csv_i", "${MAIN_DIR}/featureBackgroundEstimationComponentGroups.csv");
   };
 
   void LoadFeatureBackgroundEstimations::process(
@@ -1440,8 +1440,8 @@ namespace SmartPeak
 
   void StoreFeatureBackgroundEstimations::getInputsOutputs(Filenames& filenames) const
   {
-    filenames.addFileName("featureBackgroundEstimationComponents_csv_o", "_featureBackgroundEstimationComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
-    filenames.addFileName("featureBackgroundEstimationComponentGroups_csv_o", "_featureBackgroundEstimationComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureBackgroundEstimationComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundEstimationComponents.csv");
+    filenames.addFileName("featureBackgroundEstimationComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundEstimationComponentGroups.csv");
   };
 
   void StoreFeatureBackgroundEstimations::process(

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -64,10 +64,11 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START optimizeCalibrationCurves";
+    Filenames filenames = prepareFileNames(filenames_override);
 
     std::vector<size_t> standards_indices;
     // get all standards
@@ -179,10 +180,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadStandardsConcentrations";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("standardsConcentrations_csv_i");
 
     if (filenames.getFullPathName("standardsConcentrations_csv_i").empty()) {
@@ -240,10 +243,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadQuantitationMethods";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("quantitationMethods_csv_i");
 
     if (filenames.getFullPathName("quantitationMethods_csv_i").empty()) {
@@ -285,10 +290,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeQuantitationMethods";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Storing: " << filenames.getFullPathName("quantitationMethods_csv_o");
 
     if (filenames.getFullPathName("quantitationMethods_csv_o").empty()) {
@@ -345,10 +352,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadFeatureFilter";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureFilterComponentGroups_csv_i");
 
@@ -428,10 +437,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadFeatureQC";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureQCComponentGroups_csv_i");
 
@@ -492,10 +503,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureFilter";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Storing: " << filenames.getFullPathName("featureFilterComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureFilterComponentGroups_csv_o");
 
@@ -538,10 +551,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureQC";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureQCComponentGroups_csv_o");
 
@@ -609,10 +624,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadFeatureRSDFilter";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureRSDFilterComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i");
 
@@ -698,10 +715,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadFeatureRSDQC";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureRSDQCComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureRSDQCComponentGroups_csv_i");
 
@@ -762,10 +781,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureRSDFilter";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Storing: " << filenames.getFullPathName("featureRSDFilterComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureRSDFilterComponentGroups_csv_o");
 
@@ -808,10 +829,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureRSDQC";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureRSDQCComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureRSDQCComponentGroups_csv_o");
 
@@ -879,10 +902,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadFeatureBackgroundFilter";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundFilterComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i");
 
@@ -968,10 +993,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadFeatureBackgroundQC";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundQCComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i");
 
@@ -1032,10 +1059,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureBackgroundFilter";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Storing: " << filenames.getFullPathName("featureBackgroundFilterComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_o");
 
@@ -1078,10 +1107,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureBackgroundQC";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundQCComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_o");
 
@@ -1118,10 +1149,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START estimateFeatureFilterValues";
+    Filenames filenames = prepareFileNames(filenames_override);
+
 
     std::vector<size_t> standards_indices, qcs_indices;
 
@@ -1177,10 +1210,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START estimateFeatureQCValues";
+    Filenames filenames = prepareFileNames(filenames_override);
+
 
     std::vector<size_t> standards_indices, qcs_indices;
 
@@ -1236,10 +1271,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START TransferLOQToFeatureFilters";
+    Filenames filenames = prepareFileNames(filenames_override);
+
 
     // check if there are any quantitation methods
     if (sequenceSegmentHandler_IO.getQuantitationMethods().empty()) {
@@ -1266,10 +1303,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START TransferLOQToFeatureQCs";
+    Filenames filenames = prepareFileNames(filenames_override);
+
 
     // check if there are any quantitation methods
     if (sequenceSegmentHandler_IO.getQuantitationMethods().empty()) {
@@ -1296,10 +1335,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START EstimateFeatureRSDs";
+    Filenames filenames = prepareFileNames(filenames_override);
+
 
     // get all QCs
     std::vector<size_t> qcs_indices;
@@ -1343,10 +1384,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START EstimateFeatureBackgroundInterferences";
+    Filenames filenames = prepareFileNames(filenames_override);
+
 
     // get all Blanks
     std::vector<size_t> blanks_indices;
@@ -1398,10 +1441,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadFeatureRSDEstimation";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureRSDEstimationComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i");
 
@@ -1461,10 +1506,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureRSDEstimation";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Storing: " << filenames.getFullPathName("featureRSDEstimationComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_o");
 
@@ -1507,10 +1554,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START loadFeatureBackgroundEstimation";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i") << " and " <<
       filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i");
 
@@ -1570,10 +1619,12 @@ namespace SmartPeak
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
     const ParameterSet& params_I,
-    const Filenames& filenames
+    const Filenames& filenames_override
   ) const
   {
     LOGD << "START storeFeatureBackgroundEstimation";
+    Filenames filenames = prepareFileNames(filenames_override);
+
     LOGI << "Storing: " << filenames.getFullPathName("featureBackgroundEstimationComponents_csv_o") << " and " <<
       filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_o");
 

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -186,23 +186,15 @@ namespace SmartPeak
     LOGD << "START loadStandardsConcentrations";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("standardsConcentrations_csv_i");
-
-    if (filenames.getFullPath("standardsConcentrations_csv_i").empty()) {
-      LOGE << "Filename is empty";
-      LOGD << "END loadStandardsConcentrations";
-      return;
-    }
-
-    if (!InputDataValidation::fileExists(filenames.getFullPath("standardsConcentrations_csv_i"))) {
-      LOGE << "File not found";
-      LOGD << "END loadStandardsConcentrations";
+    if (!InputDataValidation::prepareToLoad(filenames, "standardsConcentrations_csv_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::AbsoluteQuantitationStandardsFile AQSf;
-      AQSf.load(filenames.getFullPath("standardsConcentrations_csv_i"), sequenceSegmentHandler_IO.getStandardsConcentrations());
+      AQSf.load(filenames.getFullPath("standardsConcentrations_csv_i").generic_string(), sequenceSegmentHandler_IO.getStandardsConcentrations());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -249,23 +241,15 @@ namespace SmartPeak
     LOGD << "START loadQuantitationMethods";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("quantitationMethods_csv_i");
-
-    if (filenames.getFullPath("quantitationMethods_csv_i").empty()) {
-      LOGE << "Filename is empty";
-      LOGD << "END loadQuantitationMethods";
-      return;
-    }
-
-    if (!InputDataValidation::fileExists(filenames.getFullPath("quantitationMethods_csv_i"))) {
-      LOGE << "File not found";
-      LOGD << "END loadQuantitationMethods";
+    if (!InputDataValidation::prepareToLoad(filenames, "quantitationMethods_csv_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::AbsoluteQuantitationMethodFile AQMf;
-      AQMf.load(filenames.getFullPath("quantitationMethods_csv_i"), sequenceSegmentHandler_IO.getQuantitationMethods());
+      AQMf.load(filenames.getFullPath("quantitationMethods_csv_i").generic_string(), sequenceSegmentHandler_IO.getQuantitationMethods());
       if (sequence_segment_observable_) sequence_segment_observable_->notifyQuantitationMethodsUpdated();
     }
     catch (const std::exception& e) {
@@ -296,18 +280,16 @@ namespace SmartPeak
     LOGD << "START storeQuantitationMethods";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPath("quantitationMethods_csv_o");
-
-    if (filenames.getFullPath("quantitationMethods_csv_o").empty()) {
-      LOGE << "Filename is empty";
-      LOGD << "END storeQuantitationMethods";
+    if (!InputDataValidation::prepareToStore(filenames, "quantitationMethods_csv_o"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::AbsoluteQuantitationMethodFile aqmf;
       aqmf.store(
-        filenames.getFullPath("quantitationMethods_csv_o"),
+        filenames.getFullPath("quantitationMethods_csv_o").generic_string(),
         sequenceSegmentHandler_IO.getQuantitationMethods()
       );
     }
@@ -364,38 +346,20 @@ namespace SmartPeak
     LOGD << "START loadFeatureFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureFilterComponents_csv_i") << " and " <<
-      filenames.getFullPath("featureFilterComponentGroups_csv_i");
-
-    if (filenames.getFullPath("featureFilterComponents_csv_i").empty() &&
-      filenames.getFullPath("featureFilterComponentGroups_csv_i").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END loadFeatureFilter";
-      return;
-    }
-
-    if (filenames.getFullPath("featureFilterComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureFilterComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureFilterComponents_csv_i");
-      LOGD << "END loadFeatureFilter";
-      return;
-    }
-
-    if (filenames.getFullPath("featureFilterComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureFilterComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureFilterComponentGroups_csv_i");
-      LOGD << "END loadFeatureFilter";
+    if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureFilterComponents_csv_i", "featureFilterComponentGroups_csv_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPath("featureFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureFilter(), false);
+      if (!filenames.getFullPath("featureFilterComponents_csv_i").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureFilterComponents_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureFilter(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureFiltersComponentsUpdated();
       }
-      if (filenames.getFullPath("featureFilterComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPath("featureFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureFilter(), true);
+      if (!filenames.getFullPath("featureFilterComponentGroups_csv_i").empty()) {
+        featureQCFile.load(filenames.getFullPath("featureFilterComponentGroups_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureFilter(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureFiltersComponentGroupsUpdated();
       }
     }
@@ -455,38 +419,20 @@ namespace SmartPeak
     LOGD << "START loadFeatureQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureQCComponents_csv_i") << " and " <<
-      filenames.getFullPath("featureQCComponentGroups_csv_i");
-
-    if (filenames.getFullPath("featureQCComponents_csv_i").empty() &&
-      filenames.getFullPath("featureQCComponentGroups_csv_i").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END loadFeatureQC";
-      return;
-    }
-
-    if (filenames.getFullPath("featureQCComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureQCComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureQCComponents_csv_i");
-      LOGD << "END loadFeatureQC";
-      return;
-    }
-
-    if (filenames.getFullPath("featureQCComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureQCComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureQCComponentGroups_csv_i");
-      LOGD << "END loadFeatureQC";
+    if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureQCComponents_csv_i", "featureQCComponentGroups_csv_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPath("featureQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureQC(), false);
+      if (!filenames.getFullPath("featureQCComponents_csv_i").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureQCComponents_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureQC(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureQCComponentsUpdated();
       }
-      if (filenames.getFullPath("featureQCComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPath("featureQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureQC(), true);
+      if (!filenames.getFullPath("featureQCComponentGroups_csv_i").empty()) {
+        featureQCFile.load(filenames.getFullPath("featureQCComponentGroups_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureQC(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureQCComponentGroupsUpdated();
       }
     }
@@ -521,23 +467,19 @@ namespace SmartPeak
     LOGD << "START storeFeatureFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPath("featureFilterComponents_csv_o") << " and " <<
-      filenames.getFullPath("featureFilterComponentGroups_csv_o");
-
-    if (filenames.getFullPath("featureFilterComponents_csv_o").empty() &&
-      filenames.getFullPath("featureFilterComponentGroups_csv_o").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END storeFeatureFilter";
+    if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureFilterComponents_csv_o", "featureFilterComponentGroups_csv_o"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPath("featureFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureFilter(), false);
+      if (!filenames.getFullPath("featureFilterComponents_csv_o").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureFilterComponents_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureFilter(), false);
       }
-      if (filenames.getFullPath("featureFilterComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPath("featureFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureFilter(), true);
+      if (!filenames.getFullPath("featureFilterComponentGroups_csv_o").empty()) {
+        featureQCFile.store(filenames.getFullPath("featureFilterComponentGroups_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -569,23 +511,19 @@ namespace SmartPeak
     LOGD << "START storeFeatureQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureQCComponents_csv_o") << " and " <<
-      filenames.getFullPath("featureQCComponentGroups_csv_o");
-
-    if (filenames.getFullPath("featureQCComponents_csv_o").empty() &&
-      filenames.getFullPath("featureQCComponentGroups_csv_o").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END storeFeatureQC";
+    if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureQCComponents_csv_o", "featureQCComponentGroups_csv_o"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPath("featureQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureQC(), false);
+      if (!filenames.getFullPath("featureQCComponents_csv_o").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureQCComponents_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureQC(), false);
       }
-      if (filenames.getFullPath("featureQCComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPath("featureQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureQC(), true);
+      if (!filenames.getFullPath("featureQCComponentGroups_csv_o").empty()) {
+        featureQCFile.store(filenames.getFullPath("featureQCComponentGroups_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -642,38 +580,27 @@ namespace SmartPeak
     LOGD << "START loadFeatureRSDFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureRSDFilterComponents_csv_i") << " and " <<
-      filenames.getFullPath("featureRSDFilterComponentGroups_csv_i");
-
-    if (filenames.getFullPath("featureRSDFilterComponents_csv_i").empty() &&
-      filenames.getFullPath("featureRSDFilterComponentGroups_csv_i").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END loadFeatureRSDFilter";
+    if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureRSDFilterComponents_csv_i", "featureRSDFilterComponentGroups_csv_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
-    if (filenames.getFullPath("featureRSDFilterComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDFilterComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureRSDFilterComponents_csv_i");
-      LOGD << "END loadFeatureRSDFilter";
-      return;
-    }
-
-    if (filenames.getFullPath("featureRSDFilterComponentGroups_csv_i").size() &&
+    if (!filenames.getFullPath("featureRSDFilterComponentGroups_csv_i").empty() &&
       !InputDataValidation::fileExists(filenames.getFullPath("featureRSDFilterComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureRSDFilterComponentGroups_csv_i");
+      LOGE << "File not found: " << filenames.getFullPath("featureRSDFilterComponentGroups_csv_i").generic_string();
       LOGD << "END loadFeatureRSDFilter";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureRSDFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPath("featureRSDFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
+      if (!filenames.getFullPath("featureRSDFilterComponents_csv_i").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureRSDFilterComponents_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDFilterComponentsUpdated();
       }
-      if (filenames.getFullPath("featureRSDFilterComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPath("featureRSDFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
+      if (!filenames.getFullPath("featureRSDFilterComponentGroups_csv_i").empty()) {
+        featureQCFile.load(filenames.getFullPath("featureRSDFilterComponentGroups_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDFilterComponentGroupsUpdated();
       }
     }
@@ -733,38 +660,20 @@ namespace SmartPeak
     LOGD << "START loadFeatureRSDQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureRSDQCComponents_csv_i") << " and " <<
-      filenames.getFullPath("featureRSDQCComponentGroups_csv_i");
-
-    if (filenames.getFullPath("featureRSDQCComponents_csv_i").empty() &&
-      filenames.getFullPath("featureRSDQCComponentGroups_csv_i").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END loadFeatureRSDQC";
-      return;
-    }
-
-    if (filenames.getFullPath("featureRSDQCComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDQCComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureRSDQCComponents_csv_i");
-      LOGD << "END loadFeatureRSDQC";
-      return;
-    }
-
-    if (filenames.getFullPath("featureRSDQCComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDQCComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureRSDQCComponentGroups_csv_i");
-      LOGD << "END loadFeatureRSDQC";
+    if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureRSDQCComponents_csv_i", "featureRSDQCComponentGroups_csv_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureRSDQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPath("featureRSDQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
+      if (!filenames.getFullPath("featureRSDQCComponents_csv_i").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureRSDQCComponents_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDQCComponentsUpdated();
       }
-      if (filenames.getFullPath("featureRSDQCComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPath("featureRSDQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
+      if (!filenames.getFullPath("featureRSDQCComponentGroups_csv_i").empty()) {
+        featureQCFile.load(filenames.getFullPath("featureRSDQCComponentGroups_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDQCComponentGroupsUpdated();
       }
     }
@@ -799,23 +708,19 @@ namespace SmartPeak
     LOGD << "START storeFeatureRSDFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPath("featureRSDFilterComponents_csv_o") << " and " <<
-      filenames.getFullPath("featureRSDFilterComponentGroups_csv_o");
-
-    if (filenames.getFullPath("featureRSDFilterComponents_csv_o").empty() &&
-      filenames.getFullPath("featureRSDFilterComponentGroups_csv_o").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END storeFeatureRSDFilter";
+    if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureRSDFilterComponents_csv_o", "featureRSDFilterComponentGroups_csv_o"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureRSDFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPath("featureRSDFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
+      if (!filenames.getFullPath("featureRSDFilterComponents_csv_o").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureRSDFilterComponents_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
       }
-      if (filenames.getFullPath("featureRSDFilterComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPath("featureRSDFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
+      if (!filenames.getFullPath("featureRSDFilterComponentGroups_csv_o").empty()) {
+        featureQCFile.store(filenames.getFullPath("featureRSDFilterComponentGroups_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -847,23 +752,19 @@ namespace SmartPeak
     LOGD << "START storeFeatureRSDQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureRSDQCComponents_csv_o") << " and " <<
-      filenames.getFullPath("featureRSDQCComponentGroups_csv_o");
-
-    if (filenames.getFullPath("featureRSDQCComponents_csv_o").empty() &&
-      filenames.getFullPath("featureRSDQCComponentGroups_csv_o").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END storeFeatureRSDQC";
+    if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureRSDQCComponents_csv_o", "featureRSDQCComponentGroups_csv_o"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureRSDQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPath("featureRSDQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
+      if (!filenames.getFullPath("featureRSDQCComponents_csv_o").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureRSDQCComponents_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
       }
-      if (filenames.getFullPath("featureRSDQCComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPath("featureRSDQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
+      if (!filenames.getFullPath("featureRSDQCComponentGroups_csv_o").empty()) {
+        featureQCFile.store(filenames.getFullPath("featureRSDQCComponentGroups_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -920,38 +821,20 @@ namespace SmartPeak
     LOGD << "START loadFeatureBackgroundFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureBackgroundFilterComponents_csv_i") << " and " <<
-      filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i");
-
-    if (filenames.getFullPath("featureBackgroundFilterComponents_csv_i").empty() &&
-      filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END loadFeatureBackgroundFilter";
-      return;
-    }
-
-    if (filenames.getFullPath("featureBackgroundFilterComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundFilterComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundFilterComponents_csv_i");
-      LOGD << "END loadFeatureBackgroundFilter";
-      return;
-    }
-
-    if (filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i");
-      LOGD << "END loadFeatureBackgroundFilter";
+    if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureBackgroundFilterComponents_csv_i", "featureBackgroundFilterComponentGroups_csv_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureBackgroundFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPath("featureBackgroundFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
+      if (!filenames.getFullPath("featureBackgroundFilterComponents_csv_i").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureBackgroundFilterComponents_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundFilterComponentsUpdated();
       }
-      if (filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
+      if (!filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i").empty()) {
+        featureQCFile.load(filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundFilterComponentGroupsUpdated();
       }
     }
@@ -1011,38 +894,20 @@ namespace SmartPeak
     LOGD << "START loadFeatureBackgroundQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureBackgroundQCComponents_csv_i") << " and " <<
-      filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i");
-
-    if (filenames.getFullPath("featureBackgroundQCComponents_csv_i").empty() &&
-      filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END loadFeatureBackgroundQC";
-      return;
-    }
-
-    if (filenames.getFullPath("featureBackgroundQCComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundQCComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundQCComponents_csv_i");
-      LOGD << "END loadFeatureBackgroundQC";
-      return;
-    }
-
-    if (filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i");
-      LOGD << "END loadFeatureBackgroundQC";
+    if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureBackgroundQCComponents_csv_i", "featureBackgroundQCComponentGroups_csv_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureBackgroundQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPath("featureBackgroundQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
+      if (!filenames.getFullPath("featureBackgroundQCComponents_csv_i").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureBackgroundQCComponents_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundQCComponentsUpdated();
       }
-      if (filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
+      if (!filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i").empty()) {
+        featureQCFile.load(filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundQCComponentGroupsUpdated();
       }
     }
@@ -1077,23 +942,19 @@ namespace SmartPeak
     LOGD << "START storeFeatureBackgroundFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPath("featureBackgroundFilterComponents_csv_o") << " and " <<
-      filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_o");
-
-    if (filenames.getFullPath("featureBackgroundFilterComponents_csv_o").empty() &&
-      filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_o").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END storeFeatureBackgroundFilter";
+    if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureBackgroundFilterComponents_csv_o", "featureBackgroundFilterComponentGroups_csv_o"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureBackgroundFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPath("featureBackgroundFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
+      if (!filenames.getFullPath("featureBackgroundFilterComponents_csv_o").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureBackgroundFilterComponents_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
       }
-      if (filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
+      if (!filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_o").empty()) {
+        featureQCFile.store(filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1125,23 +986,19 @@ namespace SmartPeak
     LOGD << "START storeFeatureBackgroundQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureBackgroundQCComponents_csv_o") << " and " <<
-      filenames.getFullPath("featureBackgroundQCComponentGroups_csv_o");
-
-    if (filenames.getFullPath("featureBackgroundQCComponents_csv_o").empty() &&
-      filenames.getFullPath("featureBackgroundQCComponentGroups_csv_o").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END storeFeatureBackgroundQC";
+    if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureBackgroundQCComponents_csv_o", "featureBackgroundQCComponentGroups_csv_o"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureBackgroundQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPath("featureBackgroundQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
+      if (!filenames.getFullPath("featureBackgroundQCComponents_csv_o").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureBackgroundQCComponents_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
       }
-      if (filenames.getFullPath("featureBackgroundQCComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPath("featureBackgroundQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
+      if (!filenames.getFullPath("featureBackgroundQCComponentGroups_csv_o").empty()) {
+        featureQCFile.store(filenames.getFullPath("featureBackgroundQCComponentGroups_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1459,37 +1316,19 @@ namespace SmartPeak
     LOGD << "START loadFeatureRSDEstimation";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureRSDEstimationComponents_csv_i") << " and " <<
-      filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i");
-
-    if (filenames.getFullPath("featureRSDEstimationComponents_csv_i").empty() &&
-      filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END loadFeatureRSDEstimation";
-      return;
-    }
-
-    if (filenames.getFullPath("featureRSDEstimationComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDEstimationComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureRSDEstimationComponents_csv_i");
-      LOGD << "END loadFeatureRSDEstimation";
-      return;
-    }
-
-    if (filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i");
-      LOGD << "END loadFeatureRSDEstimation";
+    if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureRSDEstimationComponents_csv_i", "featureRSDEstimationComponentGroups_csv_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureRSDEstimationComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPath("featureRSDEstimationComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
+      if (!filenames.getFullPath("featureRSDEstimationComponents_csv_i").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureRSDEstimationComponents_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
       }
-      if (filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
+      if (!filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i").empty()) {
+        featureQCFile.load(filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1524,23 +1363,19 @@ namespace SmartPeak
     LOGD << "START storeFeatureRSDEstimation";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPath("featureRSDEstimationComponents_csv_o") << " and " <<
-      filenames.getFullPath("featureRSDEstimationComponentGroups_csv_o");
-
-    if (filenames.getFullPath("featureRSDEstimationComponents_csv_o").empty() &&
-      filenames.getFullPath("featureRSDEstimationComponentGroups_csv_o").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END storeFeatureRSDEstimation";
+    if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureRSDEstimationComponents_csv_o", "featureRSDEstimationComponentGroups_csv_o"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureRSDEstimationComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPath("featureRSDEstimationComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
+      if (!filenames.getFullPath("featureRSDEstimationComponents_csv_o").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureRSDEstimationComponents_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
       }
-      if (filenames.getFullPath("featureRSDEstimationComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPath("featureRSDEstimationComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
+      if (!filenames.getFullPath("featureRSDEstimationComponentGroups_csv_o").empty()) {
+        featureQCFile.store(filenames.getFullPath("featureRSDEstimationComponentGroups_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1572,37 +1407,19 @@ namespace SmartPeak
     LOGD << "START loadFeatureBackgroundEstimation";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPath("featureBackgroundEstimationComponents_csv_i") << " and " <<
-      filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i");
-
-    if (filenames.getFullPath("featureBackgroundEstimationComponents_csv_i").empty() &&
-      filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END loadFeatureBackgroundEstimation";
-      return;
-    }
-
-    if (filenames.getFullPath("featureBackgroundEstimationComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundEstimationComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundEstimationComponents_csv_i");
-      LOGD << "END loadFeatureBackgroundEstimation";
-      return;
-    }
-
-    if (filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i");
-      LOGD << "END loadFeatureBackgroundEstimation";
+    if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureBackgroundEstimationComponents_csv_i", "featureBackgroundEstimationComponentGroups_csv_i"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureBackgroundEstimationComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPath("featureBackgroundEstimationComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
+      if (!filenames.getFullPath("featureBackgroundEstimationComponents_csv_i").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureBackgroundEstimationComponents_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
       }
-      if (filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
+      if (!filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i").empty()) {
+        featureQCFile.load(filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1637,23 +1454,19 @@ namespace SmartPeak
     LOGD << "START storeFeatureBackgroundEstimation";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPath("featureBackgroundEstimationComponents_csv_o") << " and " <<
-      filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_o");
-
-    if (filenames.getFullPath("featureBackgroundEstimationComponents_csv_o").empty() &&
-      filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_o").empty()) {
-      LOGE << "Filenames are both empty";
-      LOGD << "END storeFeatureBackgroundEstimation";
+    if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureBackgroundEstimationComponents_csv_o", "featureBackgroundEstimationComponentGroups_csv_o"))
+    {
+      LOGD << "END " << getName();
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPath("featureBackgroundEstimationComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPath("featureBackgroundEstimationComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
+      if (!filenames.getFullPath("featureBackgroundEstimationComponents_csv_o").empty()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureBackgroundEstimationComponents_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
       }
-      if (filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
+      if (!filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_o").empty()) {
+        featureQCFile.store(filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_o").generic_string(), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
       }
     }
     catch (const std::exception& e) {

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -162,13 +162,18 @@ namespace SmartPeak
       return false;
     }
     Filenames filenames;
-    filenames.quantitationMethods_csv_i = filename;
+    filenames.setFullPathName("quantitationMethods_csv_i", filename);
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
       process(sequenceSegmentHandler, SequenceHandler(), {}, filenames);
     }
     return true;
   }
+
+  void LoadStandardsConcentrations::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("standardsConcentrations_csv_i", "standardsConcentrations.csv", Filenames::FileScope::EFileScopeMain);
+  };
 
   void LoadStandardsConcentrations::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
@@ -178,15 +183,15 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadStandardsConcentrations";
-    LOGI << "Loading: " << filenames.standardsConcentrations_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("standardsConcentrations_csv_i");
 
-    if (filenames.standardsConcentrations_csv_i.empty()) {
+    if (filenames.getFullPathName("standardsConcentrations_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END loadStandardsConcentrations";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.standardsConcentrations_csv_i)) {
+    if (!InputDataValidation::fileExists(filenames.getFullPathName("standardsConcentrations_csv_i"))) {
       LOGE << "File not found";
       LOGD << "END loadStandardsConcentrations";
       return;
@@ -194,7 +199,7 @@ namespace SmartPeak
 
     try {
       OpenMS::AbsoluteQuantitationStandardsFile AQSf;
-      AQSf.load(filenames.standardsConcentrations_csv_i, sequenceSegmentHandler_IO.getStandardsConcentrations());
+      AQSf.load(filenames.getFullPathName("standardsConcentrations_csv_i"), sequenceSegmentHandler_IO.getStandardsConcentrations());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -210,6 +215,11 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void LoadQuantitationMethods::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("quantitationMethods_csv_i", "quantitationMethods.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   bool LoadQuantitationMethods::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
@@ -218,7 +228,7 @@ namespace SmartPeak
       return false;
     }
     Filenames filenames;
-    filenames.quantitationMethods_csv_i = filename;
+    filenames.setFullPathName("quantitationMethods_csv_i", filename);
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
       process(sequenceSegmentHandler, SequenceHandler(), {}, filenames);
@@ -234,15 +244,15 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadQuantitationMethods";
-    LOGI << "Loading: " << filenames.quantitationMethods_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("quantitationMethods_csv_i");
 
-    if (filenames.quantitationMethods_csv_i.empty()) {
+    if (filenames.getFullPathName("quantitationMethods_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END loadQuantitationMethods";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.quantitationMethods_csv_i)) {
+    if (!InputDataValidation::fileExists(filenames.getFullPathName("quantitationMethods_csv_i"))) {
       LOGE << "File not found";
       LOGD << "END loadQuantitationMethods";
       return;
@@ -250,7 +260,7 @@ namespace SmartPeak
 
     try {
       OpenMS::AbsoluteQuantitationMethodFile AQMf;
-      AQMf.load(filenames.quantitationMethods_csv_i, sequenceSegmentHandler_IO.getQuantitationMethods());
+      AQMf.load(filenames.getFullPathName("quantitationMethods_csv_i"), sequenceSegmentHandler_IO.getQuantitationMethods());
       if (sequence_segment_observable_) sequence_segment_observable_->notifyQuantitationMethodsUpdated();
     }
     catch (const std::exception& e) {
@@ -266,6 +276,11 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void StoreQuantitationMethods::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("quantitationMethods_csv_o", "_quantitationMethods.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreQuantitationMethods::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -274,9 +289,9 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeQuantitationMethods";
-    LOGI << "Storing: " << filenames.quantitationMethods_csv_o;
+    LOGI << "Storing: " << filenames.getFullPathName("quantitationMethods_csv_o");
 
-    if (filenames.quantitationMethods_csv_o.empty()) {
+    if (filenames.getFullPathName("quantitationMethods_csv_o").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END storeQuantitationMethods";
       return;
@@ -285,7 +300,7 @@ namespace SmartPeak
     try {
       OpenMS::AbsoluteQuantitationMethodFile aqmf;
       aqmf.store(
-        filenames.quantitationMethods_csv_o,
+        filenames.getFullPathName("quantitationMethods_csv_o"),
         sequenceSegmentHandler_IO.getQuantitationMethods()
       );
     }
@@ -311,13 +326,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.featureFilterComponents_csv_i = "";
-      filenames.featureFilterComponentGroups_csv_i = filename;
+      filenames.setFullPathName("featureFilterComponents_csv_i", "");
+      filenames.setFullPathName("featureFilterComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.featureFilterComponents_csv_i = filename;
-      filenames.featureFilterComponentGroups_csv_i = "";
+      filenames.setFullPathName("featureFilterComponents_csv_i", filename);
+      filenames.setFullPathName("featureFilterComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -334,38 +349,38 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureFilter";
-    LOGI << "Loading: " << filenames.featureFilterComponents_csv_i << " and " <<
-      filenames.featureFilterComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureFilterComponentGroups_csv_i");
 
-    if (filenames.featureFilterComponents_csv_i.empty() &&
-      filenames.featureFilterComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureFilterComponents_csv_i").empty() &&
+      filenames.getFullPathName("featureFilterComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureFilter";
       return;
     }
 
-    if (filenames.featureFilterComponents_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureFilterComponents_csv_i)) {
-      LOGE << "File not found: " << filenames.featureFilterComponents_csv_i;
+    if (filenames.getFullPathName("featureFilterComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureFilterComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureFilterComponents_csv_i");
       LOGD << "END loadFeatureFilter";
       return;
     }
 
-    if (filenames.featureFilterComponentGroups_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureFilterComponentGroups_csv_i)) {
-      LOGE << "File not found: " << filenames.featureFilterComponentGroups_csv_i;
+    if (filenames.getFullPathName("featureFilterComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureFilterComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureFilterComponentGroups_csv_i");
       LOGD << "END loadFeatureFilter";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureFilterComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.featureFilterComponents_csv_i, sequenceSegmentHandler_IO.getFeatureFilter(), false);
+      if (filenames.getFullPathName("featureFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPathName("featureFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureFilter(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureFiltersComponentsUpdated();
       }
-      if (filenames.featureFilterComponentGroups_csv_i.size()) {
-        featureQCFile.load(filenames.featureFilterComponentGroups_csv_i, sequenceSegmentHandler_IO.getFeatureFilter(), true);
+      if (filenames.getFullPathName("featureFilterComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPathName("featureFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureFilter(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureFiltersComponentGroupsUpdated();
       }
     }
@@ -394,13 +409,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.featureQCComponents_csv_i = "";
-      filenames.featureQCComponentGroups_csv_i = filename;
+      filenames.setFullPathName("featureQCComponents_csv_i", "");
+      filenames.setFullPathName("featureQCComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.featureQCComponents_csv_i = filename;
-      filenames.featureQCComponentGroups_csv_i = "";
+      filenames.setFullPathName("featureQCComponents_csv_i", filename);
+      filenames.setFullPathName("featureQCComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -417,38 +432,38 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureQC";
-    LOGI << "Loading: " << filenames.featureQCComponents_csv_i << " and " <<
-      filenames.featureQCComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureQCComponentGroups_csv_i");
 
-    if (filenames.featureQCComponents_csv_i.empty() &&
-      filenames.featureQCComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureQCComponents_csv_i").empty() &&
+      filenames.getFullPathName("featureQCComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureQC";
       return;
     }
 
-    if (filenames.featureQCComponents_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureQCComponents_csv_i)) {
-      LOGE << "File not found: " << filenames.featureQCComponents_csv_i;
+    if (filenames.getFullPathName("featureQCComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureQCComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureQCComponents_csv_i");
       LOGD << "END loadFeatureQC";
       return;
     }
 
-    if (filenames.featureQCComponentGroups_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureQCComponentGroups_csv_i)) {
-      LOGE << "File not found: " << filenames.featureQCComponentGroups_csv_i;
+    if (filenames.getFullPathName("featureQCComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureQCComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureQCComponentGroups_csv_i");
       LOGD << "END loadFeatureQC";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureQCComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.featureQCComponents_csv_i, sequenceSegmentHandler_IO.getFeatureQC(), false);
+      if (filenames.getFullPathName("featureQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPathName("featureQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureQC(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureQCComponentsUpdated();
       }
-      if (filenames.featureQCComponentGroups_csv_i.size()) {
-        featureQCFile.load(filenames.featureQCComponentGroups_csv_i, sequenceSegmentHandler_IO.getFeatureQC(), true);
+      if (filenames.getFullPathName("featureQCComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPathName("featureQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureQC(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureQCComponentGroupsUpdated();
       }
     }
@@ -467,6 +482,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void StoreFeatureFilters::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureFilterComponents_csv_o", "_featureFilterComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureFilterComponentGroups_csv_o", "_featureFilterComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreFeatureFilters::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -475,11 +496,11 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureFilter";
-    LOGI << "Storing: " << filenames.featureFilterComponents_csv_o << " and " <<
-      filenames.featureFilterComponentGroups_csv_o;
+    LOGI << "Storing: " << filenames.getFullPathName("featureFilterComponents_csv_o") << " and " <<
+      filenames.getFullPathName("featureFilterComponentGroups_csv_o");
 
-    if (filenames.featureFilterComponents_csv_o.empty() &&
-      filenames.featureFilterComponentGroups_csv_o.empty()) {
+    if (filenames.getFullPathName("featureFilterComponents_csv_o").empty() &&
+      filenames.getFullPathName("featureFilterComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureFilter";
       return;
@@ -487,11 +508,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureFilterComponents_csv_o.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.featureFilterComponents_csv_o, sequenceSegmentHandler_IO.getFeatureFilter(), false);
+      if (filenames.getFullPathName("featureFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPathName("featureFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureFilter(), false);
       }
-      if (filenames.featureFilterComponentGroups_csv_o.size()) {
-        featureQCFile.store(filenames.featureFilterComponentGroups_csv_o, sequenceSegmentHandler_IO.getFeatureFilter(), true);
+      if (filenames.getFullPathName("featureFilterComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPathName("featureFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -507,6 +528,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void StoreFeatureQCs::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureQCComponents_csv_o", "_featureQCComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureQCComponentGroups_csv_o", "_featureQCComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreFeatureQCs::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -515,11 +542,11 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureQC";
-    LOGI << "Loading: " << filenames.featureQCComponents_csv_o << " and " <<
-      filenames.featureQCComponentGroups_csv_o;
+    LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_o") << " and " <<
+      filenames.getFullPathName("featureQCComponentGroups_csv_o");
 
-    if (filenames.featureQCComponents_csv_o.empty() &&
-      filenames.featureQCComponentGroups_csv_o.empty()) {
+    if (filenames.getFullPathName("featureQCComponents_csv_o").empty() &&
+      filenames.getFullPathName("featureQCComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureQC";
       return;
@@ -527,11 +554,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureQCComponents_csv_o.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.featureQCComponents_csv_o, sequenceSegmentHandler_IO.getFeatureQC(), false);
+      if (filenames.getFullPathName("featureQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPathName("featureQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureQC(), false);
       }
-      if (filenames.featureQCComponentGroups_csv_o.size()) {
-        featureQCFile.store(filenames.featureQCComponentGroups_csv_o, sequenceSegmentHandler_IO.getFeatureQC(), true);
+      if (filenames.getFullPathName("featureQCComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPathName("featureQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -547,6 +574,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void LoadFeatureRSDFilters::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureRSDFilterComponents_csv_i", "featureRSDFilterComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureRSDFilterComponentGroups_csv_i", "featureRSDFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   bool LoadFeatureRSDFilters::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
@@ -557,13 +590,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.featureRSDFilterComponents_csv_i = "";
-      filenames.featureRSDFilterComponentGroups_csv_i = filename;
+      filenames.setFullPathName("featureRSDFilterComponents_csv_i", "");
+      filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.featureRSDFilterComponents_csv_i = filename;
-      filenames.featureRSDFilterComponentGroups_csv_i = "";
+      filenames.setFullPathName("featureRSDFilterComponents_csv_i", filename);
+      filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -580,38 +613,38 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureRSDFilter";
-    LOGI << "Loading: " << filenames.featureRSDFilterComponents_csv_i << " and " <<
-      filenames.featureRSDFilterComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureRSDFilterComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i");
 
-    if (filenames.featureRSDFilterComponents_csv_i.empty() &&
-      filenames.featureRSDFilterComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureRSDFilterComponents_csv_i").empty() &&
+      filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureRSDFilter";
       return;
     }
 
-    if (filenames.featureRSDFilterComponents_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureRSDFilterComponents_csv_i)) {
-      LOGE << "File not found: " << filenames.featureRSDFilterComponents_csv_i;
+    if (filenames.getFullPathName("featureRSDFilterComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDFilterComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureRSDFilterComponents_csv_i");
       LOGD << "END loadFeatureRSDFilter";
       return;
     }
 
-    if (filenames.featureRSDFilterComponentGroups_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureRSDFilterComponentGroups_csv_i)) {
-      LOGE << "File not found: " << filenames.featureRSDFilterComponentGroups_csv_i;
+    if (filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i");
       LOGD << "END loadFeatureRSDFilter";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureRSDFilterComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.featureRSDFilterComponents_csv_i, sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
+      if (filenames.getFullPathName("featureRSDFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPathName("featureRSDFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDFilterComponentsUpdated();
       }
-      if (filenames.featureRSDFilterComponentGroups_csv_i.size()) {
-        featureQCFile.load(filenames.featureRSDFilterComponentGroups_csv_i, sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
+      if (filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDFilterComponentGroupsUpdated();
       }
     }
@@ -630,6 +663,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void LoadFeatureRSDQCs::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureRSDQCComponents_csv_i", "featureRSDQCComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureRSDQCComponentGroups_csv_i", "featureRSDQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   bool LoadFeatureRSDQCs::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
@@ -640,13 +679,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.featureRSDQCComponents_csv_i = "";
-      filenames.featureRSDQCComponentGroups_csv_i = filename;
+      filenames.setFullPathName("featureRSDQCComponents_csv_i", "");
+      filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.featureRSDQCComponents_csv_i = filename;
-      filenames.featureRSDQCComponentGroups_csv_i = "";
+      filenames.setFullPathName("featureRSDQCComponents_csv_i", filename);
+      filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -663,38 +702,38 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureRSDQC";
-    LOGI << "Loading: " << filenames.featureRSDQCComponents_csv_i << " and " <<
-      filenames.featureRSDQCComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureRSDQCComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureRSDQCComponentGroups_csv_i");
 
-    if (filenames.featureRSDQCComponents_csv_i.empty() &&
-      filenames.featureRSDQCComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureRSDQCComponents_csv_i").empty() &&
+      filenames.getFullPathName("featureRSDQCComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureRSDQC";
       return;
     }
 
-    if (filenames.featureRSDQCComponents_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureRSDQCComponents_csv_i)) {
-      LOGE << "File not found: " << filenames.featureRSDQCComponents_csv_i;
+    if (filenames.getFullPathName("featureRSDQCComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDQCComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureRSDQCComponents_csv_i");
       LOGD << "END loadFeatureRSDQC";
       return;
     }
 
-    if (filenames.featureRSDQCComponentGroups_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureRSDQCComponentGroups_csv_i)) {
-      LOGE << "File not found: " << filenames.featureRSDQCComponentGroups_csv_i;
+    if (filenames.getFullPathName("featureRSDQCComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDQCComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureRSDQCComponentGroups_csv_i");
       LOGD << "END loadFeatureRSDQC";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureRSDQCComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.featureRSDQCComponents_csv_i, sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
+      if (filenames.getFullPathName("featureRSDQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPathName("featureRSDQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDQCComponentsUpdated();
       }
-      if (filenames.featureRSDQCComponentGroups_csv_i.size()) {
-        featureQCFile.load(filenames.featureRSDQCComponentGroups_csv_i, sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
+      if (filenames.getFullPathName("featureRSDQCComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPathName("featureRSDQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDQCComponentGroupsUpdated();
       }
     }
@@ -713,6 +752,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void StoreFeatureRSDFilters::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureRSDFilterComponents_csv_o", "_featureRSDFilterComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureRSDFilterComponentGroups_csv_o", "_featureRSDFilterComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreFeatureRSDFilters::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -721,11 +766,11 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureRSDFilter";
-    LOGI << "Storing: " << filenames.featureRSDFilterComponents_csv_o << " and " <<
-      filenames.featureRSDFilterComponentGroups_csv_o;
+    LOGI << "Storing: " << filenames.getFullPathName("featureRSDFilterComponents_csv_o") << " and " <<
+      filenames.getFullPathName("featureRSDFilterComponentGroups_csv_o");
 
-    if (filenames.featureRSDFilterComponents_csv_o.empty() &&
-      filenames.featureRSDFilterComponentGroups_csv_o.empty()) {
+    if (filenames.getFullPathName("featureRSDFilterComponents_csv_o").empty() &&
+      filenames.getFullPathName("featureRSDFilterComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureRSDFilter";
       return;
@@ -733,11 +778,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureRSDFilterComponents_csv_o.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.featureRSDFilterComponents_csv_o, sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
+      if (filenames.getFullPathName("featureRSDFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPathName("featureRSDFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
       }
-      if (filenames.featureRSDFilterComponentGroups_csv_o.size()) {
-        featureQCFile.store(filenames.featureRSDFilterComponentGroups_csv_o, sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
+      if (filenames.getFullPathName("featureRSDFilterComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPathName("featureRSDFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -753,6 +798,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void StoreFeatureRSDQCs::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureRSDQCComponents_csv_o", "_featureRSDQCComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureRSDQCComponentGroups_csv_o", "_featureRSDQCComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreFeatureRSDQCs::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -761,11 +812,11 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureRSDQC";
-    LOGI << "Loading: " << filenames.featureRSDQCComponents_csv_o << " and " <<
-      filenames.featureRSDQCComponentGroups_csv_o;
+    LOGI << "Loading: " << filenames.getFullPathName("featureRSDQCComponents_csv_o") << " and " <<
+      filenames.getFullPathName("featureRSDQCComponentGroups_csv_o");
 
-    if (filenames.featureRSDQCComponents_csv_o.empty() &&
-      filenames.featureRSDQCComponentGroups_csv_o.empty()) {
+    if (filenames.getFullPathName("featureRSDQCComponents_csv_o").empty() &&
+      filenames.getFullPathName("featureRSDQCComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureRSDQC";
       return;
@@ -773,11 +824,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureRSDQCComponents_csv_o.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.featureRSDQCComponents_csv_o, sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
+      if (filenames.getFullPathName("featureRSDQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPathName("featureRSDQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
       }
-      if (filenames.featureRSDQCComponentGroups_csv_o.size()) {
-        featureQCFile.store(filenames.featureRSDQCComponentGroups_csv_o, sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
+      if (filenames.getFullPathName("featureRSDQCComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPathName("featureRSDQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -793,6 +844,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void LoadFeatureBackgroundFilters::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureBackgroundFilterComponents_csv_i", "featureBackgroundFilterComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureBackgroundFilterComponentGroups_csv_i", "featureBackgroundFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   bool LoadFeatureBackgroundFilters::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
@@ -803,13 +860,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.featureBackgroundFilterComponents_csv_i = "";
-      filenames.featureBackgroundFilterComponentGroups_csv_i = filename;
+      filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", "");
+      filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.featureBackgroundFilterComponents_csv_i = filename;
-      filenames.featureBackgroundFilterComponentGroups_csv_i = "";
+      filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", filename);
+      filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -826,38 +883,38 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureBackgroundFilter";
-    LOGI << "Loading: " << filenames.featureBackgroundFilterComponents_csv_i << " and " <<
-      filenames.featureBackgroundFilterComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundFilterComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i");
 
-    if (filenames.featureBackgroundFilterComponents_csv_i.empty() &&
-      filenames.featureBackgroundFilterComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureBackgroundFilterComponents_csv_i").empty() &&
+      filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureBackgroundFilter";
       return;
     }
 
-    if (filenames.featureBackgroundFilterComponents_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureBackgroundFilterComponents_csv_i)) {
-      LOGE << "File not found: " << filenames.featureBackgroundFilterComponents_csv_i;
+    if (filenames.getFullPathName("featureBackgroundFilterComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundFilterComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundFilterComponents_csv_i");
       LOGD << "END loadFeatureBackgroundFilter";
       return;
     }
 
-    if (filenames.featureBackgroundFilterComponentGroups_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureBackgroundFilterComponentGroups_csv_i)) {
-      LOGE << "File not found: " << filenames.featureBackgroundFilterComponentGroups_csv_i;
+    if (filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i");
       LOGD << "END loadFeatureBackgroundFilter";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureBackgroundFilterComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.featureBackgroundFilterComponents_csv_i, sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
+      if (filenames.getFullPathName("featureBackgroundFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPathName("featureBackgroundFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundFilterComponentsUpdated();
       }
-      if (filenames.featureBackgroundFilterComponentGroups_csv_i.size()) {
-        featureQCFile.load(filenames.featureBackgroundFilterComponentGroups_csv_i, sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
+      if (filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundFilterComponentGroupsUpdated();
       }
     }
@@ -876,6 +933,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void LoadFeatureBackgroundQCs::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureBackgroundQCComponents_csv_i", "featureBackgroundQCComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureBackgroundQCComponentGroups_csv_i", "featureBackgroundQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   bool LoadFeatureBackgroundQCs::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
@@ -886,13 +949,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.featureBackgroundQCComponents_csv_i = "";
-      filenames.featureBackgroundQCComponentGroups_csv_i = filename;
+      filenames.setFullPathName("featureBackgroundQCComponents_csv_i", "");
+      filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.featureBackgroundQCComponents_csv_i = filename;
-      filenames.featureBackgroundQCComponentGroups_csv_i = "";
+      filenames.setFullPathName("featureBackgroundQCComponents_csv_i", filename);
+      filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -909,38 +972,38 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureBackgroundQC";
-    LOGI << "Loading: " << filenames.featureBackgroundQCComponents_csv_i << " and " <<
-      filenames.featureBackgroundQCComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundQCComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i");
 
-    if (filenames.featureBackgroundQCComponents_csv_i.empty() &&
-      filenames.featureBackgroundQCComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureBackgroundQCComponents_csv_i").empty() &&
+      filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureBackgroundQC";
       return;
     }
 
-    if (filenames.featureBackgroundQCComponents_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureBackgroundQCComponents_csv_i)) {
-      LOGE << "File not found: " << filenames.featureBackgroundQCComponents_csv_i;
+    if (filenames.getFullPathName("featureBackgroundQCComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundQCComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundQCComponents_csv_i");
       LOGD << "END loadFeatureBackgroundQC";
       return;
     }
 
-    if (filenames.featureBackgroundQCComponentGroups_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureBackgroundQCComponentGroups_csv_i)) {
-      LOGE << "File not found: " << filenames.featureBackgroundQCComponentGroups_csv_i;
+    if (filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i");
       LOGD << "END loadFeatureBackgroundQC";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureBackgroundQCComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.featureBackgroundQCComponents_csv_i, sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
+      if (filenames.getFullPathName("featureBackgroundQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPathName("featureBackgroundQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundQCComponentsUpdated();
       }
-      if (filenames.featureBackgroundQCComponentGroups_csv_i.size()) {
-        featureQCFile.load(filenames.featureBackgroundQCComponentGroups_csv_i, sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
+      if (filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundQCComponentGroupsUpdated();
       }
     }
@@ -959,6 +1022,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void StoreFeatureBackgroundFilters::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureBackgroundFilterComponents_csv_o", "_featureBackgroundFilterComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureBackgroundFilterComponentGroups_csv_o", "_featureBackgroundFilterComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreFeatureBackgroundFilters::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -967,11 +1036,11 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureBackgroundFilter";
-    LOGI << "Storing: " << filenames.featureBackgroundFilterComponents_csv_o << " and " <<
-      filenames.featureBackgroundFilterComponentGroups_csv_o;
+    LOGI << "Storing: " << filenames.getFullPathName("featureBackgroundFilterComponents_csv_o") << " and " <<
+      filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_o");
 
-    if (filenames.featureBackgroundFilterComponents_csv_o.empty() &&
-      filenames.featureBackgroundFilterComponentGroups_csv_o.empty()) {
+    if (filenames.getFullPathName("featureBackgroundFilterComponents_csv_o").empty() &&
+      filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureBackgroundFilter";
       return;
@@ -979,11 +1048,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureBackgroundFilterComponents_csv_o.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.featureBackgroundFilterComponents_csv_o, sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
+      if (filenames.getFullPathName("featureBackgroundFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPathName("featureBackgroundFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
       }
-      if (filenames.featureBackgroundFilterComponentGroups_csv_o.size()) {
-        featureQCFile.store(filenames.featureBackgroundFilterComponentGroups_csv_o, sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
+      if (filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -999,6 +1068,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void StoreFeatureBackgroundQCs::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureBackgroundQCComponents_csv_o", "_featureBackgroundQCComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureBackgroundQCComponentGroups_csv_o", "_featureBackgroundQCComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreFeatureBackgroundQCs::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -1007,11 +1082,11 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureBackgroundQC";
-    LOGI << "Loading: " << filenames.featureBackgroundQCComponents_csv_o << " and " <<
-      filenames.featureBackgroundQCComponentGroups_csv_o;
+    LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundQCComponents_csv_o") << " and " <<
+      filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_o");
 
-    if (filenames.featureBackgroundQCComponents_csv_o.empty() &&
-      filenames.featureBackgroundQCComponentGroups_csv_o.empty()) {
+    if (filenames.getFullPathName("featureBackgroundQCComponents_csv_o").empty() &&
+      filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureBackgroundQC";
       return;
@@ -1019,11 +1094,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureBackgroundQCComponents_csv_o.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.featureBackgroundQCComponents_csv_o, sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
+      if (filenames.getFullPathName("featureBackgroundQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPathName("featureBackgroundQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
       }
-      if (filenames.featureBackgroundQCComponentGroups_csv_o.size()) {
-        featureQCFile.store(filenames.featureBackgroundQCComponentGroups_csv_o, sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
+      if (filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1313,6 +1388,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void LoadFeatureRSDEstimations::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureRSDEstimationComponents_csv_i", "featureRSDEstimationComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureRSDEstimationComponentGroups_csv_i", "featureRSDEstimationComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   void LoadFeatureRSDEstimations::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -1321,37 +1402,37 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureRSDEstimation";
-    LOGI << "Loading: " << filenames.featureRSDEstimationComponents_csv_i << " and " <<
-      filenames.featureRSDEstimationComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureRSDEstimationComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i");
 
-    if (filenames.featureRSDEstimationComponents_csv_i.empty() &&
-      filenames.featureRSDEstimationComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureRSDEstimationComponents_csv_i").empty() &&
+      filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureRSDEstimation";
       return;
     }
 
-    if (filenames.featureRSDEstimationComponents_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureRSDEstimationComponents_csv_i)) {
-      LOGE << "File not found: " << filenames.featureRSDEstimationComponents_csv_i;
+    if (filenames.getFullPathName("featureRSDEstimationComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDEstimationComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureRSDEstimationComponents_csv_i");
       LOGD << "END loadFeatureRSDEstimation";
       return;
     }
 
-    if (filenames.featureRSDEstimationComponentGroups_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureRSDEstimationComponentGroups_csv_i)) {
-      LOGE << "File not found: " << filenames.featureRSDEstimationComponentGroups_csv_i;
+    if (filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i");
       LOGD << "END loadFeatureRSDEstimation";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureRSDEstimationComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.featureRSDEstimationComponents_csv_i, sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
+      if (filenames.getFullPathName("featureRSDEstimationComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPathName("featureRSDEstimationComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
       }
-      if (filenames.featureRSDEstimationComponentGroups_csv_i.size()) {
-        featureQCFile.load(filenames.featureRSDEstimationComponentGroups_csv_i, sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
+      if (filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1370,6 +1451,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void StoreFeatureRSDEstimations::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureRSDEstimationComponents_csv_o", "_featureRSDEstimationComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureRSDEstimationComponentGroups_csv_o", "_featureRSDEstimationComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreFeatureRSDEstimations::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -1378,11 +1465,11 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureRSDEstimation";
-    LOGI << "Storing: " << filenames.featureRSDEstimationComponents_csv_o << " and " <<
-      filenames.featureRSDEstimationComponentGroups_csv_o;
+    LOGI << "Storing: " << filenames.getFullPathName("featureRSDEstimationComponents_csv_o") << " and " <<
+      filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_o");
 
-    if (filenames.featureRSDEstimationComponents_csv_o.empty() &&
-      filenames.featureRSDEstimationComponentGroups_csv_o.empty()) {
+    if (filenames.getFullPathName("featureRSDEstimationComponents_csv_o").empty() &&
+      filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureRSDEstimation";
       return;
@@ -1390,11 +1477,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureRSDEstimationComponents_csv_o.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.featureRSDEstimationComponents_csv_o, sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
+      if (filenames.getFullPathName("featureRSDEstimationComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPathName("featureRSDEstimationComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
       }
-      if (filenames.featureRSDEstimationComponentGroups_csv_o.size()) {
-        featureQCFile.store(filenames.featureRSDEstimationComponentGroups_csv_o, sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
+      if (filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1410,6 +1497,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void LoadFeatureBackgroundEstimations::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureBackgroundEstimationComponents_csv_i", "featureBackgroundEstimationComponents.csv", Filenames::FileScope::EFileScopeMain);
+    filenames.addFileName("featureBackgroundEstimationComponentGroups_csv_i", "featureBackgroundEstimationComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
+  };
+
   void LoadFeatureBackgroundEstimations::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -1418,37 +1511,37 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureBackgroundEstimation";
-    LOGI << "Loading: " << filenames.featureBackgroundEstimationComponents_csv_i << " and " <<
-      filenames.featureBackgroundEstimationComponentGroups_csv_i;
+    LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i") << " and " <<
+      filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i");
 
-    if (filenames.featureBackgroundEstimationComponents_csv_i.empty() &&
-      filenames.featureBackgroundEstimationComponentGroups_csv_i.empty()) {
+    if (filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i").empty() &&
+      filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureBackgroundEstimation";
       return;
     }
 
-    if (filenames.featureBackgroundEstimationComponents_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureBackgroundEstimationComponents_csv_i)) {
-      LOGE << "File not found: " << filenames.featureBackgroundEstimationComponents_csv_i;
+    if (filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i");
       LOGD << "END loadFeatureBackgroundEstimation";
       return;
     }
 
-    if (filenames.featureBackgroundEstimationComponentGroups_csv_i.size() &&
-      !InputDataValidation::fileExists(filenames.featureBackgroundEstimationComponentGroups_csv_i)) {
-      LOGE << "File not found: " << filenames.featureBackgroundEstimationComponentGroups_csv_i;
+    if (filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i");
       LOGD << "END loadFeatureBackgroundEstimation";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureBackgroundEstimationComponents_csv_i.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.featureBackgroundEstimationComponents_csv_i, sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
+      if (filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
       }
-      if (filenames.featureBackgroundEstimationComponentGroups_csv_i.size()) {
-        featureQCFile.load(filenames.featureBackgroundEstimationComponentGroups_csv_i, sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
+      if (filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1467,6 +1560,12 @@ namespace SmartPeak
     return ParameterSet();
   }
 
+  void StoreFeatureBackgroundEstimations::getInputsOutputs(Filenames& filenames) const
+  {
+    filenames.addFileName("featureBackgroundEstimationComponents_csv_o", "_featureBackgroundEstimationComponents.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+    filenames.addFileName("featureBackgroundEstimationComponentGroups_csv_o", "_featureBackgroundEstimationComponentGroups.csv", Filenames::FileScope::EFileScopeInjectionOutput);
+  };
+
   void StoreFeatureBackgroundEstimations::process(
     SequenceSegmentHandler& sequenceSegmentHandler_IO,
     const SequenceHandler& sequenceHandler_I,
@@ -1475,11 +1574,11 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureBackgroundEstimation";
-    LOGI << "Storing: " << filenames.featureBackgroundEstimationComponents_csv_o << " and " <<
-      filenames.featureBackgroundEstimationComponentGroups_csv_o;
+    LOGI << "Storing: " << filenames.getFullPathName("featureBackgroundEstimationComponents_csv_o") << " and " <<
+      filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_o");
 
-    if (filenames.featureBackgroundEstimationComponents_csv_o.empty() &&
-      filenames.featureBackgroundEstimationComponentGroups_csv_o.empty()) {
+    if (filenames.getFullPathName("featureBackgroundEstimationComponents_csv_o").empty() &&
+      filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureBackgroundEstimation";
       return;
@@ -1487,11 +1586,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.featureBackgroundEstimationComponents_csv_o.size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.featureBackgroundEstimationComponents_csv_o, sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
+      if (filenames.getFullPathName("featureBackgroundEstimationComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPathName("featureBackgroundEstimationComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
       }
-      if (filenames.featureBackgroundEstimationComponentGroups_csv_o.size()) {
-        featureQCFile.store(filenames.featureBackgroundEstimationComponentGroups_csv_o, sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
+      if (filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
       }
     }
     catch (const std::exception& e) {

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -1024,7 +1024,6 @@ namespace SmartPeak
     LOGD << "START estimateFeatureFilterValues";
     Filenames filenames = prepareFileNames(filenames_I);
 
-
     std::vector<size_t> standards_indices, qcs_indices;
 
     // get all standards
@@ -1084,7 +1083,6 @@ namespace SmartPeak
   {
     LOGD << "START estimateFeatureQCValues";
     Filenames filenames = prepareFileNames(filenames_I);
-
 
     std::vector<size_t> standards_indices, qcs_indices;
 
@@ -1146,7 +1144,6 @@ namespace SmartPeak
     LOGD << "START TransferLOQToFeatureFilters";
     Filenames filenames = prepareFileNames(filenames_I);
 
-
     // check if there are any quantitation methods
     if (sequenceSegmentHandler_IO.getQuantitationMethods().empty()) {
       LOGE << "quantitation methods is empty. Returning";
@@ -1178,7 +1175,6 @@ namespace SmartPeak
     LOGD << "START TransferLOQToFeatureQCs";
     Filenames filenames = prepareFileNames(filenames_I);
 
-
     // check if there are any quantitation methods
     if (sequenceSegmentHandler_IO.getQuantitationMethods().empty()) {
       LOGE << "quantitation methods is empty. Returning";
@@ -1209,7 +1205,6 @@ namespace SmartPeak
   {
     LOGD << "START EstimateFeatureRSDs";
     Filenames filenames = prepareFileNames(filenames_I);
-
 
     // get all QCs
     std::vector<size_t> qcs_indices;
@@ -1258,7 +1253,6 @@ namespace SmartPeak
   {
     LOGD << "START EstimateFeatureBackgroundInterferences";
     Filenames filenames = prepareFileNames(filenames_I);
-
 
     // get all Blanks
     std::vector<size_t> blanks_indices;

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -155,7 +155,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  bool LoadStandardsConcentrations::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadStandardsConcentrations::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -223,7 +223,7 @@ namespace SmartPeak
     filenames.addFileName("quantitationMethods_csv_i", "quantitationMethods.csv", Filenames::FileScope::EFileScopeMain);
   };
 
-  bool LoadQuantitationMethods::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadQuantitationMethods::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -323,7 +323,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  bool LoadFeatureFilters::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadFeatureFilters::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -414,7 +414,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  bool LoadFeatureQCs::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadFeatureQCs::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -607,7 +607,7 @@ namespace SmartPeak
     filenames.addFileName("featureRSDFilterComponentGroups_csv_i", "featureRSDFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
   };
 
-  bool LoadFeatureRSDFilters::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadFeatureRSDFilters::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -698,7 +698,7 @@ namespace SmartPeak
     filenames.addFileName("featureRSDQCComponentGroups_csv_i", "featureRSDQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
   };
 
-  bool LoadFeatureRSDQCs::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadFeatureRSDQCs::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -885,7 +885,7 @@ namespace SmartPeak
     filenames.addFileName("featureBackgroundFilterComponentGroups_csv_i", "featureBackgroundFilterComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
   };
 
-  bool LoadFeatureBackgroundFilters::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadFeatureBackgroundFilters::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -976,7 +976,7 @@ namespace SmartPeak
     filenames.addFileName("featureBackgroundQCComponentGroups_csv_i", "featureBackgroundQCComponentGroups.csv", Filenames::FileScope::EFileScopeMain);
   };
 
-  bool LoadFeatureBackgroundQCs::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool LoadFeatureBackgroundQCs::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -163,7 +163,7 @@ namespace SmartPeak
       return false;
     }
     Filenames filenames;
-    filenames.setFullPathName("quantitationMethods_csv_i", filename);
+    filenames.setFullPath("quantitationMethods_csv_i", filename);
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
       process(sequenceSegmentHandler, SequenceHandler(), {}, filenames);
@@ -186,15 +186,15 @@ namespace SmartPeak
     LOGD << "START loadStandardsConcentrations";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("standardsConcentrations_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("standardsConcentrations_csv_i");
 
-    if (filenames.getFullPathName("standardsConcentrations_csv_i").empty()) {
+    if (filenames.getFullPath("standardsConcentrations_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END loadStandardsConcentrations";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.getFullPathName("standardsConcentrations_csv_i"))) {
+    if (!InputDataValidation::fileExists(filenames.getFullPath("standardsConcentrations_csv_i"))) {
       LOGE << "File not found";
       LOGD << "END loadStandardsConcentrations";
       return;
@@ -202,7 +202,7 @@ namespace SmartPeak
 
     try {
       OpenMS::AbsoluteQuantitationStandardsFile AQSf;
-      AQSf.load(filenames.getFullPathName("standardsConcentrations_csv_i"), sequenceSegmentHandler_IO.getStandardsConcentrations());
+      AQSf.load(filenames.getFullPath("standardsConcentrations_csv_i"), sequenceSegmentHandler_IO.getStandardsConcentrations());
     }
     catch (const std::exception& e) {
       LOGE << e.what();
@@ -231,7 +231,7 @@ namespace SmartPeak
       return false;
     }
     Filenames filenames;
-    filenames.setFullPathName("quantitationMethods_csv_i", filename);
+    filenames.setFullPath("quantitationMethods_csv_i", filename);
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
       process(sequenceSegmentHandler, SequenceHandler(), {}, filenames);
@@ -249,15 +249,15 @@ namespace SmartPeak
     LOGD << "START loadQuantitationMethods";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("quantitationMethods_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("quantitationMethods_csv_i");
 
-    if (filenames.getFullPathName("quantitationMethods_csv_i").empty()) {
+    if (filenames.getFullPath("quantitationMethods_csv_i").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END loadQuantitationMethods";
       return;
     }
 
-    if (!InputDataValidation::fileExists(filenames.getFullPathName("quantitationMethods_csv_i"))) {
+    if (!InputDataValidation::fileExists(filenames.getFullPath("quantitationMethods_csv_i"))) {
       LOGE << "File not found";
       LOGD << "END loadQuantitationMethods";
       return;
@@ -265,7 +265,7 @@ namespace SmartPeak
 
     try {
       OpenMS::AbsoluteQuantitationMethodFile AQMf;
-      AQMf.load(filenames.getFullPathName("quantitationMethods_csv_i"), sequenceSegmentHandler_IO.getQuantitationMethods());
+      AQMf.load(filenames.getFullPath("quantitationMethods_csv_i"), sequenceSegmentHandler_IO.getQuantitationMethods());
       if (sequence_segment_observable_) sequence_segment_observable_->notifyQuantitationMethodsUpdated();
     }
     catch (const std::exception& e) {
@@ -296,9 +296,9 @@ namespace SmartPeak
     LOGD << "START storeQuantitationMethods";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPathName("quantitationMethods_csv_o");
+    LOGI << "Storing: " << filenames.getFullPath("quantitationMethods_csv_o");
 
-    if (filenames.getFullPathName("quantitationMethods_csv_o").empty()) {
+    if (filenames.getFullPath("quantitationMethods_csv_o").empty()) {
       LOGE << "Filename is empty";
       LOGD << "END storeQuantitationMethods";
       return;
@@ -307,7 +307,7 @@ namespace SmartPeak
     try {
       OpenMS::AbsoluteQuantitationMethodFile aqmf;
       aqmf.store(
-        filenames.getFullPathName("quantitationMethods_csv_o"),
+        filenames.getFullPath("quantitationMethods_csv_o"),
         sequenceSegmentHandler_IO.getQuantitationMethods()
       );
     }
@@ -333,13 +333,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.setFullPathName("featureFilterComponents_csv_i", "");
-      filenames.setFullPathName("featureFilterComponentGroups_csv_i", filename);
+      filenames.setFullPath("featureFilterComponents_csv_i", "");
+      filenames.setFullPath("featureFilterComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.setFullPathName("featureFilterComponents_csv_i", filename);
-      filenames.setFullPathName("featureFilterComponentGroups_csv_i", "");
+      filenames.setFullPath("featureFilterComponents_csv_i", filename);
+      filenames.setFullPath("featureFilterComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -364,38 +364,38 @@ namespace SmartPeak
     LOGD << "START loadFeatureFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureFilterComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureFilterComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureFilterComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureFilterComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureFilterComponents_csv_i").empty() &&
-      filenames.getFullPathName("featureFilterComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureFilterComponents_csv_i").empty() &&
+      filenames.getFullPath("featureFilterComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureFilter";
       return;
     }
 
-    if (filenames.getFullPathName("featureFilterComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureFilterComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureFilterComponents_csv_i");
+    if (filenames.getFullPath("featureFilterComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureFilterComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureFilterComponents_csv_i");
       LOGD << "END loadFeatureFilter";
       return;
     }
 
-    if (filenames.getFullPathName("featureFilterComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureFilterComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureFilterComponentGroups_csv_i");
+    if (filenames.getFullPath("featureFilterComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureFilterComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureFilterComponentGroups_csv_i");
       LOGD << "END loadFeatureFilter";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPathName("featureFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureFilter(), false);
+      if (filenames.getFullPath("featureFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureFilter(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureFiltersComponentsUpdated();
       }
-      if (filenames.getFullPathName("featureFilterComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPathName("featureFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureFilter(), true);
+      if (filenames.getFullPath("featureFilterComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPath("featureFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureFilter(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureFiltersComponentGroupsUpdated();
       }
     }
@@ -424,13 +424,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.setFullPathName("featureQCComponents_csv_i", "");
-      filenames.setFullPathName("featureQCComponentGroups_csv_i", filename);
+      filenames.setFullPath("featureQCComponents_csv_i", "");
+      filenames.setFullPath("featureQCComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.setFullPathName("featureQCComponents_csv_i", filename);
-      filenames.setFullPathName("featureQCComponentGroups_csv_i", "");
+      filenames.setFullPath("featureQCComponents_csv_i", filename);
+      filenames.setFullPath("featureQCComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -455,38 +455,38 @@ namespace SmartPeak
     LOGD << "START loadFeatureQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureQCComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureQCComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureQCComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureQCComponents_csv_i").empty() &&
-      filenames.getFullPathName("featureQCComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureQCComponents_csv_i").empty() &&
+      filenames.getFullPath("featureQCComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureQC";
       return;
     }
 
-    if (filenames.getFullPathName("featureQCComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureQCComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureQCComponents_csv_i");
+    if (filenames.getFullPath("featureQCComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureQCComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureQCComponents_csv_i");
       LOGD << "END loadFeatureQC";
       return;
     }
 
-    if (filenames.getFullPathName("featureQCComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureQCComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureQCComponentGroups_csv_i");
+    if (filenames.getFullPath("featureQCComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureQCComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureQCComponentGroups_csv_i");
       LOGD << "END loadFeatureQC";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPathName("featureQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureQC(), false);
+      if (filenames.getFullPath("featureQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureQC(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureQCComponentsUpdated();
       }
-      if (filenames.getFullPathName("featureQCComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPathName("featureQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureQC(), true);
+      if (filenames.getFullPath("featureQCComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPath("featureQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureQC(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureQCComponentGroupsUpdated();
       }
     }
@@ -521,11 +521,11 @@ namespace SmartPeak
     LOGD << "START storeFeatureFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPathName("featureFilterComponents_csv_o") << " and " <<
-      filenames.getFullPathName("featureFilterComponentGroups_csv_o");
+    LOGI << "Storing: " << filenames.getFullPath("featureFilterComponents_csv_o") << " and " <<
+      filenames.getFullPath("featureFilterComponentGroups_csv_o");
 
-    if (filenames.getFullPathName("featureFilterComponents_csv_o").empty() &&
-      filenames.getFullPathName("featureFilterComponentGroups_csv_o").empty()) {
+    if (filenames.getFullPath("featureFilterComponents_csv_o").empty() &&
+      filenames.getFullPath("featureFilterComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureFilter";
       return;
@@ -533,11 +533,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPathName("featureFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureFilter(), false);
+      if (filenames.getFullPath("featureFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureFilter(), false);
       }
-      if (filenames.getFullPathName("featureFilterComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPathName("featureFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureFilter(), true);
+      if (filenames.getFullPath("featureFilterComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPath("featureFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -569,11 +569,11 @@ namespace SmartPeak
     LOGD << "START storeFeatureQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureQCComponents_csv_o") << " and " <<
-      filenames.getFullPathName("featureQCComponentGroups_csv_o");
+    LOGI << "Loading: " << filenames.getFullPath("featureQCComponents_csv_o") << " and " <<
+      filenames.getFullPath("featureQCComponentGroups_csv_o");
 
-    if (filenames.getFullPathName("featureQCComponents_csv_o").empty() &&
-      filenames.getFullPathName("featureQCComponentGroups_csv_o").empty()) {
+    if (filenames.getFullPath("featureQCComponents_csv_o").empty() &&
+      filenames.getFullPath("featureQCComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureQC";
       return;
@@ -581,11 +581,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPathName("featureQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureQC(), false);
+      if (filenames.getFullPath("featureQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureQC(), false);
       }
-      if (filenames.getFullPathName("featureQCComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPathName("featureQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureQC(), true);
+      if (filenames.getFullPath("featureQCComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPath("featureQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -617,13 +617,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.setFullPathName("featureRSDFilterComponents_csv_i", "");
-      filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", filename);
+      filenames.setFullPath("featureRSDFilterComponents_csv_i", "");
+      filenames.setFullPath("featureRSDFilterComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.setFullPathName("featureRSDFilterComponents_csv_i", filename);
-      filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", "");
+      filenames.setFullPath("featureRSDFilterComponents_csv_i", filename);
+      filenames.setFullPath("featureRSDFilterComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -642,38 +642,38 @@ namespace SmartPeak
     LOGD << "START loadFeatureRSDFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureRSDFilterComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureRSDFilterComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureRSDFilterComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureRSDFilterComponents_csv_i").empty() &&
-      filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureRSDFilterComponents_csv_i").empty() &&
+      filenames.getFullPath("featureRSDFilterComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureRSDFilter";
       return;
     }
 
-    if (filenames.getFullPathName("featureRSDFilterComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDFilterComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureRSDFilterComponents_csv_i");
+    if (filenames.getFullPath("featureRSDFilterComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDFilterComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureRSDFilterComponents_csv_i");
       LOGD << "END loadFeatureRSDFilter";
       return;
     }
 
-    if (filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i");
+    if (filenames.getFullPath("featureRSDFilterComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDFilterComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureRSDFilterComponentGroups_csv_i");
       LOGD << "END loadFeatureRSDFilter";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureRSDFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPathName("featureRSDFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
+      if (filenames.getFullPath("featureRSDFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureRSDFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDFilterComponentsUpdated();
       }
-      if (filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPathName("featureRSDFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
+      if (filenames.getFullPath("featureRSDFilterComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPath("featureRSDFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDFilterComponentGroupsUpdated();
       }
     }
@@ -708,13 +708,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.setFullPathName("featureRSDQCComponents_csv_i", "");
-      filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", filename);
+      filenames.setFullPath("featureRSDQCComponents_csv_i", "");
+      filenames.setFullPath("featureRSDQCComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.setFullPathName("featureRSDQCComponents_csv_i", filename);
-      filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", "");
+      filenames.setFullPath("featureRSDQCComponents_csv_i", filename);
+      filenames.setFullPath("featureRSDQCComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -733,38 +733,38 @@ namespace SmartPeak
     LOGD << "START loadFeatureRSDQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureRSDQCComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureRSDQCComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureRSDQCComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureRSDQCComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureRSDQCComponents_csv_i").empty() &&
-      filenames.getFullPathName("featureRSDQCComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureRSDQCComponents_csv_i").empty() &&
+      filenames.getFullPath("featureRSDQCComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureRSDQC";
       return;
     }
 
-    if (filenames.getFullPathName("featureRSDQCComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDQCComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureRSDQCComponents_csv_i");
+    if (filenames.getFullPath("featureRSDQCComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDQCComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureRSDQCComponents_csv_i");
       LOGD << "END loadFeatureRSDQC";
       return;
     }
 
-    if (filenames.getFullPathName("featureRSDQCComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDQCComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureRSDQCComponentGroups_csv_i");
+    if (filenames.getFullPath("featureRSDQCComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDQCComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureRSDQCComponentGroups_csv_i");
       LOGD << "END loadFeatureRSDQC";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureRSDQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPathName("featureRSDQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
+      if (filenames.getFullPath("featureRSDQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureRSDQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDQCComponentsUpdated();
       }
-      if (filenames.getFullPathName("featureRSDQCComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPathName("featureRSDQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
+      if (filenames.getFullPath("featureRSDQCComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPath("featureRSDQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureRSDQCComponentGroupsUpdated();
       }
     }
@@ -799,11 +799,11 @@ namespace SmartPeak
     LOGD << "START storeFeatureRSDFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPathName("featureRSDFilterComponents_csv_o") << " and " <<
-      filenames.getFullPathName("featureRSDFilterComponentGroups_csv_o");
+    LOGI << "Storing: " << filenames.getFullPath("featureRSDFilterComponents_csv_o") << " and " <<
+      filenames.getFullPath("featureRSDFilterComponentGroups_csv_o");
 
-    if (filenames.getFullPathName("featureRSDFilterComponents_csv_o").empty() &&
-      filenames.getFullPathName("featureRSDFilterComponentGroups_csv_o").empty()) {
+    if (filenames.getFullPath("featureRSDFilterComponents_csv_o").empty() &&
+      filenames.getFullPath("featureRSDFilterComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureRSDFilter";
       return;
@@ -811,11 +811,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureRSDFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPathName("featureRSDFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
+      if (filenames.getFullPath("featureRSDFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureRSDFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), false);
       }
-      if (filenames.getFullPathName("featureRSDFilterComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPathName("featureRSDFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
+      if (filenames.getFullPath("featureRSDFilterComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPath("featureRSDFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -847,11 +847,11 @@ namespace SmartPeak
     LOGD << "START storeFeatureRSDQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureRSDQCComponents_csv_o") << " and " <<
-      filenames.getFullPathName("featureRSDQCComponentGroups_csv_o");
+    LOGI << "Loading: " << filenames.getFullPath("featureRSDQCComponents_csv_o") << " and " <<
+      filenames.getFullPath("featureRSDQCComponentGroups_csv_o");
 
-    if (filenames.getFullPathName("featureRSDQCComponents_csv_o").empty() &&
-      filenames.getFullPathName("featureRSDQCComponentGroups_csv_o").empty()) {
+    if (filenames.getFullPath("featureRSDQCComponents_csv_o").empty() &&
+      filenames.getFullPath("featureRSDQCComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureRSDQC";
       return;
@@ -859,11 +859,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureRSDQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPathName("featureRSDQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
+      if (filenames.getFullPath("featureRSDQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureRSDQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDQC(), false);
       }
-      if (filenames.getFullPathName("featureRSDQCComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPathName("featureRSDQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
+      if (filenames.getFullPath("featureRSDQCComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPath("featureRSDQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -895,13 +895,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", "");
-      filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", filename);
+      filenames.setFullPath("featureBackgroundFilterComponents_csv_i", "");
+      filenames.setFullPath("featureBackgroundFilterComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", filename);
-      filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", "");
+      filenames.setFullPath("featureBackgroundFilterComponents_csv_i", filename);
+      filenames.setFullPath("featureBackgroundFilterComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -920,38 +920,38 @@ namespace SmartPeak
     LOGD << "START loadFeatureBackgroundFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundFilterComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureBackgroundFilterComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureBackgroundFilterComponents_csv_i").empty() &&
-      filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureBackgroundFilterComponents_csv_i").empty() &&
+      filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureBackgroundFilter";
       return;
     }
 
-    if (filenames.getFullPathName("featureBackgroundFilterComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundFilterComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundFilterComponents_csv_i");
+    if (filenames.getFullPath("featureBackgroundFilterComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundFilterComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundFilterComponents_csv_i");
       LOGD << "END loadFeatureBackgroundFilter";
       return;
     }
 
-    if (filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i");
+    if (filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i");
       LOGD << "END loadFeatureBackgroundFilter";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureBackgroundFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPathName("featureBackgroundFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
+      if (filenames.getFullPath("featureBackgroundFilterComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureBackgroundFilterComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundFilterComponentsUpdated();
       }
-      if (filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
+      if (filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundFilterComponentGroupsUpdated();
       }
     }
@@ -986,13 +986,13 @@ namespace SmartPeak
     Filenames filenames;
     if (component_group_)
     {
-      filenames.setFullPathName("featureBackgroundQCComponents_csv_i", "");
-      filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", filename);
+      filenames.setFullPath("featureBackgroundQCComponents_csv_i", "");
+      filenames.setFullPath("featureBackgroundQCComponentGroups_csv_i", filename);
     }
     else
     {
-      filenames.setFullPathName("featureBackgroundQCComponents_csv_i", filename);
-      filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", "");
+      filenames.setFullPath("featureBackgroundQCComponents_csv_i", filename);
+      filenames.setFullPath("featureBackgroundQCComponentGroups_csv_i", "");
     }
     for (SequenceSegmentHandler& sequenceSegmentHandler : application_handler->sequenceHandler_.getSequenceSegments()) {
       sequence_segment_observable_ = &(application_handler->sequenceHandler_);
@@ -1011,38 +1011,38 @@ namespace SmartPeak
     LOGD << "START loadFeatureBackgroundQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundQCComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureBackgroundQCComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureBackgroundQCComponents_csv_i").empty() &&
-      filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureBackgroundQCComponents_csv_i").empty() &&
+      filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureBackgroundQC";
       return;
     }
 
-    if (filenames.getFullPathName("featureBackgroundQCComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundQCComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundQCComponents_csv_i");
+    if (filenames.getFullPath("featureBackgroundQCComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundQCComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundQCComponents_csv_i");
       LOGD << "END loadFeatureBackgroundQC";
       return;
     }
 
-    if (filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i");
+    if (filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i");
       LOGD << "END loadFeatureBackgroundQC";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureBackgroundQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPathName("featureBackgroundQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
+      if (filenames.getFullPath("featureBackgroundQCComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureBackgroundQCComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundQCComponentsUpdated();
       }
-      if (filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
+      if (filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPath("featureBackgroundQCComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
         if (sequence_segment_observable_) sequence_segment_observable_->notifyFeatureBackgroundQCComponentGroupsUpdated();
       }
     }
@@ -1077,11 +1077,11 @@ namespace SmartPeak
     LOGD << "START storeFeatureBackgroundFilter";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPathName("featureBackgroundFilterComponents_csv_o") << " and " <<
-      filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_o");
+    LOGI << "Storing: " << filenames.getFullPath("featureBackgroundFilterComponents_csv_o") << " and " <<
+      filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_o");
 
-    if (filenames.getFullPathName("featureBackgroundFilterComponents_csv_o").empty() &&
-      filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_o").empty()) {
+    if (filenames.getFullPath("featureBackgroundFilterComponents_csv_o").empty() &&
+      filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureBackgroundFilter";
       return;
@@ -1089,11 +1089,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureBackgroundFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPathName("featureBackgroundFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
+      if (filenames.getFullPath("featureBackgroundFilterComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureBackgroundFilterComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), false);
       }
-      if (filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPathName("featureBackgroundFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
+      if (filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPath("featureBackgroundFilterComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundFilter(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1125,11 +1125,11 @@ namespace SmartPeak
     LOGD << "START storeFeatureBackgroundQC";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundQCComponents_csv_o") << " and " <<
-      filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_o");
+    LOGI << "Loading: " << filenames.getFullPath("featureBackgroundQCComponents_csv_o") << " and " <<
+      filenames.getFullPath("featureBackgroundQCComponentGroups_csv_o");
 
-    if (filenames.getFullPathName("featureBackgroundQCComponents_csv_o").empty() &&
-      filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_o").empty()) {
+    if (filenames.getFullPath("featureBackgroundQCComponents_csv_o").empty() &&
+      filenames.getFullPath("featureBackgroundQCComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureBackgroundQC";
       return;
@@ -1137,11 +1137,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureBackgroundQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPathName("featureBackgroundQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
+      if (filenames.getFullPath("featureBackgroundQCComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureBackgroundQCComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), false);
       }
-      if (filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPathName("featureBackgroundQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
+      if (filenames.getFullPath("featureBackgroundQCComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPath("featureBackgroundQCComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundQC(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1459,37 +1459,37 @@ namespace SmartPeak
     LOGD << "START loadFeatureRSDEstimation";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureRSDEstimationComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureRSDEstimationComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureRSDEstimationComponents_csv_i").empty() &&
-      filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureRSDEstimationComponents_csv_i").empty() &&
+      filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureRSDEstimation";
       return;
     }
 
-    if (filenames.getFullPathName("featureRSDEstimationComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDEstimationComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureRSDEstimationComponents_csv_i");
+    if (filenames.getFullPath("featureRSDEstimationComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDEstimationComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureRSDEstimationComponents_csv_i");
       LOGD << "END loadFeatureRSDEstimation";
       return;
     }
 
-    if (filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i");
+    if (filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i");
       LOGD << "END loadFeatureRSDEstimation";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureRSDEstimationComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPathName("featureRSDEstimationComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
+      if (filenames.getFullPath("featureRSDEstimationComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureRSDEstimationComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
       }
-      if (filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
+      if (filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPath("featureRSDEstimationComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1524,11 +1524,11 @@ namespace SmartPeak
     LOGD << "START storeFeatureRSDEstimation";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPathName("featureRSDEstimationComponents_csv_o") << " and " <<
-      filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_o");
+    LOGI << "Storing: " << filenames.getFullPath("featureRSDEstimationComponents_csv_o") << " and " <<
+      filenames.getFullPath("featureRSDEstimationComponentGroups_csv_o");
 
-    if (filenames.getFullPathName("featureRSDEstimationComponents_csv_o").empty() &&
-      filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_o").empty()) {
+    if (filenames.getFullPath("featureRSDEstimationComponents_csv_o").empty() &&
+      filenames.getFullPath("featureRSDEstimationComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureRSDEstimation";
       return;
@@ -1536,11 +1536,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureRSDEstimationComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPathName("featureRSDEstimationComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
+      if (filenames.getFullPath("featureRSDEstimationComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureRSDEstimationComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), false);
       }
-      if (filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPathName("featureRSDEstimationComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
+      if (filenames.getFullPath("featureRSDEstimationComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPath("featureRSDEstimationComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureRSDEstimations(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1572,37 +1572,37 @@ namespace SmartPeak
     LOGD << "START loadFeatureBackgroundEstimation";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Loading: " << filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i") << " and " <<
-      filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i");
+    LOGI << "Loading: " << filenames.getFullPath("featureBackgroundEstimationComponents_csv_i") << " and " <<
+      filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i");
 
-    if (filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i").empty() &&
-      filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i").empty()) {
+    if (filenames.getFullPath("featureBackgroundEstimationComponents_csv_i").empty() &&
+      filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END loadFeatureBackgroundEstimation";
       return;
     }
 
-    if (filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i");
+    if (filenames.getFullPath("featureBackgroundEstimationComponents_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundEstimationComponents_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundEstimationComponents_csv_i");
       LOGD << "END loadFeatureBackgroundEstimation";
       return;
     }
 
-    if (filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i").size() &&
-      !InputDataValidation::fileExists(filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i"))) {
-      LOGE << "File not found: " << filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i");
+    if (filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i").size() &&
+      !InputDataValidation::fileExists(filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i"))) {
+      LOGE << "File not found: " << filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i");
       LOGD << "END loadFeatureBackgroundEstimation";
       return;
     }
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.load(filenames.getFullPathName("featureBackgroundEstimationComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
+      if (filenames.getFullPath("featureBackgroundEstimationComponents_csv_i").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.load(filenames.getFullPath("featureBackgroundEstimationComponents_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
       }
-      if (filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i").size()) {
-        featureQCFile.load(filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
+      if (filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i").size()) {
+        featureQCFile.load(filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_i"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
       }
     }
     catch (const std::exception& e) {
@@ -1637,11 +1637,11 @@ namespace SmartPeak
     LOGD << "START storeFeatureBackgroundEstimation";
     Filenames filenames = prepareFileNames(filenames_I);
 
-    LOGI << "Storing: " << filenames.getFullPathName("featureBackgroundEstimationComponents_csv_o") << " and " <<
-      filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_o");
+    LOGI << "Storing: " << filenames.getFullPath("featureBackgroundEstimationComponents_csv_o") << " and " <<
+      filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_o");
 
-    if (filenames.getFullPathName("featureBackgroundEstimationComponents_csv_o").empty() &&
-      filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_o").empty()) {
+    if (filenames.getFullPath("featureBackgroundEstimationComponents_csv_o").empty() &&
+      filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_o").empty()) {
       LOGE << "Filenames are both empty";
       LOGD << "END storeFeatureBackgroundEstimation";
       return;
@@ -1649,11 +1649,11 @@ namespace SmartPeak
 
     try {
       OpenMS::MRMFeatureQCFile featureQCFile;
-      if (filenames.getFullPathName("featureBackgroundEstimationComponents_csv_o").size()) { // because we don't know if either of the two names is empty
-        featureQCFile.store(filenames.getFullPathName("featureBackgroundEstimationComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
+      if (filenames.getFullPath("featureBackgroundEstimationComponents_csv_o").size()) { // because we don't know if either of the two names is empty
+        featureQCFile.store(filenames.getFullPath("featureBackgroundEstimationComponents_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), false);
       }
-      if (filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_o").size()) {
-        featureQCFile.store(filenames.getFullPathName("featureBackgroundEstimationComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
+      if (filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_o").size()) {
+        featureQCFile.store(filenames.getFullPath("featureBackgroundEstimationComponentGroups_csv_o"), sequenceSegmentHandler_IO.getFeatureBackgroundEstimations(), true);
       }
     }
     catch (const std::exception& e) {

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -68,7 +68,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START optimizeCalibrationCurves";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     std::vector<size_t> standards_indices;
     // get all standards
@@ -171,7 +171,7 @@ namespace SmartPeak
     return true;
   }
 
-  void LoadStandardsConcentrations::getInputsOutputs(Filenames& filenames) const
+  void LoadStandardsConcentrations::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("standardsConcentrations_csv_i", "${MAIN_DIR}/standardsConcentrations.csv");
   };
@@ -184,7 +184,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadStandardsConcentrations";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoad(filenames, "standardsConcentrations_csv_i"))
     {
@@ -210,7 +210,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void LoadQuantitationMethods::getInputsOutputs(Filenames& filenames) const
+  void LoadQuantitationMethods::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("quantitationMethods_csv_i", "${MAIN_DIR}/quantitationMethods.csv");
   };
@@ -239,7 +239,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadQuantitationMethods";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoad(filenames, "quantitationMethods_csv_i"))
     {
@@ -265,7 +265,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void StoreQuantitationMethods::getInputsOutputs(Filenames& filenames) const
+  void StoreQuantitationMethods::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("quantitationMethods_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_quantitationMethods.csv");
   };
@@ -278,7 +278,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeQuantitationMethods";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStore(filenames, "quantitationMethods_csv_o"))
     {
@@ -330,7 +330,7 @@ namespace SmartPeak
     return true;
   }
 
-  void LoadFeatureFilters::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatureFilters::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureFilterComponents_csv_i", "${MAIN_DIR}/featureFilterComponents.csv");
     filenames.addFileName("featureFilterComponentGroups_csv_i", "${MAIN_DIR}/featureFilterComponentGroups.csv");
@@ -344,7 +344,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureFilter";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureFilterComponents_csv_i", "featureFilterComponentGroups_csv_i"))
     {
@@ -403,7 +403,7 @@ namespace SmartPeak
     return true;
   }
 
-  void LoadFeatureQCs::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatureQCs::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureQCComponents_csv_i", "${MAIN_DIR}/featureQCComponents.csv");
     filenames.addFileName("featureQCComponentGroups_csv_i", "${MAIN_DIR}/featureQCComponentGroups.csv");
@@ -417,7 +417,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureQC";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureQCComponents_csv_i", "featureQCComponentGroups_csv_i"))
     {
@@ -451,7 +451,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void StoreFeatureFilters::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatureFilters::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureFilterComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureFilterComponents.csv");
     filenames.addFileName("featureFilterComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureFilterComponentGroups.csv");
@@ -465,7 +465,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureFilter";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureFilterComponents_csv_o", "featureFilterComponentGroups_csv_o"))
     {
@@ -495,7 +495,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void StoreFeatureQCs::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatureQCs::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureQCComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureQCComponents.csv");
     filenames.addFileName("featureQCComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureQCComponentGroups.csv");
@@ -509,7 +509,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureQC";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureQCComponents_csv_o", "featureQCComponentGroups_csv_o"))
     {
@@ -539,7 +539,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void LoadFeatureRSDFilters::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatureRSDFilters::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureRSDFilterComponents_csv_i", "${MAIN_DIR}/featureRSDFilterComponents.csv");
     filenames.addFileName("featureRSDFilterComponentGroups_csv_i", "${MAIN_DIR}/featureRSDFilterComponentGroups.csv");
@@ -578,7 +578,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureRSDFilter";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureRSDFilterComponents_csv_i", "featureRSDFilterComponentGroups_csv_i"))
     {
@@ -619,7 +619,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void LoadFeatureRSDQCs::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatureRSDQCs::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureRSDQCComponents_csv_i", "${MAIN_DIR}/featureRSDQCComponents.csv");
     filenames.addFileName("featureRSDQCComponentGroups_csv_i", "${MAIN_DIR}/featureRSDQCComponentGroups.csv");
@@ -658,7 +658,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureRSDQC";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureRSDQCComponents_csv_i", "featureRSDQCComponentGroups_csv_i"))
     {
@@ -692,7 +692,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void StoreFeatureRSDFilters::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatureRSDFilters::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureRSDFilterComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDFilterComponents.csv");
     filenames.addFileName("featureRSDFilterComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDFilterComponentGroups.csv");
@@ -706,7 +706,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureRSDFilter";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureRSDFilterComponents_csv_o", "featureRSDFilterComponentGroups_csv_o"))
     {
@@ -736,7 +736,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void StoreFeatureRSDQCs::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatureRSDQCs::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureRSDQCComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDQCComponents.csv");
     filenames.addFileName("featureRSDQCComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDQCComponentGroups.csv");
@@ -750,7 +750,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureRSDQC";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureRSDQCComponents_csv_o", "featureRSDQCComponentGroups_csv_o"))
     {
@@ -780,7 +780,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void LoadFeatureBackgroundFilters::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatureBackgroundFilters::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureBackgroundFilterComponents_csv_i", "${MAIN_DIR}/featureBackgroundFilterComponents.csv");
     filenames.addFileName("featureBackgroundFilterComponentGroups_csv_i", "${MAIN_DIR}/featureBackgroundFilterComponentGroups.csv");
@@ -819,7 +819,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureBackgroundFilter";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureBackgroundFilterComponents_csv_i", "featureBackgroundFilterComponentGroups_csv_i"))
     {
@@ -853,7 +853,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void LoadFeatureBackgroundQCs::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatureBackgroundQCs::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureBackgroundQCComponents_csv_i", "${MAIN_DIR}/featureBackgroundQCComponents.csv");
     filenames.addFileName("featureBackgroundQCComponentGroups_csv_i", "${MAIN_DIR}/featureBackgroundQCComponentGroups.csv");
@@ -892,7 +892,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureBackgroundQC";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureBackgroundQCComponents_csv_i", "featureBackgroundQCComponentGroups_csv_i"))
     {
@@ -926,7 +926,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void StoreFeatureBackgroundFilters::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatureBackgroundFilters::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureBackgroundFilterComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundFilterComponents.csv");
     filenames.addFileName("featureBackgroundFilterComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundFilterComponentGroups.csv");
@@ -940,7 +940,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureBackgroundFilter";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureBackgroundFilterComponents_csv_o", "featureBackgroundFilterComponentGroups_csv_o"))
     {
@@ -970,7 +970,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void StoreFeatureBackgroundQCs::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatureBackgroundQCs::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureBackgroundQCComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundQCComponents.csv");
     filenames.addFileName("featureBackgroundQCComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundQCComponentGroups.csv");
@@ -984,7 +984,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureBackgroundQC";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureBackgroundQCComponents_csv_o", "featureBackgroundQCComponentGroups_csv_o"))
     {
@@ -1022,7 +1022,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START estimateFeatureFilterValues";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     std::vector<size_t> standards_indices, qcs_indices;
 
@@ -1082,7 +1082,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START estimateFeatureQCValues";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     std::vector<size_t> standards_indices, qcs_indices;
 
@@ -1142,7 +1142,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START TransferLOQToFeatureFilters";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // check if there are any quantitation methods
     if (sequenceSegmentHandler_IO.getQuantitationMethods().empty()) {
@@ -1173,7 +1173,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START TransferLOQToFeatureQCs";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // check if there are any quantitation methods
     if (sequenceSegmentHandler_IO.getQuantitationMethods().empty()) {
@@ -1204,7 +1204,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START EstimateFeatureRSDs";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // get all QCs
     std::vector<size_t> qcs_indices;
@@ -1252,7 +1252,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START EstimateFeatureBackgroundInterferences";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     // get all Blanks
     std::vector<size_t> blanks_indices;
@@ -1294,7 +1294,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void LoadFeatureRSDEstimations::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatureRSDEstimations::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureRSDEstimationComponents_csv_i", "${MAIN_DIR}/featureRSDEstimationComponents.csv");
     filenames.addFileName("featureRSDEstimationComponentGroups_csv_i", "${MAIN_DIR}/featureRSDEstimationComponentGroups.csv");
@@ -1308,7 +1308,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureRSDEstimation";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureRSDEstimationComponents_csv_i", "featureRSDEstimationComponentGroups_csv_i"))
     {
@@ -1341,7 +1341,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void StoreFeatureRSDEstimations::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatureRSDEstimations::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureRSDEstimationComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDEstimationComponents.csv");
     filenames.addFileName("featureRSDEstimationComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureRSDEstimationComponentGroups.csv");
@@ -1355,7 +1355,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureRSDEstimation";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureRSDEstimationComponents_csv_o", "featureRSDEstimationComponentGroups_csv_o"))
     {
@@ -1385,7 +1385,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void LoadFeatureBackgroundEstimations::getInputsOutputs(Filenames& filenames) const
+  void LoadFeatureBackgroundEstimations::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureBackgroundEstimationComponents_csv_i", "${MAIN_DIR}/featureBackgroundEstimationComponents.csv");
     filenames.addFileName("featureBackgroundEstimationComponentGroups_csv_i", "${MAIN_DIR}/featureBackgroundEstimationComponentGroups.csv");
@@ -1399,7 +1399,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START loadFeatureBackgroundEstimation";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToLoadOneOfTwo(filenames, "featureBackgroundEstimationComponents_csv_i", "featureBackgroundEstimationComponentGroups_csv_i"))
     {
@@ -1432,7 +1432,7 @@ namespace SmartPeak
     return ParameterSet();
   }
 
-  void StoreFeatureBackgroundEstimations::getInputsOutputs(Filenames& filenames) const
+  void StoreFeatureBackgroundEstimations::getFilenames(Filenames& filenames) const
   {
     filenames.addFileName("featureBackgroundEstimationComponents_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundEstimationComponents.csv");
     filenames.addFileName("featureBackgroundEstimationComponentGroups_csv_o", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}_featureBackgroundEstimationComponentGroups.csv");
@@ -1446,7 +1446,7 @@ namespace SmartPeak
   ) const
   {
     LOGD << "START storeFeatureBackgroundEstimation";
-    Filenames filenames = prepareFileNames(filenames_I);
+    Filenames filenames = prepareFilenames(filenames_I);
 
     if (!InputDataValidation::prepareToStoreOneOfTwo(filenames, "featureBackgroundEstimationComponents_csv_o", "featureBackgroundEstimationComponentGroups_csv_o"))
     {

--- a/src/smartpeak/source/io/InputDataValidation.cpp
+++ b/src/smartpeak/source/io/InputDataValidation.cpp
@@ -577,4 +577,77 @@ namespace SmartPeak
     oss << "\n";
     return oss.str();
   }
+
+  bool InputDataValidation::prepareToLoad(const Filenames filenames, const std::string& id)
+  {
+    LOGI << "Loading: " << filenames.getFullPath(id).generic_string();
+
+    if (filenames.getFullPath(id).empty()) {
+      LOGE << "Filename is empty";
+      return false;
+    }
+
+    if (!InputDataValidation::fileExists(filenames.getFullPath(id))) {
+      LOGE << "File not found";
+      return false;
+    }
+
+    return true;
+  }
+
+  bool InputDataValidation::prepareToLoadOneOfTwo(const Filenames filenames, const std::string& id1, const std::string& id2)
+  {
+    LOGI << "Loading: " << 
+      filenames.getFullPath(id1).generic_string() 
+      << " and " <<
+      filenames.getFullPath(id2).generic_string();
+
+    if (filenames.getFullPath(id1).empty() &&
+      filenames.getFullPath(id2).empty()) {
+      LOGE << "Filenames are both empty";
+      return false;
+    }
+
+    if (!filenames.getFullPath(id1).empty() &&
+      !InputDataValidation::fileExists(filenames.getFullPath(id1))) {
+      LOGE << "File not found: " << filenames.getFullPath(id1).generic_string();
+      return false;
+    }
+
+    if (!filenames.getFullPath(id2).empty() &&
+      !InputDataValidation::fileExists(filenames.getFullPath(id2))) {
+      LOGE << "File not found: " << filenames.getFullPath(id2).generic_string();
+      return false;
+    }
+
+    return true;
+  }
+
+  bool InputDataValidation::prepareToStore(const Filenames filenames, const std::string& id)
+  {
+    LOGI << "Storing: " << filenames.getFullPath(id).generic_string();
+
+    if (filenames.getFullPath(id).empty()) {
+      LOGE << "Filename is empty";
+      return false;
+    }
+
+    return true;
+  }
+
+  bool InputDataValidation::prepareToStoreOneOfTwo(const Filenames filenames, const std::string& id1, const std::string& id2)
+  {
+    LOGI << "Storing: " << 
+      filenames.getFullPath(id1).generic_string()
+      << " and " <<
+      filenames.getFullPath(id2).generic_string();
+
+    if (filenames.getFullPath(id1).empty() &&
+      filenames.getFullPath(id2).empty()) {
+      LOGE << "Filenames are both empty";
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/src/smartpeak/source/io/InputDataValidation.cpp
+++ b/src/smartpeak/source/io/InputDataValidation.cpp
@@ -40,33 +40,44 @@ namespace SmartPeak
     return ifs.is_open();
   }
 
-  InputDataValidation::FilenameInfo InputDataValidation::isValidFilename(const std::filesystem::path& filename, const std::string& member_name, bool required)
+  InputDataValidation::FilenameInfo InputDataValidation::processorInputAreReady(
+    const IInputsOutputsProvider& input_files,
+    const std::string& member_name,
+    const Filenames& filenames_I,
+    bool required)
   {
-    FilenameInfo v;
-    v.pathname = filename;
-    v.member_name = member_name;
-    std::ostringstream msg;
-    msg << member_name << ":\n\t";
-    const bool file_exists = fileExists(filename);
-    if (!file_exists && !required)
+    Filenames filenames = filenames_I;
+    input_files.getInputsOutputs(filenames);
+
+    for (const auto& f : filenames.getFileNames())
     {
-      msg << "NOT PROVIDED\n";
-      v.validity = FilenameInfo::not_provided;
+      FilenameInfo v;
+      // v.pathname = filename;
+      v.member_name = member_name;
+      std::ostringstream msg;
+      msg << member_name << ":\n\t";
+      const bool file_exists = fileExists(f.second.full_path_);
+      if (!file_exists && !required)
+      {
+        msg << "NOT PROVIDED\n";
+        v.validity = FilenameInfo::not_provided;
+      }
+      else
+      {
+        msg << (file_exists ? "SUCCESS" : "FAILURE") << " <- " << f.second.full_path_.generic_string() << "\n";
+        v.validity = file_exists ? FilenameInfo::valid : FilenameInfo::invalid;
+      }
+      if (v.validity == FilenameInfo::invalid)
+      {
+        LOGE << msg.str();
+      }
+      else
+      {
+        LOGI << msg.str();
+      }
+      return v;
     }
-    else
-    {
-      msg << (file_exists ? "SUCCESS" : "FAILURE") << " <- " << filename << "\n";
-      v.validity = file_exists ? FilenameInfo::valid : FilenameInfo::invalid;
-    }
-    if (v.validity == FilenameInfo::invalid)
-    {
-      LOGE << msg.str();
-    }
-    else
-    {
-      LOGI << msg.str();
-    }
-    return v;
+
   }
 
   std::string InputDataValidation::getSequenceInfo(

--- a/src/smartpeak/source/io/InputDataValidation.cpp
+++ b/src/smartpeak/source/io/InputDataValidation.cpp
@@ -40,20 +40,23 @@ namespace SmartPeak
     return ifs.is_open();
   }
 
-  InputDataValidation::FilenameInfo InputDataValidation::isValidFilename(const std::string& filename, const std::string& member_name)
+  InputDataValidation::FilenameInfo InputDataValidation::isValidFilename(const std::string& filename, const std::string& member_name, bool required)
   {
     FilenameInfo v;
     v.pathname = filename;
     v.member_name = member_name;
     std::ostringstream msg;
     msg << member_name << ":\n\t";
-    if (filename.size()) {
-      const bool is_valid = fileExists(filename);
-      msg << (is_valid ? "SUCCESS" : "FAILURE") << " <- " << filename << "\n";
-      v.validity = is_valid ? FilenameInfo::valid : FilenameInfo::invalid;
-    } else {
+    const bool file_exists = fileExists(filename);
+    if (!file_exists && !required)
+    {
       msg << "NOT PROVIDED\n";
       v.validity = FilenameInfo::not_provided;
+    }
+    else
+    {
+      msg << (file_exists ? "SUCCESS" : "FAILURE") << " <- " << filename << "\n";
+      v.validity = file_exists ? FilenameInfo::valid : FilenameInfo::invalid;
     }
     if (v.validity == FilenameInfo::invalid)
     {

--- a/src/smartpeak/source/io/InputDataValidation.cpp
+++ b/src/smartpeak/source/io/InputDataValidation.cpp
@@ -34,13 +34,13 @@
 
 namespace SmartPeak
 {
-  bool InputDataValidation::fileExists(const std::string& filepath)
+  bool InputDataValidation::fileExists(const std::filesystem::path& filepath)
   {
     std::ifstream ifs(filepath);
     return ifs.is_open();
   }
 
-  InputDataValidation::FilenameInfo InputDataValidation::isValidFilename(const std::string& filename, const std::string& member_name, bool required)
+  InputDataValidation::FilenameInfo InputDataValidation::isValidFilename(const std::filesystem::path& filename, const std::string& member_name, bool required)
   {
     FilenameInfo v;
     v.pathname = filename;

--- a/src/smartpeak/source/io/InputDataValidation.cpp
+++ b/src/smartpeak/source/io/InputDataValidation.cpp
@@ -41,13 +41,13 @@ namespace SmartPeak
   }
 
   bool InputDataValidation::precheckProcessorInputs(
-    const IInputsOutputsProvider& input_files,
+    const IFilenamesHandler& input_files,
     const std::string& processor_name,
     const Filenames& filenames_I,
     bool required)
   {
     Filenames processor_filenames;
-    input_files.getInputsOutputs(processor_filenames);
+    input_files.getFilenames(processor_filenames);
 
     Filenames merged_filenames = filenames_I;
     merged_filenames.merge(processor_filenames);
@@ -598,7 +598,7 @@ namespace SmartPeak
     return oss.str();
   }
 
-  bool InputDataValidation::prepareToLoad(const Filenames filenames, const std::string& id)
+  bool InputDataValidation::prepareToLoad(const Filenames& filenames, const std::string& id)
   {
     LOGI << "Loading: " << filenames.getFullPath(id).generic_string();
 
@@ -615,7 +615,7 @@ namespace SmartPeak
     return true;
   }
 
-  bool InputDataValidation::prepareToLoadOneOfTwo(const Filenames filenames, const std::string& id1, const std::string& id2)
+  bool InputDataValidation::prepareToLoadOneOfTwo(const Filenames& filenames, const std::string& id1, const std::string& id2)
   {
     LOGI << "Loading: " << 
       filenames.getFullPath(id1).generic_string() 
@@ -643,7 +643,7 @@ namespace SmartPeak
     return true;
   }
 
-  bool InputDataValidation::prepareToStore(const Filenames filenames, const std::string& id)
+  bool InputDataValidation::prepareToStore(const Filenames& filenames, const std::string& id)
   {
     LOGI << "Storing: " << filenames.getFullPath(id).generic_string();
 
@@ -655,7 +655,7 @@ namespace SmartPeak
     return true;
   }
 
-  bool InputDataValidation::prepareToStoreOneOfTwo(const Filenames filenames, const std::string& id1, const std::string& id2)
+  bool InputDataValidation::prepareToStoreOneOfTwo(const Filenames& filenames, const std::string& id1, const std::string& id2)
   {
     LOGI << "Storing: " << 
       filenames.getFullPath(id1).generic_string()

--- a/src/smartpeak/source/io/InputDataValidation.cpp
+++ b/src/smartpeak/source/io/InputDataValidation.cpp
@@ -55,7 +55,14 @@ namespace SmartPeak
       msg << "NOT PROVIDED\n";
       v.validity = FilenameInfo::not_provided;
     }
-    LOGI << msg.str();
+    if (v.validity == FilenameInfo::invalid)
+    {
+      LOGE << msg.str();
+    }
+    else
+    {
+      LOGI << msg.str();
+    }
     return v;
   }
 

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -74,7 +74,7 @@ namespace SmartPeak
   template<typename DELIMITER>
   void SequenceParser::readSequenceFile(
     SequenceHandler& sequenceHandler,
-    const std::string& pathname
+    const std::filesystem::path& pathname
   )
   {
     const std::string s_sample_name{ "sample_name" };
@@ -99,7 +99,7 @@ namespace SmartPeak
     const std::string s_scan_mass_low{ "scan_mass_low" };
     const std::string s_scan_mass_high{ "scan_mass_high" };
 
-    io::CSVReader<21, io::trim_chars<>, DELIMITER> reader(pathname);
+    io::CSVReader<21, io::trim_chars<>, DELIMITER> reader(pathname.generic_string());
 
     reader.read_header(
       io::ignore_extra_column | io::ignore_missing_column,
@@ -152,7 +152,7 @@ namespace SmartPeak
     for (const auto& mandatory_column : mandatory_columns)
     {
       if (!reader.has_column(mandatory_column)) {
-        LOGE << "Missing column " << mandatory_column << " in file " << pathname;
+        LOGE << "Missing column " << mandatory_column << " in file " << pathname.generic_string();
         throw std::runtime_error("Failed loading sequence file\n");
       }
     }
@@ -241,7 +241,7 @@ namespace SmartPeak
       }
       catch (const std::exception& e)
       {
-        LOGE << "Error reading " << pathname << " in line " << line_number << ", column '" << current_validating_column << "'";
+        LOGE << "Error reading " << pathname.generic_string() << " in line " << line_number << ", column '" << current_validating_column << "'";
         throw;
       }
     }
@@ -249,14 +249,14 @@ namespace SmartPeak
 
   void SequenceParser::readSequenceFile(
     SequenceHandler& sequenceHandler,
-    const std::string& pathname,
+    const std::filesystem::path& pathname,
     const std::string& delimiter
   )
   {
     LOGD << "START readSequenceFile";
     LOGD << "Delimiter: " << delimiter;
 
-    LOGI << "Loading: " << pathname;
+    LOGI << "Loading: " << pathname.generic_string();
 
     if (pathname.empty()) {
       LOGE << "Pathname is empty";
@@ -353,12 +353,14 @@ namespace SmartPeak
     }
   }
 
-  void SequenceParser::writeSequenceFileSmartPeak(SequenceHandler& sequenceHandler, const std::string& filename, const std::string& delimiter)
+  void SequenceParser::writeSequenceFileSmartPeak(SequenceHandler& sequenceHandler,
+    const std::filesystem::path& filename,
+    const std::string& delimiter)
   {
     LOGD << "START writeSequenceFileSmartPeak";
     LOGD << "Delimiter: " << delimiter;
 
-    LOGI << "Loading: " << filename;
+    LOGI << "Loading: " << filename.generic_string();
 
     if (filename.empty()) {
       LOGE << "filename is empty";
@@ -373,7 +375,7 @@ namespace SmartPeak
     makeSequenceFileSmartPeak(sequenceHandler, rows, headers);
 
     // Write the output file
-    CSVWriter writer(filename, delimiter);
+    CSVWriter writer(filename.generic_string(), delimiter);
     const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
     if (cnt < headers.size()) {
@@ -423,12 +425,15 @@ namespace SmartPeak
     }
   }
 
-  void SequenceParser::writeSequenceFileAnalyst(SequenceHandler& sequenceHandler, const std::string& filename, const std::string& delimiter)
+  void SequenceParser::writeSequenceFileAnalyst(SequenceHandler& sequenceHandler,
+    const std::filesystem::path& filename,
+    const std::string& delimiter
+  )
   {
     LOGD << "START writeSequenceFileAnalyst";
     LOGD << "Delimiter: " << delimiter;
 
-    LOGI << "Loading: " << filename;
+    LOGI << "Loading: " << filename.generic_string();
 
     if (filename.empty()) {
       LOGE << "filename is empty";
@@ -443,7 +448,7 @@ namespace SmartPeak
     makeSequenceFileAnalyst(sequenceHandler, rows, headers);
 
     // Write the output file
-    CSVWriter writer(filename, delimiter);
+    CSVWriter writer(filename.generic_string(), delimiter);
     const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
     if (cnt < headers.size()) {
@@ -487,12 +492,14 @@ namespace SmartPeak
     }
   }
 
-  void SequenceParser::writeSequenceFileMasshunter(SequenceHandler& sequenceHandler, const std::string& filename, const std::string& delimiter)
+  void SequenceParser::writeSequenceFileMasshunter(SequenceHandler& sequenceHandler,
+    const std::filesystem::path& filename,
+    const std::string& delimiter)
   {
     LOGD << "START writeSequenceFileMasshunter";
     LOGD << "Delimiter: " << delimiter;
 
-    LOGI << "Loading: " << filename;
+    LOGI << "Loading: " << filename.generic_string();
 
     if (filename.empty()) {
       LOGE << "filename is empty";
@@ -507,7 +514,7 @@ namespace SmartPeak
     makeSequenceFileMasshunter(sequenceHandler, rows, headers);
 
     // Write the output file
-    CSVWriter writer(filename, delimiter);
+    CSVWriter writer(filename.generic_string(), delimiter);
     const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
     if (cnt < headers.size()) {
@@ -562,11 +569,13 @@ namespace SmartPeak
     }
   }
 
-  void SequenceParser::writeSequenceFileXcalibur(SequenceHandler& sequenceHandler, const std::string& filename, const std::string& delimiter)
+  void SequenceParser::writeSequenceFileXcalibur(SequenceHandler& sequenceHandler,
+    const std::filesystem::path& filename,
+    const std::string& delimiter)
   {
     LOGD << "START writeSequenceFileXcalibur";
     LOGD << "Delimiter: " << delimiter;
-    LOGI << "Loading: " << filename;
+    LOGI << "Loading: " << filename.generic_string();
 
     if (filename.empty()) {
       LOGE << "filename is empty";
@@ -580,7 +589,7 @@ namespace SmartPeak
     makeSequenceFileXcalibur(sequenceHandler, rows, headers);
 
     // Write the output file
-    CSVWriter writer(filename, delimiter);
+    CSVWriter writer(filename.generic_string(), delimiter);
     std::vector<std::string> pre_headers;
     for (int i = 0; i < headers.size(); ++i) {
       if (i == 0) pre_headers.push_back("Bracket Type=4");
@@ -765,13 +774,13 @@ namespace SmartPeak
 
   bool SequenceParser::writeDataTableFromMetaValue(
     const SequenceHandler& sequenceHandler,
-    const std::string& filename,
+    const std::filesystem::path& filename,
     const std::vector<FeatureMetadata>& meta_data,
     const std::set<SampleType>& sample_types
   )
   {
     LOGD << "START writeDataTableFromMetaValue";
-    LOGI << "Storing: " << filename;
+    LOGI << "Storing: " << filename.generic_string();
 
     std::vector<std::vector<std::string>> rows;
     std::vector<std::string> headers;
@@ -781,7 +790,7 @@ namespace SmartPeak
     }
     makeDataTableFromMetaValue(sequenceHandler, rows, headers, meta_data_strings, sample_types, std::set<std::string>(), std::set<std::string>(), std::set<std::string>());
 
-    CSVWriter writer(filename, ",");
+    CSVWriter writer(filename.generic_string(), ",");
     const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
     if (cnt < headers.size()) {
@@ -956,14 +965,14 @@ namespace SmartPeak
 
   bool SequenceParser::writeDataMatrixFromMetaValue(
     const SequenceHandler& sequenceHandler,
-    const std::string& filename,
+    const std::filesystem::path& filename,
     const std::vector<FeatureMetadata>& meta_data,
     const std::set<SampleType>& sample_types
   )
   {
     LOGD << "START writeDataMatrixFromMetaValue";
 
-    LOGI << "Storing: " << filename;
+    LOGI << "Storing: " << filename.generic_string();
 
     Eigen::Tensor<float,2> data;
     Eigen::Tensor<std::string,1> columns;
@@ -977,7 +986,7 @@ namespace SmartPeak
     std::vector<std::string> headers = {"component_group_name", "component_name", "meta_value"};
     for (int i=0;i<columns.size();++i) headers.push_back(columns(i));
 
-    CSVWriter writer(filename, ",");
+    CSVWriter writer(filename.generic_string(), ",");
     const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
     if (cnt < headers.size()) {

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -1010,7 +1010,7 @@ namespace SmartPeak
     return true;
   }
 
-  bool StoreSequenceFileSmartPeak::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool StoreSequenceFileSmartPeak::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -1021,7 +1021,7 @@ namespace SmartPeak
     return true;
   }
 
-  bool StoreSequenceFileAnalyst::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool StoreSequenceFileAnalyst::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -1032,7 +1032,7 @@ namespace SmartPeak
     return true;
   }
 
-  bool StoreSequenceFileMasshunter::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool StoreSequenceFileMasshunter::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {
@@ -1043,7 +1043,7 @@ namespace SmartPeak
     return true;
   }
 
-  bool StoreSequenceFileXcalibur::onFilePicked(const std::string& filename, ApplicationHandler* application_handler)
+  bool StoreSequenceFileXcalibur::onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler)
   {
     if (application_handler->sequenceHandler_.getSequence().size() == 0)
     {

--- a/src/smartpeak/source/ui/Report.cpp
+++ b/src/smartpeak/source/ui/Report.cpp
@@ -88,7 +88,7 @@ namespace SmartPeak
       const bool checkboxes_check = initializeMetadataAndSampleTypes();
       if (checkboxes_check)
       {
-        const std::string pathname = application_handler_.main_dir_ + "/FeatureDB.csv";
+        const auto pathname = application_handler_.main_dir_ / "FeatureDB.csv";
         run_and_join(
           SequenceParser::writeDataTableFromMetaValue,
           "FeatureDB.csv",
@@ -111,7 +111,7 @@ namespace SmartPeak
       const bool checkboxes_check = initializeMetadataAndSampleTypes();
       if (checkboxes_check)
       {
-        const std::string pathname = application_handler_.main_dir_ + "/PivotTable.csv";
+        const auto pathname = application_handler_.main_dir_ / "PivotTable.csv";
         run_and_join(
           SequenceParser::writeDataMatrixFromMetaValue,
           "PivotTable.csv",
@@ -161,10 +161,10 @@ namespace SmartPeak
   }
 
   void Report::run_and_join(
-    bool (*data_writer)(const SequenceHandler&, const std::string&, const std::vector<FeatureMetadata>&, const std::set<SampleType>&),
+    bool (*data_writer)(const SequenceHandler&, const std::filesystem::path&, const std::vector<FeatureMetadata>&, const std::set<SampleType>&),
     const std::string& data_writer_label,
     const SequenceHandler sequence,
-    const std::string& pathname,
+    const std::filesystem::path& pathname,
     const std::vector<FeatureMetadata>& meta_data,
     const std::set<SampleType>& sample_types
   )
@@ -188,7 +188,7 @@ namespace SmartPeak
     }
 
     if (data_was_written) {
-      LOGN << data_writer_label << " file has been stored at: " << pathname;
+      LOGN << data_writer_label << " file has been stored at: " << pathname.generic_string();
     } else {
       LOGE << "Error during write. " << data_writer_label << " content is invalid.";
     }

--- a/src/smartpeak/source/ui/RunWorkflowWidget.cpp
+++ b/src/smartpeak/source/ui/RunWorkflowWidget.cpp
@@ -115,9 +115,9 @@ namespace SmartPeak
           {
             for (auto& p : cmd.dynamic_filenames)
             {
-              p.second.setTag("MZML_INPUT_PATH", application_handler_.mzML_dir_.generic_string());
-              p.second.setTag("FEATURES_INPUT_PATH", application_handler_.features_in_dir_.generic_string());
-              p.second.setTag("FEATURES_OUTPUT_PATH", application_handler_.features_out_dir_.generic_string());
+              p.second.setTag(Filenames::Tag::MZML_INPUT_PATH, application_handler_.mzML_dir_.generic_string());
+              p.second.setTag(Filenames::Tag::FEATURES_INPUT_PATH, application_handler_.features_in_dir_.generic_string());
+              p.second.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, application_handler_.features_out_dir_.generic_string());
             }
           }
           const std::set<std::string> injection_names = session_handler_.getSelectInjectionNamesWorkflow(application_handler_.sequenceHandler_);

--- a/src/smartpeak/source/ui/RunWorkflowWidget.cpp
+++ b/src/smartpeak/source/ui/RunWorkflowWidget.cpp
@@ -115,7 +115,6 @@ namespace SmartPeak
           {
             for (auto& p : cmd.dynamic_filenames)
             {
-              p.second.setTag("MAIN_DIR", application_handler_.main_dir_.generic_string());
               p.second.setTag("MZML_INPUT_PATH", application_handler_.mzML_dir_.generic_string());
               p.second.setTag("FEATURES_INPUT_PATH", application_handler_.features_in_dir_.generic_string());
               p.second.setTag("FEATURES_OUTPUT_PATH", application_handler_.features_out_dir_.generic_string());

--- a/src/smartpeak/source/ui/RunWorkflowWidget.cpp
+++ b/src/smartpeak/source/ui/RunWorkflowWidget.cpp
@@ -102,11 +102,11 @@ namespace SmartPeak
           {
             for (auto& p : cmd.dynamic_filenames)
             {
-              Filenames::updateDefaultDynamicFilenames(
+              p.second.setRootPaths(
+                application_handler_.main_dir_,
                 application_handler_.mzML_dir_,
                 application_handler_.features_in_dir_,
-                application_handler_.features_out_dir_,
-                p.second
+                application_handler_.features_out_dir_
               );
             }
           }

--- a/src/smartpeak/source/ui/RunWorkflowWidget.cpp
+++ b/src/smartpeak/source/ui/RunWorkflowWidget.cpp
@@ -37,9 +37,18 @@ namespace SmartPeak
   {
     if (ImGui::BeginPopupModal("Run workflow modal", NULL, ImGuiWindowFlags_None))
     {
+      if (!directories_set_)
+      {
+        // InputTextWithHint does not support std::filesystem::path so we have to create temporary strings for the paths
+        mzML_dir_ = application_handler_.mzML_dir_.generic_string();
+        features_in_dir_ = application_handler_.features_in_dir_.generic_string();
+        features_out_dir_ = application_handler_.features_out_dir_.generic_string();
+        directories_set_ = true;
+      }
+
       ImGui::Text("mzML folder");
       ImGui::PushID(1);
-      ImGui::InputTextWithHint("", application_handler_.mzML_dir_.c_str(), &(application_handler_.mzML_dir_));
+      ImGui::InputTextWithHint("", mzML_dir_.c_str(), &mzML_dir_);
       ImGui::PopID();
       ImGui::SameLine();
       ImGui::PushID(11);
@@ -52,7 +61,7 @@ namespace SmartPeak
 
       ImGui::Text("Input features folder");
       ImGui::PushID(2);
-      ImGui::InputTextWithHint("", application_handler_.features_in_dir_.c_str(), &(application_handler_.features_in_dir_));
+      ImGui::InputTextWithHint("", features_in_dir_.c_str(), &features_in_dir_);
       ImGui::PopID();
       ImGui::SameLine();
       ImGui::PushID(22);
@@ -65,7 +74,7 @@ namespace SmartPeak
 
       ImGui::Text("Output features folder");
       ImGui::PushID(3);
-      ImGui::InputTextWithHint("", application_handler_.features_out_dir_.c_str(), &(application_handler_.features_out_dir_));
+      ImGui::InputTextWithHint("", features_out_dir_.c_str(), &features_out_dir_);
       ImGui::PopID();
 
       ImGui::SameLine();
@@ -88,7 +97,10 @@ namespace SmartPeak
       ImGui::Separator();
       if (ImGui::Button("Run workflow"))
       {
-        for (const std::string& pathname : { application_handler_.mzML_dir_, application_handler_.features_in_dir_, application_handler_.features_out_dir_ }) {
+        application_handler_.mzML_dir_ = mzML_dir_;
+        application_handler_.features_in_dir_ = features_in_dir_;
+        application_handler_.features_out_dir_ = features_out_dir_;
+        for (const auto& pathname : { application_handler_.mzML_dir_, application_handler_.features_in_dir_, application_handler_.features_out_dir_ }) {
           fs::create_directories(fs::path(pathname));
         }
         BuildCommandsFromNames buildCommandsFromNames(application_handler_);
@@ -132,6 +144,7 @@ namespace SmartPeak
       {
         visible_ = false;
         ImGui::CloseCurrentPopup();
+        directories_set_ = false;
       }
       ImGui::EndPopup();
     }

--- a/src/smartpeak/source/ui/RunWorkflowWidget.cpp
+++ b/src/smartpeak/source/ui/RunWorkflowWidget.cpp
@@ -115,12 +115,10 @@ namespace SmartPeak
           {
             for (auto& p : cmd.dynamic_filenames)
             {
-              p.second.setRootPaths(
-                application_handler_.main_dir_,
-                application_handler_.mzML_dir_,
-                application_handler_.features_in_dir_,
-                application_handler_.features_out_dir_
-              );
+              p.second.setTag("MAIN_DIR", application_handler_.main_dir_.generic_string());
+              p.second.setTag("MZML_INPUT_PATH", application_handler_.mzML_dir_.generic_string());
+              p.second.setTag("FEATURES_INPUT_PATH", application_handler_.features_in_dir_.generic_string());
+              p.second.setTag("FEATURES_OUTPUT_PATH", application_handler_.features_out_dir_.generic_string());
             }
           }
           const std::set<std::string> injection_names = session_handler_.getSelectInjectionNamesWorkflow(application_handler_.sequenceHandler_);

--- a/src/smartpeak/source/ui/RunWorkflowWidget.cpp
+++ b/src/smartpeak/source/ui/RunWorkflowWidget.cpp
@@ -37,18 +37,19 @@ namespace SmartPeak
   {
     if (ImGui::BeginPopupModal("Run workflow modal", NULL, ImGuiWindowFlags_None))
     {
-      if (!directories_set_)
+      if (   mzML_dir_old_ != application_handler_.mzML_dir_.generic_string()
+          || features_in_dir_old_ != application_handler_.features_in_dir_.generic_string()
+          || features_out_dir_old_ != application_handler_.features_out_dir_.generic_string())
       {
         // InputTextWithHint does not support std::filesystem::path so we have to create temporary strings for the paths
-        mzML_dir_ = application_handler_.mzML_dir_.generic_string();
-        features_in_dir_ = application_handler_.features_in_dir_.generic_string();
-        features_out_dir_ = application_handler_.features_out_dir_.generic_string();
-        directories_set_ = true;
+        mzML_dir_old_ = mzML_dir_edit_ = application_handler_.mzML_dir_.generic_string();
+        features_in_dir_old_ = features_in_dir_edit_ = application_handler_.features_in_dir_.generic_string();
+        features_out_dir_old_ = features_out_dir_edit_ = application_handler_.features_out_dir_.generic_string();
       }
 
       ImGui::Text("mzML folder");
       ImGui::PushID(1);
-      ImGui::InputTextWithHint("", mzML_dir_.c_str(), &mzML_dir_);
+      ImGui::InputTextWithHint("", mzML_dir_edit_.c_str(), &mzML_dir_edit_);
       ImGui::PopID();
       ImGui::SameLine();
       ImGui::PushID(11);
@@ -61,7 +62,7 @@ namespace SmartPeak
 
       ImGui::Text("Input features folder");
       ImGui::PushID(2);
-      ImGui::InputTextWithHint("", features_in_dir_.c_str(), &features_in_dir_);
+      ImGui::InputTextWithHint("", features_in_dir_edit_.c_str(), &features_in_dir_edit_);
       ImGui::PopID();
       ImGui::SameLine();
       ImGui::PushID(22);
@@ -74,7 +75,7 @@ namespace SmartPeak
 
       ImGui::Text("Output features folder");
       ImGui::PushID(3);
-      ImGui::InputTextWithHint("", features_out_dir_.c_str(), &features_out_dir_);
+      ImGui::InputTextWithHint("", features_out_dir_edit_.c_str(), &features_out_dir_edit_);
       ImGui::PopID();
 
       ImGui::SameLine();
@@ -97,9 +98,9 @@ namespace SmartPeak
       ImGui::Separator();
       if (ImGui::Button("Run workflow"))
       {
-        application_handler_.mzML_dir_ = mzML_dir_;
-        application_handler_.features_in_dir_ = features_in_dir_;
-        application_handler_.features_out_dir_ = features_out_dir_;
+        application_handler_.mzML_dir_ = mzML_dir_edit_;
+        application_handler_.features_in_dir_ = features_in_dir_edit_;
+        application_handler_.features_out_dir_ = features_out_dir_edit_;
         for (const auto& pathname : { application_handler_.mzML_dir_, application_handler_.features_in_dir_, application_handler_.features_out_dir_ }) {
           fs::create_directories(fs::path(pathname));
         }
@@ -144,7 +145,6 @@ namespace SmartPeak
       {
         visible_ = false;
         ImGui::CloseCurrentPopup();
-        directories_set_ = false;
       }
       ImGui::EndPopup();
     }

--- a/src/tests/class_tests/smartpeak/data/RawDataProcessor_serumTest_accurateMassSearch.featureXML
+++ b/src/tests/class_tests/smartpeak/data/RawDataProcessor_serumTest_accurateMassSearch.featureXML
@@ -13,7 +13,7 @@
 			<UserParam type="float" name="peak_apex_int" value="4663.75927734375"/>
 			<UserParam type="string" name="PeptideRef" value="2546191730263012646"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="1782.034423828125"/>
 		</feature>
@@ -28,7 +28,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1327.870849609375"/>
 			<UserParam type="string" name="PeptideRef" value="7047264750004285769"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="1782.034423828125"/>
 		</feature>
@@ -43,7 +43,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1782.034423828125"/>
 			<UserParam type="string" name="PeptideRef" value="10867367902361092822"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="1782.034423828125"/>
 		</feature>
@@ -58,7 +58,7 @@
 			<UserParam type="float" name="peak_apex_int" value="6854.7197265625"/>
 			<UserParam type="string" name="PeptideRef" value="1306115447222430574"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2721.5546875"/>
 		</feature>
@@ -73,7 +73,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1645.4468994140625"/>
 			<UserParam type="string" name="PeptideRef" value="9320239912727277212"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2721.5546875"/>
 		</feature>
@@ -88,7 +88,7 @@
 			<UserParam type="float" name="peak_apex_int" value="2721.5546875"/>
 			<UserParam type="string" name="PeptideRef" value="14487362933930428766"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2721.5546875"/>
 		</feature>
@@ -103,7 +103,7 @@
 			<UserParam type="float" name="peak_apex_int" value="7906.986328125"/>
 			<UserParam type="string" name="PeptideRef" value="8221410908260069317"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3906.63232421875"/>
 		</feature>
@@ -118,7 +118,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1333.8792724609375"/>
 			<UserParam type="string" name="PeptideRef" value="14996642710636339961"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3906.63232421875"/>
 		</feature>
@@ -133,7 +133,7 @@
 			<UserParam type="float" name="peak_apex_int" value="3906.63232421875"/>
 			<UserParam type="string" name="PeptideRef" value="17201481698882531974"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3906.63232421875"/>
 		</feature>
@@ -148,7 +148,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1.10300107421875e04"/>
 			<UserParam type="string" name="PeptideRef" value="5675194232103913502"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="6435.259765625"/>
 		</feature>
@@ -163,7 +163,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1567.5623779296875"/>
 			<UserParam type="string" name="PeptideRef" value="16906569291418009471"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="6435.259765625"/>
 		</feature>
@@ -178,7 +178,7 @@
 			<UserParam type="float" name="peak_apex_int" value="6435.259765625"/>
 			<UserParam type="string" name="PeptideRef" value="12101455856628377421"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="6435.259765625"/>
 		</feature>
@@ -193,7 +193,7 @@
 			<UserParam type="float" name="peak_apex_int" value="7753.3671875"/>
 			<UserParam type="string" name="PeptideRef" value="15081642743990714724"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="5959.04052734375"/>
 		</feature>
@@ -208,7 +208,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1310.031005859375"/>
 			<UserParam type="string" name="PeptideRef" value="4575851649936790924"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="5959.04052734375"/>
 		</feature>
@@ -223,7 +223,7 @@
 			<UserParam type="float" name="peak_apex_int" value="5959.04052734375"/>
 			<UserParam type="string" name="PeptideRef" value="10446247540685851900"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="5959.04052734375"/>
 		</feature>
@@ -238,7 +238,7 @@
 			<UserParam type="float" name="peak_apex_int" value="6344.2890625"/>
 			<UserParam type="string" name="PeptideRef" value="16155385607072094228"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2442.411865234375"/>
 		</feature>
@@ -253,7 +253,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1666.787841796875"/>
 			<UserParam type="string" name="PeptideRef" value="16880800140833314916"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2442.411865234375"/>
 		</feature>
@@ -268,7 +268,7 @@
 			<UserParam type="float" name="peak_apex_int" value="2442.411865234375"/>
 			<UserParam type="string" name="PeptideRef" value="1018813942965563909"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2442.411865234375"/>
 		</feature>
@@ -283,7 +283,7 @@
 			<UserParam type="float" name="peak_apex_int" value="4264.67041015625"/>
 			<UserParam type="string" name="PeptideRef" value="12500599395234159988"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="4264.67041015625"/>
 		</feature>
@@ -298,7 +298,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1317.1180419921875"/>
 			<UserParam type="string" name="PeptideRef" value="3330608013487267485"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="4264.67041015625"/>
 		</feature>
@@ -313,7 +313,7 @@
 			<UserParam type="float" name="peak_apex_int" value="5073.10107421875"/>
 			<UserParam type="string" name="PeptideRef" value="3056693389443268874"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="4264.67041015625"/>
 		</feature>
@@ -328,7 +328,7 @@
 			<UserParam type="float" name="peak_apex_int" value="5545.5263671875"/>
 			<UserParam type="string" name="PeptideRef" value="14310891247344330710"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3188.935302734375"/>
 		</feature>
@@ -343,7 +343,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1445.0850830078125"/>
 			<UserParam type="string" name="PeptideRef" value="8996054454410342829"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3188.935302734375"/>
 		</feature>
@@ -358,7 +358,7 @@
 			<UserParam type="float" name="peak_apex_int" value="3188.935302734375"/>
 			<UserParam type="string" name="PeptideRef" value="13460763987588908337"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3188.935302734375"/>
 		</feature>
@@ -373,7 +373,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1429.2493896484375"/>
 			<UserParam type="string" name="PeptideRef" value="8242408182235129380"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="4906.3115234375"/>
 		</feature>
@@ -388,7 +388,7 @@
 			<UserParam type="float" name="peak_apex_int" value="5655.9619140625"/>
 			<UserParam type="string" name="PeptideRef" value="2052426701185366657"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="4906.3115234375"/>
 		</feature>
@@ -403,7 +403,7 @@
 			<UserParam type="float" name="peak_apex_int" value="4906.3115234375"/>
 			<UserParam type="string" name="PeptideRef" value="9125422121711470294"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="4906.3115234375"/>
 		</feature>
@@ -418,7 +418,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1491.02490234375"/>
 			<UserParam type="string" name="PeptideRef" value="8709629731051711180"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2756.538818359375"/>
 		</feature>
@@ -433,7 +433,7 @@
 			<UserParam type="float" name="peak_apex_int" value="2756.538818359375"/>
 			<UserParam type="string" name="PeptideRef" value="7512290900303837137"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2756.538818359375"/>
 		</feature>
@@ -448,7 +448,7 @@
 			<UserParam type="float" name="peak_apex_int" value="5536.1982421875"/>
 			<UserParam type="string" name="PeptideRef" value="13480910844670884323"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2756.538818359375"/>
 		</feature>
@@ -463,7 +463,7 @@
 			<UserParam type="float" name="peak_apex_int" value="2497.237548828125"/>
 			<UserParam type="string" name="PeptideRef" value="15864558342317159050"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2497.237548828125"/>
 		</feature>
@@ -478,7 +478,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1354.1805419921875"/>
 			<UserParam type="string" name="PeptideRef" value="8953360608285606494"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2497.237548828125"/>
 		</feature>
@@ -493,7 +493,7 @@
 			<UserParam type="float" name="peak_apex_int" value="3380.662353515625"/>
 			<UserParam type="string" name="PeptideRef" value="1823302716626955168"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2497.237548828125"/>
 		</feature>
@@ -508,7 +508,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1328.9027099609375"/>
 			<UserParam type="string" name="PeptideRef" value="5028180764727827305"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3195.01025390625"/>
 		</feature>
@@ -523,7 +523,7 @@
 			<UserParam type="float" name="peak_apex_int" value="3195.01025390625"/>
 			<UserParam type="string" name="PeptideRef" value="6631791906778070880"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3195.01025390625"/>
 		</feature>
@@ -538,7 +538,7 @@
 			<UserParam type="float" name="peak_apex_int" value="4818.3349609375"/>
 			<UserParam type="string" name="PeptideRef" value="6775771386349348690"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3195.01025390625"/>
 		</feature>
@@ -553,7 +553,7 @@
 			<UserParam type="float" name="peak_apex_int" value="3278.521484375"/>
 			<UserParam type="string" name="PeptideRef" value="11088210786042692385"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3278.521484375"/>
 		</feature>
@@ -568,7 +568,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1246.566162109375"/>
 			<UserParam type="string" name="PeptideRef" value="14612203223538988797"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3278.521484375"/>
 		</feature>
@@ -583,7 +583,7 @@
 			<UserParam type="float" name="peak_apex_int" value="5923.14306640625"/>
 			<UserParam type="string" name="PeptideRef" value="14819399630550767546"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3278.521484375"/>
 		</feature>
@@ -598,7 +598,7 @@
 			<UserParam type="float" name="peak_apex_int" value="2690.849365234375"/>
 			<UserParam type="string" name="PeptideRef" value="4783301327221314814"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2690.849365234375"/>
 		</feature>
@@ -613,7 +613,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1337.9310302734375"/>
 			<UserParam type="string" name="PeptideRef" value="11169187761895238618"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2690.849365234375"/>
 		</feature>
@@ -628,7 +628,7 @@
 			<UserParam type="float" name="peak_apex_int" value="5656.189453125"/>
 			<UserParam type="string" name="PeptideRef" value="200779923071488287"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2690.849365234375"/>
 		</feature>
@@ -643,7 +643,7 @@
 			<UserParam type="float" name="peak_apex_int" value="3195.5166015625"/>
 			<UserParam type="string" name="PeptideRef" value="17903178729808463854"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3195.5166015625"/>
 		</feature>
@@ -658,7 +658,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1514.6697998046875"/>
 			<UserParam type="string" name="PeptideRef" value="14181154191576915295"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3195.5166015625"/>
 		</feature>
@@ -673,7 +673,7 @@
 			<UserParam type="float" name="peak_apex_int" value="3469.517333984375"/>
 			<UserParam type="string" name="PeptideRef" value="16101348360644825164"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="3195.5166015625"/>
 		</feature>
@@ -688,7 +688,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1345.7808837890625"/>
 			<UserParam type="string" name="PeptideRef" value="12171055424826401897"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="1833.6702880859375"/>
 		</feature>
@@ -703,7 +703,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1833.6702880859375"/>
 			<UserParam type="string" name="PeptideRef" value="5436799788136855293"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="1833.6702880859375"/>
 		</feature>
@@ -718,7 +718,7 @@
 			<UserParam type="float" name="peak_apex_int" value="5430.1630859375"/>
 			<UserParam type="string" name="PeptideRef" value="9104792656761772928"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="1833.6702880859375"/>
 		</feature>
@@ -733,7 +733,7 @@
 			<UserParam type="float" name="peak_apex_int" value="1386.3045654296875"/>
 			<UserParam type="string" name="PeptideRef" value="6927368807828094945"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2166.0048828125"/>
 		</feature>
@@ -748,7 +748,7 @@
 			<UserParam type="float" name="peak_apex_int" value="2166.0048828125"/>
 			<UserParam type="string" name="PeptideRef" value="15956005094333477810"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2166.0048828125"/>
 		</feature>
@@ -763,11 +763,11 @@
 			<UserParam type="float" name="peak_apex_int" value="4385.34716796875"/>
 			<UserParam type="string" name="PeptideRef" value="428702440691772349"/>
 			<UserParam type="string" name="used_" value="false"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 			<UserParam type="string" name="scan_polarity" value="positive"/>
 			<UserParam type="float" name="signal_to_noise" value="2166.0048828125"/>
 		</feature>
-		<feature id="f_5696850174438009858">
+		<feature id="f_6574919789979128803">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -776,7 +776,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_5696850174438009858_1224478606434246046">
+				<feature id="f_6574919789979128803_1143733367967374982">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999506212642459</position>
 					<intensity>1782.034424</intensity>
@@ -788,7 +788,7 @@
 					<UserParam type="float" name="peak_apex_int" value="1782.034423828125"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="1782.034423828125"/>
@@ -803,9 +803,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_11116741782953250751">
+		<feature id="f_13285560108744551357">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -814,7 +814,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_11116741782953250751_15884355380718120654">
+				<feature id="f_13285560108744551357_10289761688931342282">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999506212642459</position>
 					<intensity>1782.034424</intensity>
@@ -826,7 +826,7 @@
 					<UserParam type="float" name="peak_apex_int" value="1782.034423828125"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0033556"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2,5-Dimethyl-1,4-dithiane-2,5-diol,Ethyl 2-(methyldithio)propionate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="1782.034423828125"/>
@@ -841,9 +841,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0033556"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_7087553237473734436">
+		<feature id="f_10632183372529892261">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -852,7 +852,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_7087553237473734436_14040601855019736551">
+				<feature id="f_10632183372529892261_14053127563558964505">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999675824920274</position>
 					<intensity>2721.554688</intensity>
@@ -864,7 +864,7 @@
 					<UserParam type="float" name="peak_apex_int" value="2721.5546875"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="2721.5546875"/>
@@ -879,9 +879,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_11648831278038790466">
+		<feature id="f_9644685233299641248">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -890,7 +890,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_11648831278038790466_1367869864606132322">
+				<feature id="f_9644685233299641248_15948675216143985222">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999720447045235</position>
 					<intensity>3906.632324</intensity>
@@ -902,7 +902,7 @@
 					<UserParam type="float" name="peak_apex_int" value="3906.63232421875"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="3906.63232421875"/>
@@ -917,9 +917,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_15330272756281258575">
+		<feature id="f_10846881707602086688">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -928,7 +928,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_15330272756281258575_3335995413404219753">
+				<feature id="f_10846881707602086688_13046388352244864787">
 					<position dim="0">0.0</position>
 					<position dim="1">109.985819421479434</position>
 					<intensity>1567.562378</intensity>
@@ -940,7 +940,7 @@
 					<UserParam type="float" name="peak_apex_int" value="1567.5623779296875"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0032739"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[S-Methyl methanesulfinothioate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="6435.259765625"/>
@@ -955,9 +955,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0032739"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_7495556939029467335">
+		<feature id="f_13476297502193838445">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -966,7 +966,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_7495556939029467335_4413659604556046318">
+				<feature id="f_13476297502193838445_3558374648145285062">
 					<position dim="0">0.0</position>
 					<position dim="1">109.985819421479434</position>
 					<intensity>1567.562378</intensity>
@@ -978,7 +978,7 @@
 					<UserParam type="float" name="peak_apex_int" value="1567.5623779296875"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0000598"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[Sulfide]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="6435.259765625"/>
@@ -993,9 +993,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0000598"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_629205618873695649">
+		<feature id="f_15636573561521305307">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1004,7 +1004,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_629205618873695649_17779710765946078910">
+				<feature id="f_15636573561521305307_11513713594612637814">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999659882006583</position>
 					<intensity>6435.259766</intensity>
@@ -1016,7 +1016,7 @@
 					<UserParam type="float" name="peak_apex_int" value="6435.259765625"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="6435.259765625"/>
@@ -1031,9 +1031,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_6628495340508555783">
+		<feature id="f_14925988591243931659">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1042,7 +1042,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_6628495340508555783_10218098921177285742">
+				<feature id="f_14925988591243931659_1230759799273968688">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999660280018588</position>
 					<intensity>5959.040527</intensity>
@@ -1054,7 +1054,7 @@
 					<UserParam type="float" name="peak_apex_int" value="5959.04052734375"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="5959.04052734375"/>
@@ -1069,9 +1069,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_10023419269916015991">
+		<feature id="f_1212392808700420389">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1080,7 +1080,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_10023419269916015991_6188184235207464320">
+				<feature id="f_1212392808700420389_591236830797119611">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999675664455381</position>
 					<intensity>2442.411865</intensity>
@@ -1092,7 +1092,7 @@
 					<UserParam type="float" name="peak_apex_int" value="2442.411865234375"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="2442.411865234375"/>
@@ -1107,9 +1107,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_187539238039105830">
+		<feature id="f_15014080580914970284">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1118,7 +1118,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_187539238039105830_6334471029274127852">
+				<feature id="f_15014080580914970284_5329908914971022506">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999679858201148</position>
 					<intensity>5073.101074</intensity>
@@ -1130,7 +1130,7 @@
 					<UserParam type="float" name="peak_apex_int" value="5073.10107421875"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="4264.67041015625"/>
@@ -1145,9 +1145,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_1115744762225357584">
+		<feature id="f_4029445246459115374">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1156,7 +1156,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_1115744762225357584_13525555283732579263">
+				<feature id="f_4029445246459115374_6675730005764724344">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999665611968851</position>
 					<intensity>3188.935303</intensity>
@@ -1168,7 +1168,7 @@
 					<UserParam type="float" name="peak_apex_int" value="3188.935302734375"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="3188.935302734375"/>
@@ -1183,9 +1183,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_6837704891003443313">
+		<feature id="f_8442706108587169992">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1194,7 +1194,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_6837704891003443313_7514359881634365319">
+				<feature id="f_8442706108587169992_7521600997090984254">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999677504100532</position>
 					<intensity>4906.311523</intensity>
@@ -1206,7 +1206,7 @@
 					<UserParam type="float" name="peak_apex_int" value="4906.3115234375"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="4906.3115234375"/>
@@ -1221,9 +1221,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_4194914963955999359">
+		<feature id="f_14654503397875321328">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1232,7 +1232,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_4194914963955999359_14025110526450525501">
+				<feature id="f_14654503397875321328_9519436811811051429">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999659612432197</position>
 					<intensity>5536.198242</intensity>
@@ -1244,7 +1244,7 @@
 					<UserParam type="float" name="peak_apex_int" value="5536.1982421875"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="2756.538818359375"/>
@@ -1259,9 +1259,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_314989246244931529">
+		<feature id="f_17588371399254241507">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1270,7 +1270,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_314989246244931529_3619312999614903071">
+				<feature id="f_17588371399254241507_7541920048427084779">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999712565789196</position>
 					<intensity>3380.662354</intensity>
@@ -1282,7 +1282,7 @@
 					<UserParam type="float" name="peak_apex_int" value="3380.662353515625"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="2497.237548828125"/>
@@ -1297,9 +1297,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_6674511172675167457">
+		<feature id="f_10814220487626090611">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1308,7 +1308,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_6674511172675167457_2783845716513306770">
+				<feature id="f_10814220487626090611_15916296961285418691">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999700244428624</position>
 					<intensity>4818.334961</intensity>
@@ -1320,7 +1320,7 @@
 					<UserParam type="float" name="peak_apex_int" value="4818.3349609375"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="3195.01025390625"/>
@@ -1335,9 +1335,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_6794299836583864478">
+		<feature id="f_5829408189658457072">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1346,7 +1346,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_6794299836583864478_7639073489540540482">
+				<feature id="f_5829408189658457072_9853329119224086838">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999668129505366</position>
 					<intensity>5923.143066</intensity>
@@ -1358,7 +1358,7 @@
 					<UserParam type="float" name="peak_apex_int" value="5923.14306640625"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="3278.521484375"/>
@@ -1373,9 +1373,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_17834711799306188653">
+		<feature id="f_239542729288015466">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1384,7 +1384,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_17834711799306188653_6282992522103909755">
+				<feature id="f_239542729288015466_10793404471982079332">
 					<position dim="0">0.0</position>
 					<position dim="1">109.99967468369114</position>
 					<intensity>5656.189453</intensity>
@@ -1396,7 +1396,7 @@
 					<UserParam type="float" name="peak_apex_int" value="5656.189453125"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="2690.849365234375"/>
@@ -1411,9 +1411,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_1981275948176454081">
+		<feature id="f_17780600295902891203">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1422,7 +1422,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_1981275948176454081_7313359709672440934">
+				<feature id="f_17780600295902891203_9650828517805820989">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999704039295011</position>
 					<intensity>3469.517334</intensity>
@@ -1434,7 +1434,7 @@
 					<UserParam type="float" name="peak_apex_int" value="3469.517333984375"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="3195.5166015625"/>
@@ -1449,9 +1449,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_28156935396359555">
+		<feature id="f_11872038688914494504">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1460,7 +1460,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_28156935396359555_12210427218725640556">
+				<feature id="f_11872038688914494504_8566153194206956084">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999695744915897</position>
 					<intensity>5430.163086</intensity>
@@ -1472,7 +1472,7 @@
 					<UserParam type="float" name="peak_apex_int" value="5430.1630859375"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="1833.6702880859375"/>
@@ -1487,9 +1487,9 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
-		<feature id="f_17878244210647381311">
+		<feature id="f_15730579281657642886">
 			<position dim="0">0.0</position>
 			<position dim="1">0.0</position>
 			<intensity>0.0</intensity>
@@ -1498,7 +1498,7 @@
 			<overallquality>0.0</overallquality>
 			<charge>0</charge>
 			<subordinate>
-				<feature id="f_17878244210647381311_2513239043131857590">
+				<feature id="f_15730579281657642886_2985788164660973921">
 					<position dim="0">0.0</position>
 					<position dim="1">109.999716214016758</position>
 					<intensity>4385.347168</intensity>
@@ -1510,7 +1510,7 @@
 					<UserParam type="float" name="peak_apex_int" value="4385.34716796875"/>
 					<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 					<UserParam type="string" name="used_" value="true"/>
-					<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+					<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 					<UserParam type="stringList" name="description" value="[2-Methoxyacetaminophen sulfate]"/>
 					<UserParam type="string" name="scan_polarity" value="positive"/>
 					<UserParam type="float" name="signal_to_noise" value="2166.0048828125"/>
@@ -1525,7 +1525,7 @@
 			</subordinate>
 			<UserParam type="string" name="PeptideRef" value="HMDB:HMDB0062550"/>
 			<UserParam type="string" name="used_" value="true"/>
-			<UserParam type="string" name="timestamp_" value="2021-07-01-14-52-30"/>
+			<UserParam type="string" name="timestamp_" value="2021-08-04-15-42-21"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/class_tests/smartpeak/source/ApplicationHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/ApplicationHandler_test.cpp
@@ -45,25 +45,25 @@ public:
 TEST_F(ApplicationHandlerFixture, SetRawDataPathname_ProcessSetsPath)
 {
   SetRawDataPathname cmd;
-  EXPECT_STREQ(ah_.mzML_dir_.c_str(), "");
+  EXPECT_STREQ(ah_.mzML_dir_.generic_string().c_str(), "");
   EXPECT_TRUE(cmd.onFilePicked("test", &ah_));
-  EXPECT_STREQ(ah_.mzML_dir_.c_str(), "test");
+  EXPECT_STREQ(ah_.mzML_dir_.generic_string().c_str(), "test");
 }
 
 /* SetInputFeaturesPathname */
 TEST_F(ApplicationHandlerFixture, SetInputFeaturesPathname_ProcessSetsPath)
 {
   SetInputFeaturesPathname cmd;
-  EXPECT_STREQ(ah_.features_in_dir_.c_str(), "");
+  EXPECT_STREQ(ah_.features_in_dir_.generic_string().c_str(), "");
   EXPECT_TRUE(cmd.onFilePicked("test", &ah_));
-  EXPECT_STREQ(ah_.features_in_dir_.c_str(), "test");
+  EXPECT_STREQ(ah_.features_in_dir_.generic_string().c_str(), "test");
 }
 
 /* SetOutputFeaturesPathname */
 TEST_F(ApplicationHandlerFixture, SetOutputFeaturesPathname_ProcessSetsPath)
 {
   SetOutputFeaturesPathname cmd;
-  EXPECT_STREQ(ah_.features_out_dir_.c_str(), "");
+  EXPECT_STREQ(ah_.features_out_dir_.generic_string().c_str(), "");
   EXPECT_TRUE(cmd.onFilePicked("test", &ah_));
-  EXPECT_STREQ(ah_.features_out_dir_.c_str(), "test");
+  EXPECT_STREQ(ah_.features_out_dir_.generic_string().c_str(), "test");
 }

--- a/src/tests/class_tests/smartpeak/source/ApplicationProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/ApplicationProcessor_test.cpp
@@ -40,7 +40,7 @@ struct ApplicationProcessorFixture : public ::testing::Test
     datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
     auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
 
-    filenames_.setFullPathName("referenceData_csv_i", (std::filesystem::path{datapath_} / std::filesystem::path{"MRMFeatureValidator_referenceData_1.csv"}).string());
+    filenames_.setFullPath("referenceData_csv_i", (std::filesystem::path{datapath_} / std::filesystem::path{"MRMFeatureValidator_referenceData_1.csv"}).string());
 
     // Injections sequence:
     std::vector<InjectionHandler> seq;

--- a/src/tests/class_tests/smartpeak/source/ApplicationProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/ApplicationProcessor_test.cpp
@@ -40,8 +40,8 @@ struct ApplicationProcessorFixture : public ::testing::Test
     datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
     auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
 
-    filenames_ = Filenames::getDefaultStaticFilenames(workflow.string());
-    filenames_.referenceData_csv_i = (std::filesystem::path{ datapath_ } / std::filesystem::path{ "MRMFeatureValidator_referenceData_1.csv" }).string();
+//    filenames_.updatePaths(workflow.string(),"","","");
+    filenames_.setFullPathName("referenceData_csv_i", (std::filesystem::path{datapath_} / std::filesystem::path{"MRMFeatureValidator_referenceData_1.csv"}).string());
 
     // Injections sequence:
     std::vector<InjectionHandler> seq;

--- a/src/tests/class_tests/smartpeak/source/ApplicationProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/ApplicationProcessor_test.cpp
@@ -40,7 +40,6 @@ struct ApplicationProcessorFixture : public ::testing::Test
     datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
     auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
 
-//    filenames_.updatePaths(workflow.string(),"","","");
     filenames_.setFullPathName("referenceData_csv_i", (std::filesystem::path{datapath_} / std::filesystem::path{"MRMFeatureValidator_referenceData_1.csv"}).string());
 
     // Injections sequence:

--- a/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
@@ -17,8 +17,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey, Ahmed Khalil $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Bertrand Boudaud $
+// $Authors: Bertrand Boudaud $
 // --------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
@@ -27,240 +27,113 @@
 
 using namespace SmartPeak;
 using namespace std;
-/*
-TEST(Filenames, filenames_getDefaultStaticFilenames)
+
+TEST(Filenames, constructor)
 {
-  Filenames filenames = Filenames::getDefaultStaticFilenames("/home/user");
-  EXPECT_STREQ(filenames.sequence_csv_i.c_str(), "/home/user/sequence.csv");
-  EXPECT_STREQ(filenames.parameters_csv_i.c_str(), "/home/user/parameters.csv");
-  EXPECT_STREQ(filenames.traML_csv_i.c_str(), "/home/user/traML.csv");
-  EXPECT_STREQ(filenames.featureFilterComponents_csv_i.c_str(), "/home/user/featureFilterComponents.csv");
-  EXPECT_STREQ(filenames.featureFilterComponentGroups_csv_i.c_str(), "/home/user/featureFilterComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureQCComponents_csv_i.c_str(), "/home/user/featureQCComponents.csv");
-  EXPECT_STREQ(filenames.featureQCComponentGroups_csv_i.c_str(), "/home/user/featureQCComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureRSDFilterComponents_csv_i.c_str(), "/home/user/featureRSDFilterComponents.csv");
-  EXPECT_STREQ(filenames.featureRSDFilterComponentGroups_csv_i.c_str(), "/home/user/featureRSDFilterComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureRSDQCComponents_csv_i.c_str(), "/home/user/featureRSDQCComponents.csv");
-  EXPECT_STREQ(filenames.featureRSDQCComponentGroups_csv_i.c_str(), "/home/user/featureRSDQCComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponents_csv_i.c_str(), "/home/user/featureBackgroundFilterComponents.csv");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponentGroups_csv_i.c_str(), "/home/user/featureBackgroundFilterComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponents_csv_i.c_str(), "/home/user/featureBackgroundQCComponents.csv");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponentGroups_csv_i.c_str(), "/home/user/featureBackgroundQCComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponents_csv_i.c_str(), "/home/user/featureRSDEstimationComponents.csv");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponentGroups_csv_i.c_str(), "/home/user/featureRSDEstimationComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureRSDQCComponents_csv_i.c_str(), "/home/user/featureRSDQCComponents.csv");
-  EXPECT_STREQ(filenames.featureRSDQCComponentGroups_csv_i.c_str(), "/home/user/featureRSDQCComponentGroups.csv");
-  EXPECT_STREQ(filenames.quantitationMethods_csv_i.c_str(), "/home/user/quantitationMethods.csv");
-  EXPECT_STREQ(filenames.standardsConcentrations_csv_i.c_str(), "/home/user/standardsConcentrations.csv");
-  EXPECT_STREQ(filenames.referenceData_csv_i.c_str(), "/home/user/referenceData.csv");
-  EXPECT_STREQ(filenames.mzML_i.c_str(), "");
-  EXPECT_STREQ(filenames.mzTab_o.c_str(), "");
-  EXPECT_STREQ(filenames.mzTab_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureXML_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureXMLSampleGroup_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureXML_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureXMLSampleGroup_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDFilterComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDFilterComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.quantitationMethods_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.componentsToConcentrations_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.pivotTable_csv_o.c_str(), "/home/user/PivotTable.csv");
-  EXPECT_STREQ(filenames.featureDB_csv_o.c_str(), "/home/user/FeatureDB.csv");
+  Filenames filenames;
+  EXPECT_EQ(filenames.getFileNames().size(), 0);
 }
 
-TEST(Filenames, filenames_getDefaultDynamicFilenames)
+TEST(Filenames, addFileName)
 {
-  Filenames filenames = Filenames::getDefaultDynamicFilenames(
-    "/home/user",
-    "/home/user/mzML",
-    "/home/user/featuresIn", 
-    "/home/user/featuresOut", 
-    "mzMLIn",
-    "injIn",
-    "injOut",
-    "sampleIn",
-    "sampleOut");
-  EXPECT_STREQ(filenames.sequence_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.parameters_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.workflow_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.traML_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDFilterComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDFilterComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.quantitationMethods_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.standardsConcentrations_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.referenceData_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.mzML_i.c_str(), "/home/user/mzML/mzMLIn.mzML");
-  EXPECT_STREQ(filenames.mzTab_o.c_str(), "/home/user/featuresOut/injOut.mzTab");
-  EXPECT_STREQ(filenames.mzTab_i.c_str(), "/home/user/featuresIn/injIn.mzTab");
-  EXPECT_STREQ(filenames.featureXML_o.c_str(), "/home/user/featuresOut/injOut.featureXML");
-  EXPECT_STREQ(filenames.featureXMLSampleGroup_o.c_str(), "/home/user/featuresOut/sampleOut.featureXML");
-  EXPECT_STREQ(filenames.featureXML_i.c_str(), "/home/user/featuresIn/injIn.featureXML");
-  EXPECT_STREQ(filenames.featureXMLSampleGroup_i.c_str(), "/home/user/featuresIn/sampleIn.featureXML");
-  EXPECT_STREQ(filenames.featureFilterComponents_csv_o.c_str(), "/home/user/featuresOut/injOut_featureFilterComponents.csv");
-  EXPECT_STREQ(filenames.featureFilterComponentGroups_csv_o.c_str(), "/home/user/featuresOut/injOut_featureFilterComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureQCComponents_csv_o.c_str(), "/home/user/featuresOut/injOut_featureQCComponents.csv");
-  EXPECT_STREQ(filenames.featureQCComponentGroups_csv_o.c_str(), "/home/user/featuresOut/injOut_featureQCComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureRSDFilterComponents_csv_o.c_str(), "/home/user/featuresOut/injOut_featureRSDFilterComponents.csv");
-  EXPECT_STREQ(filenames.featureRSDFilterComponentGroups_csv_o.c_str(), "/home/user/featuresOut/injOut_featureRSDFilterComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureRSDQCComponents_csv_o.c_str(), "/home/user/featuresOut/injOut_featureRSDQCComponents.csv");
-  EXPECT_STREQ(filenames.featureRSDQCComponentGroups_csv_o.c_str(), "/home/user/featuresOut/injOut_featureRSDQCComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponents_csv_o.c_str(), "/home/user/featuresOut/injOut_featureBackgroundFilterComponents.csv");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponentGroups_csv_o.c_str(), "/home/user/featuresOut/injOut_featureBackgroundFilterComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponents_csv_o.c_str(), "/home/user/featuresOut/injOut_featureBackgroundQCComponents.csv");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponentGroups_csv_o.c_str(), "/home/user/featuresOut/injOut_featureBackgroundQCComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponents_csv_o.c_str(), "/home/user/featuresOut/injOut_featureRSDEstimationComponents.csv");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponentGroups_csv_o.c_str(), "/home/user/featuresOut/injOut_featureRSDEstimationComponentGroups.csv");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponents_csv_o.c_str(), "/home/user/featuresOut/injOut_featureBackgroundEstimationComponents.csv");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponentGroups_csv_o.c_str(), "/home/user/featuresOut/injOut_featureBackgroundEstimationComponentGroups.csv");
-  EXPECT_STREQ(filenames.quantitationMethods_csv_o.c_str(), "/home/user/featuresOut/injOut_quantitationMethods.csv");
-  EXPECT_STREQ(filenames.componentsToConcentrations_csv_o.c_str(), "/home/user/featuresOut/injOut_componentsToConcentrations.csv");
-  EXPECT_STREQ(filenames.pivotTable_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureDB_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.selectDilutions_csv_i.c_str(), "/home/user/selectDilutions.csv");
+  Filenames filenames;
+  filenames.addFileName("my_file", "file.txt", Filenames::FileScope::EFileScopeMain);
+  const auto& filenames_list = filenames.getFileNames();
+  ASSERT_EQ(filenames_list.size(), 1);
+  const auto& filename = filenames_list.at("my_file");
+  EXPECT_STREQ(filename.default_name_.c_str(), "file.txt");
+  EXPECT_EQ(filename.file_scope_, Filenames::FileScope::EFileScopeMain);
+  EXPECT_STREQ(filename.file_variant_.c_str(), "");
+  EXPECT_STREQ(filename.root_path_.generic_string().c_str(), "");
+  EXPECT_STREQ(filename.full_path_.generic_string().c_str(), "file.txt");
+  EXPECT_FALSE(filename.full_path_override_);
 }
 
-TEST(Filenames, clear1)
+TEST(Filenames, getFullPath)
 {
-  Filenames filenames = Filenames::getDefaultStaticFilenames("/home/user");
-  filenames.clear();
-  EXPECT_STREQ(filenames.sequence_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.parameters_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.traML_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDFilterComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDFilterComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.quantitationMethods_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.standardsConcentrations_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.referenceData_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.selectDilutions_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.mzML_i.c_str(), "");
-  EXPECT_STREQ(filenames.mzTab_o.c_str(), "");
-  EXPECT_STREQ(filenames.mzTab_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureXML_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureXMLSampleGroup_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureXML_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureXMLSampleGroup_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDFilterComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDFilterComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.quantitationMethods_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.componentsToConcentrations_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.pivotTable_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureDB_csv_o.c_str(), "");
+  Filenames filenames;
+  filenames.addFileName("my_file_main", "file_main.txt", Filenames::FileScope::EFileScopeMain);
+  EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "file_main.txt");
 }
 
-TEST(Filenames, clear2)
+TEST(Filenames, getFullPath_non_existing)
 {
-  Filenames filenames = Filenames::getDefaultDynamicFilenames(
-    "/home/user",
-    "/home/user/mzML",
-    "/home/user/featuresIn",
-    "/home/user/featuresOut",
-    "mzMLIn",
-    "injIn",
-    "injOut",
-    "sampleIn",
-    "sampleOut");
-  filenames.clear();
-  EXPECT_STREQ(filenames.sequence_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.parameters_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.traML_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponents_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponentGroups_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.quantitationMethods_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.standardsConcentrations_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.referenceData_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.selectDilutions_csv_i.c_str(), "");
-  EXPECT_STREQ(filenames.mzML_i.c_str(), "");
-  EXPECT_STREQ(filenames.mzTab_o.c_str(), "");
-  EXPECT_STREQ(filenames.mzTab_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureXML_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureXMLSampleGroup_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureXML_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureXMLSampleGroup_i.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureFilterComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureQCComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDQCComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundFilterComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundQCComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureRSDEstimationComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponents_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureBackgroundEstimationComponentGroups_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.quantitationMethods_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.componentsToConcentrations_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.pivotTable_csv_o.c_str(), "");
-  EXPECT_STREQ(filenames.featureDB_csv_o.c_str(), "");
+  Filenames filenames;
+  try {
+    filenames.getFullPath("test");
+    FAIL() << "Expected std::out_of_range";
+  }
+  catch (std::out_of_range const& err) {
+  }
+  catch (...) {
+    FAIL() << "Expected std::out_of_range";
+  }
 }
-*/
+
+TEST(Filenames, setFullPath)
+{
+  Filenames filenames;
+  filenames.addFileName("my_file_main", "file_main.txt", Filenames::FileScope::EFileScopeMain);
+  filenames.setFullPath("my_file_main", "/file/to/file_main.txt");
+  EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/file/to/file_main.txt");
+  // setting variant or root has no effect
+  filenames.setRootPaths("/main", "/mzml", "/feat_input", "/feat_output");
+  filenames.setFileVariants( "variant_mzml_", "variant_input_injection_", "variant_output_injection_", "variant_input_sample_", "variant_output_sample_");
+  EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/file/to/file_main.txt");
+}
+
+TEST(Filenames, setRootPath_setVariant_after)
+{
+  Filenames filenames;
+  filenames.addFileName("my_file_main", "file_main.txt", Filenames::FileScope::EFileScopeMain);
+  filenames.addFileName("my_file_injection_input", "file_injection_input.txt", Filenames::FileScope::EFileScopeInjectionInput);
+  filenames.addFileName("my_file_injection_output", "file_injection_output.txt", Filenames::FileScope::EFileScopeInjectionOutput);
+  filenames.addFileName("my_file_group_input", "file_group_input.txt", Filenames::FileScope::EFileScopeSampleGroupInput);
+  filenames.addFileName("my_file_group_output", "file_group_output.txt", Filenames::FileScope::EFileScopeSampleGroupOutput);
+  filenames.setRootPaths("/main", "/mzml", "/feat_input", "/feat_output");
+  filenames.setFileVariants("variant_mzml_", "variant_input_injection_", "variant_output_injection_", "variant_input_sample_", "variant_output_sample_");
+  EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/main/file_main.txt");
+  EXPECT_STREQ(filenames.getFullPath("my_file_injection_input").generic_string().c_str(), "/feat_input/variant_input_injection_file_injection_input.txt");
+  EXPECT_STREQ(filenames.getFullPath("my_file_injection_output").generic_string().c_str(), "/feat_output/variant_output_injection_file_injection_output.txt");
+  EXPECT_STREQ(filenames.getFullPath("my_file_group_input").generic_string().c_str(), "/feat_input/variant_input_sample_file_group_input.txt");
+  EXPECT_STREQ(filenames.getFullPath("my_file_group_output").generic_string().c_str(), "/feat_output/variant_output_sample_file_group_output.txt");
+}
+
+TEST(Filenames, setRootPath_setVariant_before)
+{
+  Filenames filenames;
+  filenames.setRootPaths("/main", "/mzml", "/feat_input", "/feat_output");
+  filenames.setFileVariants("variant_mzml_", "variant_input_injection_", "variant_output_injection_", "variant_input_sample_", "variant_output_sample_");
+  filenames.addFileName("my_file_main", "file_main.txt", Filenames::FileScope::EFileScopeMain);
+  filenames.addFileName("my_file_injection_input", "file_injection_input.txt", Filenames::FileScope::EFileScopeInjectionInput);
+  filenames.addFileName("my_file_injection_output", "file_injection_output.txt", Filenames::FileScope::EFileScopeInjectionOutput);
+  filenames.addFileName("my_file_group_input", "file_group_input.txt", Filenames::FileScope::EFileScopeSampleGroupInput);
+  filenames.addFileName("my_file_group_output", "file_group_output.txt", Filenames::FileScope::EFileScopeSampleGroupOutput);
+  EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/main/file_main.txt");
+  EXPECT_STREQ(filenames.getFullPath("my_file_injection_input").generic_string().c_str(), "/feat_input/variant_input_injection_file_injection_input.txt");
+  EXPECT_STREQ(filenames.getFullPath("my_file_injection_output").generic_string().c_str(), "/feat_output/variant_output_injection_file_injection_output.txt");
+  EXPECT_STREQ(filenames.getFullPath("my_file_group_input").generic_string().c_str(), "/feat_input/variant_input_sample_file_group_input.txt");
+  EXPECT_STREQ(filenames.getFullPath("my_file_group_output").generic_string().c_str(), "/feat_output/variant_output_sample_file_group_output.txt");
+}
+
+TEST(Filenames, merge)
+{
+  Filenames filenames1;
+  filenames1.setRootPaths("/main", "/mzml", "/feat_input", "/feat_output");
+  filenames1.setFileVariants("variant_mzml_", "variant_input_injection_", "variant_output_injection_", "variant_input_sample_", "variant_output_sample_");
+  filenames1.addFileName("my_file_main", "file_main.txt", Filenames::FileScope::EFileScopeMain);
+  filenames1.addFileName("my_file_injection_input", "file_injection_input.txt", Filenames::FileScope::EFileScopeInjectionInput);
+
+  Filenames filenames2;
+  filenames1.addFileName("my_file_main", "file_main_again.txt", Filenames::FileScope::EFileScopeMain);
+  filenames2.addFileName("my_file_injection_output", "file_injection_output.txt", Filenames::FileScope::EFileScopeInjectionOutput);
+  filenames2.addFileName("my_file_group_input", "file_group_input.txt", Filenames::FileScope::EFileScopeSampleGroupInput);
+  filenames2.addFileName("my_file_group_output", "file_group_output.txt", Filenames::FileScope::EFileScopeSampleGroupOutput);
+
+  filenames1.merge(filenames2);
+  EXPECT_STREQ(filenames1.getFullPath("my_file_main").generic_string().c_str(), "/main/file_main.txt");
+  EXPECT_STREQ(filenames1.getFullPath("my_file_injection_input").generic_string().c_str(), "/feat_input/variant_input_injection_file_injection_input.txt");
+  EXPECT_STREQ(filenames1.getFullPath("my_file_injection_output").generic_string().c_str(), "/feat_output/variant_output_injection_file_injection_output.txt");
+  EXPECT_STREQ(filenames1.getFullPath("my_file_group_input").generic_string().c_str(), "/feat_input/variant_input_sample_file_group_input.txt");
+  EXPECT_STREQ(filenames1.getFullPath("my_file_group_output").generic_string().c_str(), "/feat_output/variant_output_sample_file_group_output.txt");
+}

--- a/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
@@ -31,22 +31,15 @@ using namespace std;
 TEST(Filenames, constructor)
 {
   Filenames filenames;
-  EXPECT_EQ(filenames.getFileNames().size(), 0);
+  EXPECT_EQ(filenames.getFileIds().size(), 0);
 }
 
 TEST(Filenames, addFileName)
 {
   Filenames filenames;
   filenames.addFileName("my_file", "file.txt", Filenames::FileScope::EFileScopeMain);
-  const auto& filenames_list = filenames.getFileNames();
-  ASSERT_EQ(filenames_list.size(), 1);
-  const auto& filename = filenames_list.at("my_file");
-  EXPECT_STREQ(filename.default_name_.c_str(), "file.txt");
-  EXPECT_EQ(filename.file_scope_, Filenames::FileScope::EFileScopeMain);
-  EXPECT_STREQ(filename.file_variant_.c_str(), "");
-  EXPECT_STREQ(filename.root_path_.generic_string().c_str(), "");
-  EXPECT_STREQ(filename.full_path_.generic_string().c_str(), "file.txt");
-  EXPECT_FALSE(filename.full_path_override_);
+  const auto& file_ids = filenames.getFileIds();
+  ASSERT_EQ(file_ids.size(), 1);
 }
 
 TEST(Filenames, getFullPath)

--- a/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
@@ -70,15 +70,15 @@ TEST(Filenames, setFullPath)
   filenames.setFullPath("my_file_main", "/file/to/file_main.txt");
   EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/file/to/file_main.txt");
   // setting variant or root has no effect
-  filenames.setTag("MAIN_DIR", "/main");
-  filenames.setTag("MZML_INPUT_PATH", "/mzml");
-  filenames.setTag("FEATURES_INPUT_PATH", "/feat_input");
-  filenames.setTag("FEATURES_OUTPUT_PATH", "/feat_output");
-  filenames.setTag("INPUT_MZML_FILENAME", "variant_mzml_");
-  filenames.setTag("INPUT_INJECTION_NAME", "variant_input_injection_");
-  filenames.setTag("OUTPUT_INJECTION_NAME", "variant_output_injection_");
-  filenames.setTag("INPUT_GROUP_NAME", "variant_input_sample_");
-  filenames.setTag("OUTPUT_GROUP_NAME", "variant_output_sample_");
+  filenames.setTag(Filenames::Tag::MAIN_DIR, "/main");
+  filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, "/mzml");
+  filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, "/feat_input");
+  filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, "/feat_output");
+  filenames.setTag(Filenames::Tag::INPUT_MZML_FILENAME, "variant_mzml_");
+  filenames.setTag(Filenames::Tag::INPUT_INJECTION_NAME, "variant_input_injection_");
+  filenames.setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, "variant_output_injection_");
+  filenames.setTag(Filenames::Tag::INPUT_GROUP_NAME, "variant_input_sample_");
+  filenames.setTag(Filenames::Tag::OUTPUT_GROUP_NAME, "variant_output_sample_");
   EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/file/to/file_main.txt");
 }
 
@@ -90,15 +90,15 @@ TEST(Filenames, setRootPath_setVariant_after)
   filenames.addFileName("my_file_injection_output", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}file_injection_output.txt");
   filenames.addFileName("my_file_group_input", "${FEATURES_INPUT_PATH}/${INPUT_GROUP_NAME}file_group_input.txt");
   filenames.addFileName("my_file_group_output", "${FEATURES_OUTPUT_PATH}/${OUTPUT_GROUP_NAME}file_group_output.txt");
-  filenames.setTag("MAIN_DIR", "/main");
-  filenames.setTag("MZML_INPUT_PATH", "/mzml");
-  filenames.setTag("FEATURES_INPUT_PATH", "/feat_input");
-  filenames.setTag("FEATURES_OUTPUT_PATH", "/feat_output");
-  filenames.setTag("INPUT_MZML_FILENAME", "variant_mzml_");
-  filenames.setTag("INPUT_INJECTION_NAME", "variant_input_injection_");
-  filenames.setTag("OUTPUT_INJECTION_NAME", "variant_output_injection_");
-  filenames.setTag("INPUT_GROUP_NAME", "variant_input_sample_");
-  filenames.setTag("OUTPUT_GROUP_NAME", "variant_output_sample_");
+  filenames.setTag(Filenames::Tag::MAIN_DIR, "/main");
+  filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, "/mzml");
+  filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, "/feat_input");
+  filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, "/feat_output");
+  filenames.setTag(Filenames::Tag::INPUT_MZML_FILENAME, "variant_mzml_");
+  filenames.setTag(Filenames::Tag::INPUT_INJECTION_NAME, "variant_input_injection_");
+  filenames.setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, "variant_output_injection_");
+  filenames.setTag(Filenames::Tag::INPUT_GROUP_NAME, "variant_input_sample_");
+  filenames.setTag(Filenames::Tag::OUTPUT_GROUP_NAME, "variant_output_sample_");
   EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/main/file_main.txt");
   EXPECT_STREQ(filenames.getFullPath("my_file_injection_input").generic_string().c_str(), "/feat_input/variant_input_injection_file_injection_input.txt");
   EXPECT_STREQ(filenames.getFullPath("my_file_injection_output").generic_string().c_str(), "/feat_output/variant_output_injection_file_injection_output.txt");
@@ -109,15 +109,15 @@ TEST(Filenames, setRootPath_setVariant_after)
 TEST(Filenames, setRootPath_setVariant_before)
 {
   Filenames filenames;
-  filenames.setTag("MAIN_DIR", "/main");
-  filenames.setTag("MZML_INPUT_PATH", "/mzml");
-  filenames.setTag("FEATURES_INPUT_PATH", "/feat_input");
-  filenames.setTag("FEATURES_OUTPUT_PATH", "/feat_output");
-  filenames.setTag("INPUT_MZML_FILENAME", "variant_mzml_");
-  filenames.setTag("INPUT_INJECTION_NAME", "variant_input_injection_");
-  filenames.setTag("OUTPUT_INJECTION_NAME", "variant_output_injection_");
-  filenames.setTag("INPUT_GROUP_NAME", "variant_input_sample_");
-  filenames.setTag("OUTPUT_GROUP_NAME", "variant_output_sample_");
+  filenames.setTag(Filenames::Tag::MAIN_DIR, "/main");
+  filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, "/mzml");
+  filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, "/feat_input");
+  filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, "/feat_output");
+  filenames.setTag(Filenames::Tag::INPUT_MZML_FILENAME, "variant_mzml_");
+  filenames.setTag(Filenames::Tag::INPUT_INJECTION_NAME, "variant_input_injection_");
+  filenames.setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, "variant_output_injection_");
+  filenames.setTag(Filenames::Tag::INPUT_GROUP_NAME, "variant_input_sample_");
+  filenames.setTag(Filenames::Tag::OUTPUT_GROUP_NAME, "variant_output_sample_");
   filenames.addFileName("my_file_main", "${MAIN_DIR}/file_main.txt");
   filenames.addFileName("my_file_injection_input", "${FEATURES_INPUT_PATH}/${INPUT_INJECTION_NAME}file_injection_input.txt");
   filenames.addFileName("my_file_injection_output", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}file_injection_output.txt");
@@ -133,15 +133,15 @@ TEST(Filenames, setRootPath_setVariant_before)
 TEST(Filenames, merge)
 {
   Filenames filenames1;
-  filenames1.setTag("MAIN_DIR", "/main");
-  filenames1.setTag("MZML_INPUT_PATH", "/mzml");
-  filenames1.setTag("FEATURES_INPUT_PATH", "/feat_input");
-  filenames1.setTag("FEATURES_OUTPUT_PATH", "/feat_output");
-  filenames1.setTag("INPUT_MZML_FILENAME", "variant_mzml_");
-  filenames1.setTag("INPUT_INJECTION_NAME", "variant_input_injection_");
-  filenames1.setTag("OUTPUT_INJECTION_NAME", "variant_output_injection_");
-  filenames1.setTag("INPUT_GROUP_NAME", "variant_input_sample_");
-  filenames1.setTag("OUTPUT_GROUP_NAME", "variant_output_sample_");
+  filenames1.setTag(Filenames::Tag::MAIN_DIR, "/main");
+  filenames1.setTag(Filenames::Tag::MZML_INPUT_PATH, "/mzml");
+  filenames1.setTag(Filenames::Tag::FEATURES_INPUT_PATH, "/feat_input");
+  filenames1.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, "/feat_output");
+  filenames1.setTag(Filenames::Tag::INPUT_MZML_FILENAME, "variant_mzml_");
+  filenames1.setTag(Filenames::Tag::INPUT_INJECTION_NAME, "variant_input_injection_");
+  filenames1.setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, "variant_output_injection_");
+  filenames1.setTag(Filenames::Tag::INPUT_GROUP_NAME, "variant_input_sample_");
+  filenames1.setTag(Filenames::Tag::OUTPUT_GROUP_NAME, "variant_output_sample_");
   filenames1.addFileName("my_file_main", "${MAIN_DIR}/file_main.txt");
   filenames1.addFileName("my_file_injection_input", "${FEATURES_INPUT_PATH}/${INPUT_INJECTION_NAME}file_injection_input.txt");
 

--- a/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
@@ -18,7 +18,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Douglas McCloskey, Bertrand Boudaud $
-// $Authors: Bertrand Boudaud $
+// $Authors: Douglas McCloskey $
 // --------------------------------------------------------------------------
 
 #include <gtest/gtest.h>

--- a/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
@@ -37,7 +37,7 @@ TEST(Filenames, constructor)
 TEST(Filenames, addFileName)
 {
   Filenames filenames;
-  filenames.addFileName("my_file", "file.txt", Filenames::FileScope::EFileScopeMain);
+  filenames.addFileName("my_file", "${MAIN_DIR}/file.txt");
   const auto& file_ids = filenames.getFileIds();
   ASSERT_EQ(file_ids.size(), 1);
 }
@@ -45,8 +45,8 @@ TEST(Filenames, addFileName)
 TEST(Filenames, getFullPath)
 {
   Filenames filenames;
-  filenames.addFileName("my_file_main", "file_main.txt", Filenames::FileScope::EFileScopeMain);
-  EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "file_main.txt");
+  filenames.addFileName("my_file_main", "${MAIN_DIR}/file_main.txt");
+  EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/file_main.txt");
 }
 
 TEST(Filenames, getFullPath_non_existing)
@@ -66,25 +66,39 @@ TEST(Filenames, getFullPath_non_existing)
 TEST(Filenames, setFullPath)
 {
   Filenames filenames;
-  filenames.addFileName("my_file_main", "file_main.txt", Filenames::FileScope::EFileScopeMain);
+  filenames.addFileName("my_file_main", "${MAIN_DIR}/file_main.txt");
   filenames.setFullPath("my_file_main", "/file/to/file_main.txt");
   EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/file/to/file_main.txt");
   // setting variant or root has no effect
-  filenames.setRootPaths("/main", "/mzml", "/feat_input", "/feat_output");
-  filenames.setFileVariants( "variant_mzml_", "variant_input_injection_", "variant_output_injection_", "variant_input_sample_", "variant_output_sample_");
+  filenames.setTag("MAIN_DIR", "/main");
+  filenames.setTag("MZML_INPUT_PATH", "/mzml");
+  filenames.setTag("FEATURES_INPUT_PATH", "/feat_input");
+  filenames.setTag("FEATURES_OUTPUT_PATH", "/feat_output");
+  filenames.setTag("INPUT_MZML_FILENAME", "variant_mzml_");
+  filenames.setTag("INPUT_INJECTION_NAME", "variant_input_injection_");
+  filenames.setTag("OUTPUT_INJECTION_NAME", "variant_output_injection_");
+  filenames.setTag("INPUT_GROUP_NAME", "variant_input_sample_");
+  filenames.setTag("OUTPUT_GROUP_NAME", "variant_output_sample_");
   EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/file/to/file_main.txt");
 }
 
 TEST(Filenames, setRootPath_setVariant_after)
 {
   Filenames filenames;
-  filenames.addFileName("my_file_main", "file_main.txt", Filenames::FileScope::EFileScopeMain);
-  filenames.addFileName("my_file_injection_input", "file_injection_input.txt", Filenames::FileScope::EFileScopeInjectionInput);
-  filenames.addFileName("my_file_injection_output", "file_injection_output.txt", Filenames::FileScope::EFileScopeInjectionOutput);
-  filenames.addFileName("my_file_group_input", "file_group_input.txt", Filenames::FileScope::EFileScopeSampleGroupInput);
-  filenames.addFileName("my_file_group_output", "file_group_output.txt", Filenames::FileScope::EFileScopeSampleGroupOutput);
-  filenames.setRootPaths("/main", "/mzml", "/feat_input", "/feat_output");
-  filenames.setFileVariants("variant_mzml_", "variant_input_injection_", "variant_output_injection_", "variant_input_sample_", "variant_output_sample_");
+  filenames.addFileName("my_file_main", "${MAIN_DIR}/file_main.txt");
+  filenames.addFileName("my_file_injection_input", "${FEATURES_INPUT_PATH}/${INPUT_INJECTION_NAME}file_injection_input.txt");
+  filenames.addFileName("my_file_injection_output", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}file_injection_output.txt");
+  filenames.addFileName("my_file_group_input", "${FEATURES_INPUT_PATH}/${INPUT_GROUP_NAME}file_group_input.txt");
+  filenames.addFileName("my_file_group_output", "${FEATURES_OUTPUT_PATH}/${OUTPUT_GROUP_NAME}file_group_output.txt");
+  filenames.setTag("MAIN_DIR", "/main");
+  filenames.setTag("MZML_INPUT_PATH", "/mzml");
+  filenames.setTag("FEATURES_INPUT_PATH", "/feat_input");
+  filenames.setTag("FEATURES_OUTPUT_PATH", "/feat_output");
+  filenames.setTag("INPUT_MZML_FILENAME", "variant_mzml_");
+  filenames.setTag("INPUT_INJECTION_NAME", "variant_input_injection_");
+  filenames.setTag("OUTPUT_INJECTION_NAME", "variant_output_injection_");
+  filenames.setTag("INPUT_GROUP_NAME", "variant_input_sample_");
+  filenames.setTag("OUTPUT_GROUP_NAME", "variant_output_sample_");
   EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/main/file_main.txt");
   EXPECT_STREQ(filenames.getFullPath("my_file_injection_input").generic_string().c_str(), "/feat_input/variant_input_injection_file_injection_input.txt");
   EXPECT_STREQ(filenames.getFullPath("my_file_injection_output").generic_string().c_str(), "/feat_output/variant_output_injection_file_injection_output.txt");
@@ -95,13 +109,20 @@ TEST(Filenames, setRootPath_setVariant_after)
 TEST(Filenames, setRootPath_setVariant_before)
 {
   Filenames filenames;
-  filenames.setRootPaths("/main", "/mzml", "/feat_input", "/feat_output");
-  filenames.setFileVariants("variant_mzml_", "variant_input_injection_", "variant_output_injection_", "variant_input_sample_", "variant_output_sample_");
-  filenames.addFileName("my_file_main", "file_main.txt", Filenames::FileScope::EFileScopeMain);
-  filenames.addFileName("my_file_injection_input", "file_injection_input.txt", Filenames::FileScope::EFileScopeInjectionInput);
-  filenames.addFileName("my_file_injection_output", "file_injection_output.txt", Filenames::FileScope::EFileScopeInjectionOutput);
-  filenames.addFileName("my_file_group_input", "file_group_input.txt", Filenames::FileScope::EFileScopeSampleGroupInput);
-  filenames.addFileName("my_file_group_output", "file_group_output.txt", Filenames::FileScope::EFileScopeSampleGroupOutput);
+  filenames.setTag("MAIN_DIR", "/main");
+  filenames.setTag("MZML_INPUT_PATH", "/mzml");
+  filenames.setTag("FEATURES_INPUT_PATH", "/feat_input");
+  filenames.setTag("FEATURES_OUTPUT_PATH", "/feat_output");
+  filenames.setTag("INPUT_MZML_FILENAME", "variant_mzml_");
+  filenames.setTag("INPUT_INJECTION_NAME", "variant_input_injection_");
+  filenames.setTag("OUTPUT_INJECTION_NAME", "variant_output_injection_");
+  filenames.setTag("INPUT_GROUP_NAME", "variant_input_sample_");
+  filenames.setTag("OUTPUT_GROUP_NAME", "variant_output_sample_");
+  filenames.addFileName("my_file_main", "${MAIN_DIR}/file_main.txt");
+  filenames.addFileName("my_file_injection_input", "${FEATURES_INPUT_PATH}/${INPUT_INJECTION_NAME}file_injection_input.txt");
+  filenames.addFileName("my_file_injection_output", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}file_injection_output.txt");
+  filenames.addFileName("my_file_group_input", "${FEATURES_INPUT_PATH}/${INPUT_GROUP_NAME}file_group_input.txt");
+  filenames.addFileName("my_file_group_output", "${FEATURES_OUTPUT_PATH}/${OUTPUT_GROUP_NAME}file_group_output.txt");
   EXPECT_STREQ(filenames.getFullPath("my_file_main").generic_string().c_str(), "/main/file_main.txt");
   EXPECT_STREQ(filenames.getFullPath("my_file_injection_input").generic_string().c_str(), "/feat_input/variant_input_injection_file_injection_input.txt");
   EXPECT_STREQ(filenames.getFullPath("my_file_injection_output").generic_string().c_str(), "/feat_output/variant_output_injection_file_injection_output.txt");
@@ -112,16 +133,23 @@ TEST(Filenames, setRootPath_setVariant_before)
 TEST(Filenames, merge)
 {
   Filenames filenames1;
-  filenames1.setRootPaths("/main", "/mzml", "/feat_input", "/feat_output");
-  filenames1.setFileVariants("variant_mzml_", "variant_input_injection_", "variant_output_injection_", "variant_input_sample_", "variant_output_sample_");
-  filenames1.addFileName("my_file_main", "file_main.txt", Filenames::FileScope::EFileScopeMain);
-  filenames1.addFileName("my_file_injection_input", "file_injection_input.txt", Filenames::FileScope::EFileScopeInjectionInput);
+  filenames1.setTag("MAIN_DIR", "/main");
+  filenames1.setTag("MZML_INPUT_PATH", "/mzml");
+  filenames1.setTag("FEATURES_INPUT_PATH", "/feat_input");
+  filenames1.setTag("FEATURES_OUTPUT_PATH", "/feat_output");
+  filenames1.setTag("INPUT_MZML_FILENAME", "variant_mzml_");
+  filenames1.setTag("INPUT_INJECTION_NAME", "variant_input_injection_");
+  filenames1.setTag("OUTPUT_INJECTION_NAME", "variant_output_injection_");
+  filenames1.setTag("INPUT_GROUP_NAME", "variant_input_sample_");
+  filenames1.setTag("OUTPUT_GROUP_NAME", "variant_output_sample_");
+  filenames1.addFileName("my_file_main", "${MAIN_DIR}/file_main.txt");
+  filenames1.addFileName("my_file_injection_input", "${FEATURES_INPUT_PATH}/${INPUT_INJECTION_NAME}file_injection_input.txt");
 
   Filenames filenames2;
-  filenames1.addFileName("my_file_main", "file_main_again.txt", Filenames::FileScope::EFileScopeMain);
-  filenames2.addFileName("my_file_injection_output", "file_injection_output.txt", Filenames::FileScope::EFileScopeInjectionOutput);
-  filenames2.addFileName("my_file_group_input", "file_group_input.txt", Filenames::FileScope::EFileScopeSampleGroupInput);
-  filenames2.addFileName("my_file_group_output", "file_group_output.txt", Filenames::FileScope::EFileScopeSampleGroupOutput);
+  filenames1.addFileName("my_file_main", "${MAIN_DIR}/file_main_again.txt");
+  filenames2.addFileName("my_file_injection_output", "${FEATURES_OUTPUT_PATH}/${OUTPUT_INJECTION_NAME}file_injection_output.txt");
+  filenames2.addFileName("my_file_group_input", "${FEATURES_INPUT_PATH}/${INPUT_GROUP_NAME}file_group_input.txt");
+  filenames2.addFileName("my_file_group_output", "${FEATURES_OUTPUT_PATH}/${OUTPUT_GROUP_NAME}file_group_output.txt");
 
   filenames1.merge(filenames2);
   EXPECT_STREQ(filenames1.getFullPath("my_file_main").generic_string().c_str(), "/main/file_main.txt");

--- a/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Filenames_test.cpp
@@ -27,7 +27,7 @@
 
 using namespace SmartPeak;
 using namespace std;
-
+/*
 TEST(Filenames, filenames_getDefaultStaticFilenames)
 {
   Filenames filenames = Filenames::getDefaultStaticFilenames("/home/user");
@@ -263,3 +263,4 @@ TEST(Filenames, clear2)
   EXPECT_STREQ(filenames.pivotTable_csv_o.c_str(), "");
   EXPECT_STREQ(filenames.featureDB_csv_o.c_str(), "");
 }
+*/

--- a/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
@@ -96,7 +96,7 @@ TEST(InputDataValidation, findMissingNames)
 TEST(InputDataValidation, sampleNamesAreConsistent)
 {
   SequenceHandler sequenceHandler;
-  Filenames filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames filenames;
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -109,7 +109,7 @@ TEST(InputDataValidation, sampleNamesAreConsistent)
   result = InputDataValidation::sampleNamesAreConsistent(sequenceHandler);
   EXPECT_TRUE(result);
 
-  filenames.sequence_csv_i = main_dir + "/sequence_missing.csv";
+  filenames.setFullPathName("sequence_csv_i", main_dir + "/sequence_missing.csv");
   sequenceHandler.clear();
 
   cs.filenames_ = filenames;
@@ -122,7 +122,7 @@ TEST(InputDataValidation, sampleNamesAreConsistent)
 TEST(InputDataValidation, componentNamesAreConsistent)
 {
   SequenceHandler sequenceHandler;
-  Filenames filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames filenames;
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -135,7 +135,7 @@ TEST(InputDataValidation, componentNamesAreConsistent)
   result = InputDataValidation::componentNamesAreConsistent(sequenceHandler);
   EXPECT_TRUE(result);
 
-  filenames.traML_csv_i = main_dir + "/traML_missing.csv";
+  filenames.setFullPathName("traML_csv_i", main_dir + "/traML_missing.csv");
   // SequenceProcessor::createSequence(sequenceHandler, filenames, ",", false);
   RawDataHandler& rawData0 = sequenceHandler.getSequence().front().getRawData();
   LoadTransitions loadTransitions;
@@ -148,7 +148,7 @@ TEST(InputDataValidation, componentNamesAreConsistent)
 TEST(InputDataValidation, componentNameGroupsAreConsistent)
 {
   SequenceHandler sequenceHandler;
-  Filenames filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames filenames;
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -161,7 +161,7 @@ TEST(InputDataValidation, componentNameGroupsAreConsistent)
   result = InputDataValidation::componentNameGroupsAreConsistent(sequenceHandler);
   EXPECT_TRUE(result);
 
-  filenames.traML_csv_i = main_dir + "/traML_missing.csv";
+  filenames.setFullPathName("traML_csv_i", main_dir + "/traML_missing.csv");
   //SequenceProcessor::createSequence(sequenceHandler, filenames, ",", false);
   RawDataHandler& rawData0 = sequenceHandler.getSequence().front().getRawData();
   LoadTransitions loadTransitions;
@@ -174,7 +174,7 @@ TEST(InputDataValidation, componentNameGroupsAreConsistent)
 TEST(InputDataValidation, heavyComponentsAreConsistent)
 {
   SequenceHandler sequenceHandler;
-  Filenames filenames = Filenames::getDefaultStaticFilenames(main_dir);
+  Filenames filenames;
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -187,7 +187,7 @@ TEST(InputDataValidation, heavyComponentsAreConsistent)
   result = InputDataValidation::heavyComponentsAreConsistent(sequenceHandler);
   EXPECT_TRUE(result);
 
-  filenames.quantitationMethods_csv_i = main_dir + "/quantitationMethods_missing.csv";
+  filenames.setFullPathName("quantitationMethods_csv_i", main_dir + "/quantitationMethods_missing.csv");
   //SequenceProcessor::createSequence(sequenceHandler, filenames, ",", false);
   SequenceSegmentHandler& seqSeg0 = sequenceHandler.getSequenceSegments().front();
   LoadQuantitationMethods loadQuantitationMethods;

--- a/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
@@ -46,21 +46,21 @@ TEST(InputDataValidation, isValidFilename)
   {
     void getInputsOutputs(Filenames& filenames) const
     {
-      filenames.addFileName("some standards file", "OpenMSFile_standardsConcentrations_1.csv", Filenames::FileScope::EFileScopeMain);
+      filenames.addFileName("some standards file", "${MAIN_DIR}/OpenMSFile_standardsConcentrations_1.csv");
     };
   };
   struct NonExistingFile : public IInputsOutputsProvider
   {
     void getInputsOutputs(Filenames& filenames) const
     {
-      filenames.addFileName("a file that does not exist", "this_does_not_exist.csv", Filenames::FileScope::EFileScopeMain);
+      filenames.addFileName("a file that does not exist", "${MAIN_DIR}/this_does_not_exist.csv");
     };
   };
   struct EmptyFileName : public IInputsOutputsProvider
   {
     void getInputsOutputs(Filenames& filenames) const
     {
-      filenames.addFileName("an empty pathname", "", Filenames::FileScope::EFileScopeMain);
+      filenames.addFileName("an empty pathname", "");
     };
   };
   Filenames filenames;
@@ -117,8 +117,7 @@ TEST(InputDataValidation, sampleNamesAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
-  filenames.setRootPaths(main_dir, "", "", "");
-
+  filenames.setTag("MAIN_DIR", main_dir);
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
   cs.delimiter          = ",";
@@ -144,7 +143,7 @@ TEST(InputDataValidation, componentNamesAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
-  filenames.setRootPaths(main_dir, "", "", "");
+  filenames.setTag("MAIN_DIR", main_dir);
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -171,7 +170,7 @@ TEST(InputDataValidation, componentNameGroupsAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
-  filenames.setRootPaths(main_dir, "", "", "");
+  filenames.setTag("MAIN_DIR", main_dir);
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -198,7 +197,7 @@ TEST(InputDataValidation, heavyComponentsAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
-  filenames.setRootPaths(main_dir, "", "", "");
+  filenames.setTag("MAIN_DIR", main_dir);
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;

--- a/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
@@ -42,6 +42,7 @@ TEST(InputDataValidation, fileExists)
 
 TEST(InputDataValidation, isValidFilename)
 {
+  /*
   string pathname = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_standardsConcentrations_1.csv");
   InputDataValidation::FilenameInfo v;
   v = InputDataValidation::isValidFilename(pathname, "some standards file", true);
@@ -52,6 +53,7 @@ TEST(InputDataValidation, isValidFilename)
   pathname.clear();
   v = InputDataValidation::isValidFilename(pathname, "an empty pathname", false);
   EXPECT_EQ(v.validity, InputDataValidation::FilenameInfo::not_provided);  // not provided
+  */
 }
 
 TEST(InputDataValidation, validateNamesInStructures)

--- a/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
@@ -117,7 +117,7 @@ TEST(InputDataValidation, sampleNamesAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
-  filenames.setTag("MAIN_DIR", main_dir);
+  filenames.setTag(Filenames::Tag::MAIN_DIR, main_dir);
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
   cs.delimiter          = ",";
@@ -143,7 +143,7 @@ TEST(InputDataValidation, componentNamesAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
-  filenames.setTag("MAIN_DIR", main_dir);
+  filenames.setTag(Filenames::Tag::MAIN_DIR, main_dir);
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -170,7 +170,7 @@ TEST(InputDataValidation, componentNameGroupsAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
-  filenames.setTag("MAIN_DIR", main_dir);
+  filenames.setTag(Filenames::Tag::MAIN_DIR, main_dir);
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -197,7 +197,7 @@ TEST(InputDataValidation, heavyComponentsAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
-  filenames.setTag("MAIN_DIR", main_dir);
+  filenames.setTag(Filenames::Tag::MAIN_DIR, main_dir);
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;

--- a/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
@@ -42,23 +42,23 @@ TEST(InputDataValidation, fileExists)
 
 TEST(InputDataValidation, isValidFilename)
 {
-  struct ExistingFile : public IInputsOutputsProvider
+  struct ExistingFile : public IFilenamesHandler
   {
-    void getInputsOutputs(Filenames& filenames) const
+    void getFilenames(Filenames& filenames) const
     {
       filenames.addFileName("some standards file", "${MAIN_DIR}/OpenMSFile_standardsConcentrations_1.csv");
     };
   };
-  struct NonExistingFile : public IInputsOutputsProvider
+  struct NonExistingFile : public IFilenamesHandler
   {
-    void getInputsOutputs(Filenames& filenames) const
+    void getFilenames(Filenames& filenames) const
     {
       filenames.addFileName("a file that does not exist", "${MAIN_DIR}/this_does_not_exist.csv");
     };
   };
-  struct EmptyFileName : public IInputsOutputsProvider
+  struct EmptyFileName : public IFilenamesHandler
   {
-    void getInputsOutputs(Filenames& filenames) const
+    void getFilenames(Filenames& filenames) const
     {
       filenames.addFileName("an empty pathname", "");
     };

--- a/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
@@ -42,18 +42,36 @@ TEST(InputDataValidation, fileExists)
 
 TEST(InputDataValidation, isValidFilename)
 {
-  /*
-  string pathname = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_standardsConcentrations_1.csv");
-  InputDataValidation::FilenameInfo v;
-  v = InputDataValidation::isValidFilename(pathname, "some standards file", true);
-  EXPECT_EQ(v.validity, InputDataValidation::FilenameInfo::valid);  // success
-  pathname = SMARTPEAK_GET_TEST_DATA_PATH("this_does_not_exist.csv");
-  v = InputDataValidation::isValidFilename(pathname, "a file that does not exist", true);
-  EXPECT_EQ(v.validity, InputDataValidation::FilenameInfo::invalid); // failure
-  pathname.clear();
-  v = InputDataValidation::isValidFilename(pathname, "an empty pathname", false);
-  EXPECT_EQ(v.validity, InputDataValidation::FilenameInfo::not_provided);  // not provided
-  */
+  struct ExistingFile : public IInputsOutputsProvider
+  {
+    void getInputsOutputs(Filenames& filenames) const
+    {
+      filenames.addFileName("some standards file", "OpenMSFile_standardsConcentrations_1.csv", Filenames::FileScope::EFileScopeMain);
+    };
+  };
+  struct NonExistingFile : public IInputsOutputsProvider
+  {
+    void getInputsOutputs(Filenames& filenames) const
+    {
+      filenames.addFileName("a file that does not exist", "this_does_not_exist.csv", Filenames::FileScope::EFileScopeMain);
+    };
+  };
+  struct EmptyFileName : public IInputsOutputsProvider
+  {
+    void getInputsOutputs(Filenames& filenames) const
+    {
+      filenames.addFileName("an empty pathname", "", Filenames::FileScope::EFileScopeMain);
+    };
+  };
+  Filenames filenames;
+  filenames.setFullPath("some standards file", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_standardsConcentrations_1.csv"));
+  EXPECT_TRUE(InputDataValidation::precheckProcessorInputs(ExistingFile(), "some standards file", filenames, true));
+  filenames.setFullPath("a file that does not exist", SMARTPEAK_GET_TEST_DATA_PATH("this_does_not_exist.csv"));
+  EXPECT_FALSE(InputDataValidation::precheckProcessorInputs(NonExistingFile(), "a file that does not exist", filenames, true));
+  EXPECT_TRUE(InputDataValidation::precheckProcessorInputs(NonExistingFile(), "a file that does not exist", filenames, false));
+  filenames.setFullPath("an empty pathname", "");
+  EXPECT_FALSE(InputDataValidation::precheckProcessorInputs(EmptyFileName(), "an empty pathname", filenames, true));
+  EXPECT_TRUE(InputDataValidation::precheckProcessorInputs(EmptyFileName(), "an empty pathname", filenames, false));
 }
 
 TEST(InputDataValidation, validateNamesInStructures)

--- a/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
@@ -97,6 +97,7 @@ TEST(InputDataValidation, sampleNamesAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
+  filenames.setRootPaths(main_dir, "", "", "");
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -123,6 +124,7 @@ TEST(InputDataValidation, componentNamesAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
+  filenames.setRootPaths(main_dir, "", "", "");
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -149,6 +151,7 @@ TEST(InputDataValidation, componentNameGroupsAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
+  filenames.setRootPaths(main_dir, "", "", "");
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;
@@ -175,6 +178,7 @@ TEST(InputDataValidation, heavyComponentsAreConsistent)
 {
   SequenceHandler sequenceHandler;
   Filenames filenames;
+  filenames.setRootPaths(main_dir, "", "", "");
 
   CreateSequence cs(sequenceHandler);
   cs.filenames_          = filenames;

--- a/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
@@ -112,7 +112,7 @@ TEST(InputDataValidation, sampleNamesAreConsistent)
   result = InputDataValidation::sampleNamesAreConsistent(sequenceHandler);
   EXPECT_TRUE(result);
 
-  filenames.setFullPathName("sequence_csv_i", main_dir + "/sequence_missing.csv");
+  filenames.setFullPath("sequence_csv_i", main_dir + "/sequence_missing.csv");
   sequenceHandler.clear();
 
   cs.filenames_ = filenames;
@@ -139,7 +139,7 @@ TEST(InputDataValidation, componentNamesAreConsistent)
   result = InputDataValidation::componentNamesAreConsistent(sequenceHandler);
   EXPECT_TRUE(result);
 
-  filenames.setFullPathName("traML_csv_i", main_dir + "/traML_missing.csv");
+  filenames.setFullPath("traML_csv_i", main_dir + "/traML_missing.csv");
   // SequenceProcessor::createSequence(sequenceHandler, filenames, ",", false);
   RawDataHandler& rawData0 = sequenceHandler.getSequence().front().getRawData();
   LoadTransitions loadTransitions;
@@ -166,7 +166,7 @@ TEST(InputDataValidation, componentNameGroupsAreConsistent)
   result = InputDataValidation::componentNameGroupsAreConsistent(sequenceHandler);
   EXPECT_TRUE(result);
 
-  filenames.setFullPathName("traML_csv_i", main_dir + "/traML_missing.csv");
+  filenames.setFullPath("traML_csv_i", main_dir + "/traML_missing.csv");
   //SequenceProcessor::createSequence(sequenceHandler, filenames, ",", false);
   RawDataHandler& rawData0 = sequenceHandler.getSequence().front().getRawData();
   LoadTransitions loadTransitions;
@@ -193,7 +193,7 @@ TEST(InputDataValidation, heavyComponentsAreConsistent)
   result = InputDataValidation::heavyComponentsAreConsistent(sequenceHandler);
   EXPECT_TRUE(result);
 
-  filenames.setFullPathName("quantitationMethods_csv_i", main_dir + "/quantitationMethods_missing.csv");
+  filenames.setFullPath("quantitationMethods_csv_i", main_dir + "/quantitationMethods_missing.csv");
   //SequenceProcessor::createSequence(sequenceHandler, filenames, ",", false);
   SequenceSegmentHandler& seqSeg0 = sequenceHandler.getSequenceSegments().front();
   LoadQuantitationMethods loadQuantitationMethods;

--- a/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
@@ -202,3 +202,41 @@ TEST(InputDataValidation, heavyComponentsAreConsistent)
   result = InputDataValidation::heavyComponentsAreConsistent(sequenceHandler);
   EXPECT_FALSE(result); // g6p.g6p_2.Heavy is missing
 }
+
+TEST(InputDataValidation, prepareToLoad)
+{
+  Filenames filenames;
+  filenames.setFullPath("quantitationMethods_csv_i", main_dir + "/quantitationMethods_missing.csv");
+  filenames.setFullPath("non_existing_file", main_dir + "/non_existing_file.csv");
+  EXPECT_TRUE(InputDataValidation::prepareToLoad(filenames, "quantitationMethods_csv_i"));
+  EXPECT_FALSE(InputDataValidation::prepareToLoad(filenames, "non_existing_file"));
+}
+
+TEST(InputDataValidation, prepareToLoadOneOfTwo)
+{
+  Filenames filenames;
+  filenames.setFullPath("quantitationMethods_csv_i", main_dir + "/quantitationMethods_missing.csv");
+  filenames.setFullPath("empty_file", "");
+  filenames.setFullPath("another_empty_file", "");
+  EXPECT_TRUE(InputDataValidation::prepareToLoadOneOfTwo(filenames, "quantitationMethods_csv_i", "empty_file"));
+  EXPECT_FALSE(InputDataValidation::prepareToLoadOneOfTwo(filenames, "empty_file", "another_empty_file"));
+}
+
+TEST(InputDataValidation, prepareToStore)
+{
+  Filenames filenames;
+  filenames.setFullPath("quantitationMethods_csv_i", main_dir + "/quantitationMethods_missing.csv");
+  filenames.setFullPath("empty_file", "");
+  EXPECT_TRUE(InputDataValidation::prepareToStore(filenames, "quantitationMethods_csv_i"));
+  EXPECT_FALSE(InputDataValidation::prepareToStore(filenames, "empty_file"));
+}
+
+TEST(InputDataValidation, prepareToStoreOneOfTwo)
+{
+  Filenames filenames;
+  filenames.setFullPath("quantitationMethods_csv_i", main_dir + "/quantitationMethods_missing.csv");
+  filenames.setFullPath("empty_file", "");
+  filenames.setFullPath("another_empty_file", "");
+  EXPECT_TRUE(InputDataValidation::prepareToStoreOneOfTwo(filenames, "quantitationMethods_csv_i", "empty_file"));
+  EXPECT_FALSE(InputDataValidation::prepareToStoreOneOfTwo(filenames, "empty_file", "another_empty_file"));
+}

--- a/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/InputDataValidation_test.cpp
@@ -44,13 +44,13 @@ TEST(InputDataValidation, isValidFilename)
 {
   string pathname = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_standardsConcentrations_1.csv");
   InputDataValidation::FilenameInfo v;
-  v = InputDataValidation::isValidFilename(pathname, "some standards file");
+  v = InputDataValidation::isValidFilename(pathname, "some standards file", true);
   EXPECT_EQ(v.validity, InputDataValidation::FilenameInfo::valid);  // success
   pathname = SMARTPEAK_GET_TEST_DATA_PATH("this_does_not_exist.csv");
-  v = InputDataValidation::isValidFilename(pathname, "a file that does not exist");
+  v = InputDataValidation::isValidFilename(pathname, "a file that does not exist", true);
   EXPECT_EQ(v.validity, InputDataValidation::FilenameInfo::invalid); // failure
   pathname.clear();
-  v = InputDataValidation::isValidFilename(pathname, "an empty pathname");
+  v = InputDataValidation::isValidFilename(pathname, "an empty pathname", false);
   EXPECT_EQ(v.validity, InputDataValidation::FilenameInfo::not_provided);  // not provided
 }
 

--- a/src/tests/class_tests/smartpeak/source/MRMFeatureValidator_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/MRMFeatureValidator_test.cpp
@@ -36,7 +36,7 @@ using namespace std;
 TEST(MRMFeaturevalidator, validate_MRMFeatures)
 {
   Filenames filenames;
-  filenames.referenceData_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv");
+  filenames.setFullPathName("referenceData_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv"));
   const string featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_test_1_algorithm_MRMFeatureValidator.featureXML");
   const string filename_params = SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_test_pyTOPP_MRMFeatureValidator_params.csv");
 

--- a/src/tests/class_tests/smartpeak/source/MRMFeatureValidator_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/MRMFeatureValidator_test.cpp
@@ -36,7 +36,7 @@ using namespace std;
 TEST(MRMFeaturevalidator, validate_MRMFeatures)
 {
   Filenames filenames;
-  filenames.setFullPathName("referenceData_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv"));
+  filenames.setFullPath("referenceData_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv"));
   const string featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_test_1_algorithm_MRMFeatureValidator.featureXML");
   const string filename_params = SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_test_pyTOPP_MRMFeatureValidator_params.csv");
 

--- a/src/tests/class_tests/smartpeak/source/RawDataProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/RawDataProcessor_test.cpp
@@ -2462,7 +2462,6 @@ TEST(RawDataProcessor, process)
   rawDataHandler.setQuantitationMethods(sequenceSegmentHandler_IO.getQuantitationMethods());
 
   LoadFeatureQCsRDP loadFeatureQCs;
-  loadFeatureQCs.getInputsOutputs(filenames);
   loadFeatureQCs.process(rawDataHandler, params_1, filenames);
 
   filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));

--- a/src/tests/class_tests/smartpeak/source/RawDataProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/RawDataProcessor_test.cpp
@@ -44,8 +44,8 @@ void load_data(
 )
 {
   Filenames filenames1, filenames2;
-  filenames1.parameters_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_params_1_core_tmpFix.csv");
-  filenames2.parameters_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_params_2_tmpFix.csv");
+  filenames1.setFullPathName("parameters_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_params_1_core_tmpFix.csv"));
+  filenames2.setFullPathName("parameters_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_params_2_tmpFix.csv"));
   RawDataHandler rawDataHandler;
   LoadParameters loadParameters;
   loadParameters.process(rawDataHandler, {}, filenames1);
@@ -89,11 +89,11 @@ TEST(RawDataProcessor, processorClearData)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   LoadRawData::extractMetaData(rawDataHandler);
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_test_1_io_FileReaderOpenMS.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_test_1_io_FileReaderOpenMS.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
@@ -151,7 +151,7 @@ TEST(RawDataProcessor, processorLoadRawData)
   params_I.addFunctionParameters(FunctionParameters("MRMMapping"));
 
   Filenames filenames;
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML"));
   processor.process(rawDataHandler, params_I, filenames);
 
   const vector<OpenMS::MSChromatogram>& chromatograms1 = rawDataHandler.getExperiment().getChromatograms();
@@ -182,7 +182,7 @@ TEST(RawDataProcessor, processorLoadRawData)
   params_I.at("mzML").addParameter(param);
   
   rawDataHandler.clear();
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_ChromeleonFile_10ug.txt");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_ChromeleonFile_10ug.txt"));
   processor.process(rawDataHandler, params_I, filenames);
 
   const vector<OpenMS::MSChromatogram>& chromatograms3 = rawDataHandler.getExperiment().getChromatograms();
@@ -210,11 +210,11 @@ TEST(RawDataProcessor, extractMetaData)
 
   // Pre-requisites: load the transitions and raw data
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, {}, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
 
@@ -304,11 +304,11 @@ TEST(RawDataProcessor, processorMapChromatograms)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -370,7 +370,7 @@ TEST(RawDataProcessor, processorZeroChromatogramBaseline)
   params_I.addFunctionParameters(FunctionParameters("ChromatogramExtractor"));
 
   Filenames filenames;
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML"));
   LoadRawData processor;
   processor.process(rawDataHandler, params_I, filenames);
   rawDataHandler.setChromatogramMap(rawDataHandler.getExperiment()); // Avoiding the mapping step for testing purposes
@@ -398,7 +398,7 @@ TEST(RawDataProcessor, processorZeroChromatogramBaseline)
   }};
   params_I.addFunctionParameters(FunctionParameters("mzML", params));
   rawDataHandler.clear();
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_ChromeleonFile_10ug.txt");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_ChromeleonFile_10ug.txt"));
   processor.process(rawDataHandler, params_I, filenames);
   rawDataHandler.setChromatogramMap(rawDataHandler.getExperiment()); // Avoiding the mapping step for testing purposes
   zeroChromBase.process(rawDataHandler, params_I, filenames);
@@ -448,11 +448,11 @@ TEST(RawDataProcessor, processorExtractChromatogramWindows)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -477,8 +477,8 @@ TEST(RawDataProcessor, processorExtractChromatogramWindows)
   EXPECT_NEAR(chromatograms1.back()[2].getMZ(), 914.139, 1e-3);
 
   // Test window extraction
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_extractChromWindowTest_1.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_extractChromWindowTest_1.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, {}, filenames);
 
@@ -535,7 +535,7 @@ TEST(RawDataProcessor, processorExtractSpectraWindows)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -590,7 +590,7 @@ TEST(RawDataProcessor, processorMergeSpectra)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -623,7 +623,7 @@ TEST(RawDataProcessor, processorMergeSpectraZeroPeak)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest_SpecWithZeroPeak.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest_SpecWithZeroPeak.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -673,7 +673,7 @@ TEST(RawDataProcessor, gettersLoadFeatures)
 TEST(RawDataProcessor, processLoadFeatures)
 {
   Filenames filenames;
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_test_1_io_FileReaderOpenMS.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_test_1_io_FileReaderOpenMS.featureXML"));
   RawDataHandler rawDataHandler;
   rawDataHandler.getMetaData().setFilename("filename");
   LoadFeatures loadFeatures;
@@ -775,7 +775,7 @@ TEST(RawDataProcessor, gettersLoadAnnotations)
 TEST(RawDataProcessor, processLoadAnnotations)
 {
   Filenames filenames;
-  filenames.mzTab_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzTab");
+  filenames.setFullPathName("mzTab_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzTab"));
   RawDataHandler rawDataHandler;
   LoadAnnotations loadAnnotations;
   loadAnnotations.process(rawDataHandler, {}, filenames);
@@ -847,7 +847,7 @@ TEST(RawDataProcessor, gettersLoadTransitions)
 TEST(RawDataProcessor, processLoadTransitions_csv)
 {
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   RawDataHandler rawDataHandler;
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, {}, filenames);
@@ -871,7 +871,7 @@ TEST(RawDataProcessor, processLoadTransitions_csv)
 TEST(RawDataProcessor, processLoadTransitions_traML)
 {
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("LoadTransitions_test.TraML");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("LoadTransitions_test.TraML"));
   RawDataHandler rawDataHandler;
   LoadTransitions loadTransitions;
   map<std::string, vector<map<string, string>>> params_struct({
@@ -928,8 +928,8 @@ TEST(RawDataProcessor, processLoadFeatureFilters)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, {}, filenames);
@@ -971,8 +971,8 @@ TEST(RawDataProcessor, processLoadFeatureQCs)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.featureQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, {}, filenames);
@@ -1014,12 +1014,12 @@ TEST(RawDataProcessor, processStoreFeatureFilters)
   RawDataHandler rawDataHandler, rawDataHandler_test;
 
   Filenames filenames;
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, {}, filenames);
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureFiltersRDP storeFeatureFilters;
   storeFeatureFilters.process(rawDataHandler, {}, filenames);
   loadFeatureFilters.process(rawDataHandler_test, {}, filenames);
@@ -1066,12 +1066,12 @@ TEST(RawDataProcessor, processStoreFeatureQCs)
   RawDataHandler rawDataHandler, rawDataHandler_test;
 
   Filenames filenames;
-  filenames.featureQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, {}, filenames);
-  filenames.featureQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv");
-  filenames.featureQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureQCsRDP storeFeatureQCs;
   storeFeatureQCs.process(rawDataHandler, {}, filenames);
   loadFeatureQCs.process(rawDataHandler_test, {}, filenames);
@@ -1116,7 +1116,7 @@ TEST(RawDataProcessor, gettersLoadValidationData)
 TEST(RawDataProcessor, processLoadValidationData)
 {
   Filenames filenames;
-  filenames.referenceData_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv");
+  filenames.setFullPathName("referenceData_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv"));
   RawDataHandler rawDataHandler;
 
   LoadValidationData loadValidationData;
@@ -1257,11 +1257,11 @@ TEST(RawDataProcessor, pickFeaturesMRM)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler,params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -1336,7 +1336,7 @@ TEST(RawDataProcessor, pickMS1Features)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest_merged.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest_merged.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -1439,7 +1439,7 @@ TEST(RawDataProcessor, pickMS2Features)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_germicidin.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_germicidin.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -1533,7 +1533,7 @@ TEST(RawDataProcessor, searchAccurateMass)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
@@ -1542,7 +1542,7 @@ TEST(RawDataProcessor, searchAccurateMass)
   searchAccurateMass.process(rawDataHandler, params_1, filenames);
 
   // DELETE ME
-  filenames.featureXML_o = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest_accurateMassSearch.featureXML");
+  filenames.setFullPathName("featureXML_o", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest_accurateMassSearch.featureXML"));
   StoreFeatures storeFeatures;
   storeFeatures.process(rawDataHandler, params_1, filenames);
 
@@ -1625,7 +1625,7 @@ TEST(RawDataProcessor, consensusFeatures)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest_accurateMassSearch.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest_accurateMassSearch.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
@@ -1727,11 +1727,11 @@ TEST(RawDataProcessor, filterFeatures)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler,params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -1739,12 +1739,12 @@ TEST(RawDataProcessor, filterFeatures)
   MapChromatograms mapChroms;
   mapChroms.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, params_1, filenames);
 
@@ -1819,11 +1819,11 @@ TEST(RawDataProcessor, selectFeatures)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler,params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -1831,7 +1831,7 @@ TEST(RawDataProcessor, selectFeatures)
   MapChromatograms mapChroms;
   mapChroms.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_2_core_RawDataProcessor.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_2_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
@@ -1906,11 +1906,11 @@ TEST(RawDataProcessor, validateFeatures)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.referenceData_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv");
+  filenames.setFullPathName("referenceData_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv"));
   LoadValidationData loadValidationData;
   loadValidationData.process(rawDataHandler, params_1, filenames);
 
@@ -1989,7 +1989,7 @@ TEST(RawDataProcessor, quantifyComponents)
 {
   // Pre-requisites: load the parameters and associated raw data
   Filenames filenames;
-  filenames.quantitationMethods_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv");
+  filenames.setFullPathName("quantitationMethods_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv"));
   SequenceSegmentHandler sequenceSegmentHandler_IO;
   
   LoadQuantitationMethods loadQuantitationMethods;
@@ -1998,7 +1998,7 @@ TEST(RawDataProcessor, quantifyComponents)
   RawDataHandler rawDataHandler;
   rawDataHandler.setQuantitationMethods(sequenceSegmentHandler_IO.getQuantitationMethods());
 
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, {}, filenames);
 
@@ -2058,16 +2058,16 @@ TEST(RawDataProcessor, checkFeatures)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, params_1, filenames);
 
@@ -2127,11 +2127,11 @@ TEST(RawDataProcessor, filterFeaturesRSDs)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -2139,12 +2139,12 @@ TEST(RawDataProcessor, filterFeaturesRSDs)
   MapChromatograms mapChroms;
   mapChroms.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, params_1, filenames);
   rawDataHandler.setFeatureRSDFilter(rawDataHandler.getFeatureFilter()); // copy over the feature filter
@@ -2226,11 +2226,11 @@ TEST(RawDataProcessor, filterFeaturesBackgroundInterferences)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -2238,12 +2238,12 @@ TEST(RawDataProcessor, filterFeaturesBackgroundInterferences)
   MapChromatograms mapChroms;
   mapChroms.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, params_1, filenames);
   rawDataHandler.setFeatureBackgroundFilter(rawDataHandler.getFeatureFilter()); // copy over the feature filter
@@ -2320,16 +2320,16 @@ TEST(RawDataProcessor, checkFeaturesBackgroundInterferences)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv");
-  filenames.featureQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
+  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, params_1, filenames);
 
@@ -2396,16 +2396,16 @@ TEST(RawDataProcessor, checkFeaturesRSDs)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv");
-  filenames.featureQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
+  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, params_1, filenames);
   rawDataHandler.setFeatureRSDQC(rawDataHandler.getFeatureQC()); // copy over the feature filter
@@ -2446,25 +2446,26 @@ TEST(RawDataProcessor, process)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, params_1, filenames);
 
-  filenames.quantitationMethods_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv");
+  filenames.setFullPathName("quantitationMethods_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv"));
   SequenceSegmentHandler sequenceSegmentHandler_IO;
   LoadQuantitationMethods loadQuantitationMethods;
   loadQuantitationMethods.process(sequenceSegmentHandler_IO, SequenceHandler(), {}, filenames);
   rawDataHandler.setQuantitationMethods(sequenceSegmentHandler_IO.getQuantitationMethods());
 
   LoadFeatureQCsRDP loadFeatureQCs;
+  loadFeatureQCs.getInputsOutputs(filenames);
   loadFeatureQCs.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   params_1.addFunctionParameters(FunctionParameters("ChromatogramExtractor"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
@@ -2540,11 +2541,11 @@ TEST(RawDataProcessor, emg_processor)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler,params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -2592,11 +2593,11 @@ TEST(RawDataProcessor, emg_processor)
 
   // test feature storing
   RawDataHandler rawDataHandler2;
-  filenames.featureXML_o = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.featureXML");
+  filenames.setFullPathName("featureXML_o", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.featureXML"));
   StoreFeatures storeFeatures;
   storeFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler2, params_1, filenames);
 
@@ -2835,7 +2836,7 @@ TEST(RawDataProcessor, calculateMDVAccuracies)
 
   // for peptide SumFormula
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, {}, filenames);
   
@@ -2901,17 +2902,17 @@ TEST(RawDataProcessor, SearchSpectrum)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("dda_min_traML.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min_traML.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("dda_min.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
 
   LoadFeatures loadFeatures;
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("dda_min.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min.featureXML"));
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
   SearchSpectrum searchSpectrum;
@@ -2951,24 +2952,24 @@ TEST(RawDataProcessor, DDA)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.traML_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("dda_min_traML.csv");
+  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min_traML.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.mzML_i = SMARTPEAK_GET_TEST_DATA_PATH("dda_min.mzML");
+  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
 
   LoadFeatures loadFeatures;
-  filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH("dda_after_search.featureXML");
+  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_after_search.featureXML"));
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.traML_csv_o = std::tmpnam(nullptr);
+  filenames.setFullPathName("traML_csv_o", std::tmpnam(nullptr));
   DDA dda;
   dda.process(rawDataHandler, params_1, filenames);
 
-  EXPECT_TRUE(std::filesystem::exists(filenames.traML_csv_o));
+  EXPECT_TRUE(std::filesystem::exists(filenames.getFullPathName("traML_csv_o")));
   ASSERT_EQ(rawDataHandler.getFeatureMap().size(), 8);
   const auto& f = rawDataHandler.getFeatureMap()[0];
   std::cout << f.getMetaValue("PeptideRef").toString() << std::endl;

--- a/src/tests/class_tests/smartpeak/source/RawDataProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/RawDataProcessor_test.cpp
@@ -44,8 +44,8 @@ void load_data(
 )
 {
   Filenames filenames1, filenames2;
-  filenames1.setFullPathName("parameters_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_params_1_core_tmpFix.csv"));
-  filenames2.setFullPathName("parameters_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_params_2_tmpFix.csv"));
+  filenames1.setFullPath("parameters_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_params_1_core_tmpFix.csv"));
+  filenames2.setFullPath("parameters_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_params_2_tmpFix.csv"));
   RawDataHandler rawDataHandler;
   LoadParameters loadParameters;
   loadParameters.process(rawDataHandler, {}, filenames1);
@@ -89,11 +89,11 @@ TEST(RawDataProcessor, processorClearData)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   LoadRawData::extractMetaData(rawDataHandler);
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_test_1_io_FileReaderOpenMS.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_test_1_io_FileReaderOpenMS.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
@@ -151,7 +151,7 @@ TEST(RawDataProcessor, processorLoadRawData)
   params_I.addFunctionParameters(FunctionParameters("MRMMapping"));
 
   Filenames filenames;
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML"));
   processor.process(rawDataHandler, params_I, filenames);
 
   const vector<OpenMS::MSChromatogram>& chromatograms1 = rawDataHandler.getExperiment().getChromatograms();
@@ -182,7 +182,7 @@ TEST(RawDataProcessor, processorLoadRawData)
   params_I.at("mzML").addParameter(param);
   
   rawDataHandler.clear();
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_ChromeleonFile_10ug.txt"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_ChromeleonFile_10ug.txt"));
   processor.process(rawDataHandler, params_I, filenames);
 
   const vector<OpenMS::MSChromatogram>& chromatograms3 = rawDataHandler.getExperiment().getChromatograms();
@@ -210,11 +210,11 @@ TEST(RawDataProcessor, extractMetaData)
 
   // Pre-requisites: load the transitions and raw data
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, {}, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
 
@@ -304,11 +304,11 @@ TEST(RawDataProcessor, processorMapChromatograms)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -370,7 +370,7 @@ TEST(RawDataProcessor, processorZeroChromatogramBaseline)
   params_I.addFunctionParameters(FunctionParameters("ChromatogramExtractor"));
 
   Filenames filenames;
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_baseline_correction.mzML"));
   LoadRawData processor;
   processor.process(rawDataHandler, params_I, filenames);
   rawDataHandler.setChromatogramMap(rawDataHandler.getExperiment()); // Avoiding the mapping step for testing purposes
@@ -398,7 +398,7 @@ TEST(RawDataProcessor, processorZeroChromatogramBaseline)
   }};
   params_I.addFunctionParameters(FunctionParameters("mzML", params));
   rawDataHandler.clear();
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_ChromeleonFile_10ug.txt"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_ChromeleonFile_10ug.txt"));
   processor.process(rawDataHandler, params_I, filenames);
   rawDataHandler.setChromatogramMap(rawDataHandler.getExperiment()); // Avoiding the mapping step for testing purposes
   zeroChromBase.process(rawDataHandler, params_I, filenames);
@@ -448,11 +448,11 @@ TEST(RawDataProcessor, processorExtractChromatogramWindows)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -477,8 +477,8 @@ TEST(RawDataProcessor, processorExtractChromatogramWindows)
   EXPECT_NEAR(chromatograms1.back()[2].getMZ(), 914.139, 1e-3);
 
   // Test window extraction
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_extractChromWindowTest_1.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_extractChromWindowTest_1.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, {}, filenames);
 
@@ -535,7 +535,7 @@ TEST(RawDataProcessor, processorExtractSpectraWindows)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -590,7 +590,7 @@ TEST(RawDataProcessor, processorMergeSpectra)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -623,7 +623,7 @@ TEST(RawDataProcessor, processorMergeSpectraZeroPeak)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest_SpecWithZeroPeak.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest_SpecWithZeroPeak.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -673,7 +673,7 @@ TEST(RawDataProcessor, gettersLoadFeatures)
 TEST(RawDataProcessor, processLoadFeatures)
 {
   Filenames filenames;
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_test_1_io_FileReaderOpenMS.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_test_1_io_FileReaderOpenMS.featureXML"));
   RawDataHandler rawDataHandler;
   rawDataHandler.getMetaData().setFilename("filename");
   LoadFeatures loadFeatures;
@@ -775,7 +775,7 @@ TEST(RawDataProcessor, gettersLoadAnnotations)
 TEST(RawDataProcessor, processLoadAnnotations)
 {
   Filenames filenames;
-  filenames.setFullPathName("mzTab_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzTab"));
+  filenames.setFullPath("mzTab_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest.mzTab"));
   RawDataHandler rawDataHandler;
   LoadAnnotations loadAnnotations;
   loadAnnotations.process(rawDataHandler, {}, filenames);
@@ -847,7 +847,7 @@ TEST(RawDataProcessor, gettersLoadTransitions)
 TEST(RawDataProcessor, processLoadTransitions_csv)
 {
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   RawDataHandler rawDataHandler;
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, {}, filenames);
@@ -871,7 +871,7 @@ TEST(RawDataProcessor, processLoadTransitions_csv)
 TEST(RawDataProcessor, processLoadTransitions_traML)
 {
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("LoadTransitions_test.TraML"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("LoadTransitions_test.TraML"));
   RawDataHandler rawDataHandler;
   LoadTransitions loadTransitions;
   map<std::string, vector<map<string, string>>> params_struct({
@@ -928,8 +928,8 @@ TEST(RawDataProcessor, processLoadFeatureFilters)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, {}, filenames);
@@ -971,8 +971,8 @@ TEST(RawDataProcessor, processLoadFeatureQCs)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, {}, filenames);
@@ -1014,12 +1014,12 @@ TEST(RawDataProcessor, processStoreFeatureFilters)
   RawDataHandler rawDataHandler, rawDataHandler_test;
 
   Filenames filenames;
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, {}, filenames);
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureFiltersRDP storeFeatureFilters;
   storeFeatureFilters.process(rawDataHandler, {}, filenames);
   loadFeatureFilters.process(rawDataHandler_test, {}, filenames);
@@ -1066,12 +1066,12 @@ TEST(RawDataProcessor, processStoreFeatureQCs)
   RawDataHandler rawDataHandler, rawDataHandler_test;
 
   Filenames filenames;
-  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, {}, filenames);
-  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
-  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
+  filenames.setFullPath("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPath("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureQCsRDP storeFeatureQCs;
   storeFeatureQCs.process(rawDataHandler, {}, filenames);
   loadFeatureQCs.process(rawDataHandler_test, {}, filenames);
@@ -1116,7 +1116,7 @@ TEST(RawDataProcessor, gettersLoadValidationData)
 TEST(RawDataProcessor, processLoadValidationData)
 {
   Filenames filenames;
-  filenames.setFullPathName("referenceData_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv"));
+  filenames.setFullPath("referenceData_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv"));
   RawDataHandler rawDataHandler;
 
   LoadValidationData loadValidationData;
@@ -1257,11 +1257,11 @@ TEST(RawDataProcessor, pickFeaturesMRM)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler,params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -1336,7 +1336,7 @@ TEST(RawDataProcessor, pickMS1Features)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest_merged.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_SerumTest_merged.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -1439,7 +1439,7 @@ TEST(RawDataProcessor, pickMS2Features)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_germicidin.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_germicidin.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -1533,7 +1533,7 @@ TEST(RawDataProcessor, searchAccurateMass)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
@@ -1542,7 +1542,7 @@ TEST(RawDataProcessor, searchAccurateMass)
   searchAccurateMass.process(rawDataHandler, params_1, filenames);
 
   // DELETE ME
-  filenames.setFullPathName("featureXML_o", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest_accurateMassSearch.featureXML"));
+  filenames.setFullPath("featureXML_o", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest_accurateMassSearch.featureXML"));
   StoreFeatures storeFeatures;
   storeFeatures.process(rawDataHandler, params_1, filenames);
 
@@ -1625,7 +1625,7 @@ TEST(RawDataProcessor, consensusFeatures)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest_accurateMassSearch.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_serumTest_accurateMassSearch.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
@@ -1727,11 +1727,11 @@ TEST(RawDataProcessor, filterFeatures)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler,params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -1739,12 +1739,12 @@ TEST(RawDataProcessor, filterFeatures)
   MapChromatograms mapChroms;
   mapChroms.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, params_1, filenames);
 
@@ -1819,11 +1819,11 @@ TEST(RawDataProcessor, selectFeatures)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler,params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -1831,7 +1831,7 @@ TEST(RawDataProcessor, selectFeatures)
   MapChromatograms mapChroms;
   mapChroms.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_2_core_RawDataProcessor.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_2_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
@@ -1906,11 +1906,11 @@ TEST(RawDataProcessor, validateFeatures)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("referenceData_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv"));
+  filenames.setFullPath("referenceData_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("MRMFeatureValidator_referenceData_1.csv"));
   LoadValidationData loadValidationData;
   loadValidationData.process(rawDataHandler, params_1, filenames);
 
@@ -1989,7 +1989,7 @@ TEST(RawDataProcessor, quantifyComponents)
 {
   // Pre-requisites: load the parameters and associated raw data
   Filenames filenames;
-  filenames.setFullPathName("quantitationMethods_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv"));
+  filenames.setFullPath("quantitationMethods_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv"));
   SequenceSegmentHandler sequenceSegmentHandler_IO;
   
   LoadQuantitationMethods loadQuantitationMethods;
@@ -1998,7 +1998,7 @@ TEST(RawDataProcessor, quantifyComponents)
   RawDataHandler rawDataHandler;
   rawDataHandler.setQuantitationMethods(sequenceSegmentHandler_IO.getQuantitationMethods());
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, {}, filenames);
 
@@ -2058,16 +2058,16 @@ TEST(RawDataProcessor, checkFeatures)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, params_1, filenames);
 
@@ -2127,11 +2127,11 @@ TEST(RawDataProcessor, filterFeaturesRSDs)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -2139,12 +2139,12 @@ TEST(RawDataProcessor, filterFeaturesRSDs)
   MapChromatograms mapChroms;
   mapChroms.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, params_1, filenames);
   rawDataHandler.setFeatureRSDFilter(rawDataHandler.getFeatureFilter()); // copy over the feature filter
@@ -2226,11 +2226,11 @@ TEST(RawDataProcessor, filterFeaturesBackgroundInterferences)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -2238,12 +2238,12 @@ TEST(RawDataProcessor, filterFeaturesBackgroundInterferences)
   MapChromatograms mapChroms;
   mapChroms.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_1_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, params_1, filenames);
   rawDataHandler.setFeatureBackgroundFilter(rawDataHandler.getFeatureFilter()); // copy over the feature filter
@@ -2320,16 +2320,16 @@ TEST(RawDataProcessor, checkFeaturesBackgroundInterferences)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
-  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
+  filenames.setFullPath("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, params_1, filenames);
 
@@ -2396,16 +2396,16 @@ TEST(RawDataProcessor, checkFeaturesRSDs)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_test_3_core_RawDataProcessor.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
-  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponents_1.csv"));
+  filenames.setFullPath("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeaturersdqccomponentgroups_1.csv"));
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, params_1, filenames);
   rawDataHandler.setFeatureRSDQC(rawDataHandler.getFeatureQC()); // copy over the feature filter
@@ -2446,16 +2446,16 @@ TEST(RawDataProcessor, process)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureFiltersRDP loadFeatureFilters;
   loadFeatureFilters.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("quantitationMethods_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv"));
+  filenames.setFullPath("quantitationMethods_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv"));
   SequenceSegmentHandler sequenceSegmentHandler_IO;
   LoadQuantitationMethods loadQuantitationMethods;
   loadQuantitationMethods.process(sequenceSegmentHandler_IO, SequenceHandler(), {}, filenames);
@@ -2464,7 +2464,7 @@ TEST(RawDataProcessor, process)
   LoadFeatureQCsRDP loadFeatureQCs;
   loadFeatureQCs.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   params_1.addFunctionParameters(FunctionParameters("ChromatogramExtractor"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
@@ -2540,11 +2540,11 @@ TEST(RawDataProcessor, emg_processor)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler,params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
@@ -2592,11 +2592,11 @@ TEST(RawDataProcessor, emg_processor)
 
   // test feature storing
   RawDataHandler rawDataHandler2;
-  filenames.setFullPathName("featureXML_o", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.featureXML"));
+  filenames.setFullPath("featureXML_o", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.featureXML"));
   StoreFeatures storeFeatures;
   storeFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_mzML_1.featureXML"));
   LoadFeatures loadFeatures;
   loadFeatures.process(rawDataHandler2, params_1, filenames);
 
@@ -2835,7 +2835,7 @@ TEST(RawDataProcessor, calculateMDVAccuracies)
 
   // for peptide SumFormula
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_traML_1.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, {}, filenames);
   
@@ -2901,17 +2901,17 @@ TEST(RawDataProcessor, SearchSpectrum)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min_traML.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min_traML.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
 
   LoadFeatures loadFeatures;
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min.featureXML"));
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
   SearchSpectrum searchSpectrum;
@@ -2951,24 +2951,24 @@ TEST(RawDataProcessor, DDA)
   RawDataHandler rawDataHandler;
 
   Filenames filenames;
-  filenames.setFullPathName("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min_traML.csv"));
+  filenames.setFullPath("traML_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min_traML.csv"));
   LoadTransitions loadTransitions;
   loadTransitions.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min.mzML"));
+  filenames.setFullPath("mzML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_min.mzML"));
   LoadRawData loadRawData;
   loadRawData.process(rawDataHandler, params_1, filenames);
   loadRawData.extractMetaData(rawDataHandler);
 
   LoadFeatures loadFeatures;
-  filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_after_search.featureXML"));
+  filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH("dda_after_search.featureXML"));
   loadFeatures.process(rawDataHandler, params_1, filenames);
 
-  filenames.setFullPathName("traML_csv_o", std::tmpnam(nullptr));
+  filenames.setFullPath("traML_csv_o", std::tmpnam(nullptr));
   DDA dda;
   dda.process(rawDataHandler, params_1, filenames);
 
-  EXPECT_TRUE(std::filesystem::exists(filenames.getFullPathName("traML_csv_o")));
+  EXPECT_TRUE(std::filesystem::exists(filenames.getFullPath("traML_csv_o")));
   ASSERT_EQ(rawDataHandler.getFeatureMap().size(), 8);
   const auto& f = rawDataHandler.getFeatureMap()[0];
   std::cout << f.getMetaValue("PeptideRef").toString() << std::endl;

--- a/src/tests/class_tests/smartpeak/source/SampleGroupProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SampleGroupProcessor_test.cpp
@@ -400,7 +400,7 @@ TEST(SequenceHandler, processLoadFeaturesSampleGroup)
   // test store features
   LoadFeaturesSampleGroup process;
   Filenames filenames;
-  filenames.featureXMLSampleGroup_i = SMARTPEAK_GET_TEST_DATA_PATH(sampleGroupHandler.getSampleGroupName() + ".featureXML");
+  filenames.setFullPathName("featureXMLSampleGroup_i", SMARTPEAK_GET_TEST_DATA_PATH(sampleGroupHandler.getSampleGroupName() + ".featureXML"));
   process.process(sampleGroupHandler, sequenceHandler, {}, filenames);
 
   EXPECT_EQ(sampleGroupHandler.getFeatureMap().size(), 3);
@@ -514,7 +514,7 @@ TEST(SelectDilutionsParser, process_preferred)
   SampleGroupHandler sampleGroupHandler = sequenceHandler.getSampleGroups().front();
 
   Filenames filenames;
-  filenames.selectDilutions_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("SampleGroupProcessor_selectDilutions.csv");
+  filenames.setFullPathName("selectDilutions_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SampleGroupProcessor_selectDilutions.csv"));
   SelectDilutions select_dilutions;
   select_dilutions.process(sampleGroupHandler, sequenceHandler, select_dilutions_params, filenames);
 
@@ -621,7 +621,7 @@ TEST(SelectDilutionsParser, process_exclusive)
   ParameterSet params_exclusive(params_struct);
 
   Filenames filenames;
-  filenames.selectDilutions_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("SampleGroupProcessor_selectDilutions.csv");
+  filenames.setFullPathName("selectDilutions_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SampleGroupProcessor_selectDilutions.csv"));
   sampleGroupHandler.getFeatureMap().clear();
   SelectDilutions select_dilutions;
   select_dilutions.process(sampleGroupHandler, sequenceHandler, params_exclusive, filenames);

--- a/src/tests/class_tests/smartpeak/source/SampleGroupProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SampleGroupProcessor_test.cpp
@@ -400,7 +400,7 @@ TEST(SequenceHandler, processLoadFeaturesSampleGroup)
   // test store features
   LoadFeaturesSampleGroup process;
   Filenames filenames;
-  filenames.setFullPathName("featureXMLSampleGroup_i", SMARTPEAK_GET_TEST_DATA_PATH(sampleGroupHandler.getSampleGroupName() + ".featureXML"));
+  filenames.setFullPath("featureXMLSampleGroup_i", SMARTPEAK_GET_TEST_DATA_PATH(sampleGroupHandler.getSampleGroupName() + ".featureXML"));
   process.process(sampleGroupHandler, sequenceHandler, {}, filenames);
 
   EXPECT_EQ(sampleGroupHandler.getFeatureMap().size(), 3);
@@ -514,7 +514,7 @@ TEST(SelectDilutionsParser, process_preferred)
   SampleGroupHandler sampleGroupHandler = sequenceHandler.getSampleGroups().front();
 
   Filenames filenames;
-  filenames.setFullPathName("selectDilutions_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SampleGroupProcessor_selectDilutions.csv"));
+  filenames.setFullPath("selectDilutions_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SampleGroupProcessor_selectDilutions.csv"));
   SelectDilutions select_dilutions;
   select_dilutions.process(sampleGroupHandler, sequenceHandler, select_dilutions_params, filenames);
 
@@ -621,7 +621,7 @@ TEST(SelectDilutionsParser, process_exclusive)
   ParameterSet params_exclusive(params_struct);
 
   Filenames filenames;
-  filenames.setFullPathName("selectDilutions_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SampleGroupProcessor_selectDilutions.csv"));
+  filenames.setFullPath("selectDilutions_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SampleGroupProcessor_selectDilutions.csv"));
   sampleGroupHandler.getFeatureMap().clear();
   SelectDilutions select_dilutions;
   select_dilutions.process(sampleGroupHandler, sequenceHandler, params_exclusive, filenames);

--- a/src/tests/class_tests/smartpeak/source/SequenceParser_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceParser_test.cpp
@@ -67,7 +67,7 @@ struct SequenceParserFixture : public ::testing::Test
       metaDataHandler.scan_mass_low = 60;
 
       Filenames filenames;
-      filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH(metaDataHandler.getInjectionName() + ".featureXML");
+      filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH(metaDataHandler.getInjectionName() + ".featureXML"));
       RawDataHandler rawDataHandler;
       LoadFeatures loadFeatures;
       loadFeatures.process(rawDataHandler, {}, filenames);

--- a/src/tests/class_tests/smartpeak/source/SequenceParser_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceParser_test.cpp
@@ -67,7 +67,7 @@ struct SequenceParserFixture : public ::testing::Test
       metaDataHandler.scan_mass_low = 60;
 
       Filenames filenames;
-      filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH(metaDataHandler.getInjectionName() + ".featureXML"));
+      filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH(metaDataHandler.getInjectionName() + ".featureXML"));
       RawDataHandler rawDataHandler;
       LoadFeatures loadFeatures;
       loadFeatures.process(rawDataHandler, {}, filenames);

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -256,20 +256,18 @@ TEST(SequenceHandler, processSequence)
   std::map<std::string, Filenames> dynamic_filenames;
   Filenames methods_filenames;
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
-  methods_filenames.setRootPaths(path,
-    path + "mzML",
-    path + "features",
-    path + "features");
+  methods_filenames.setTag("MAIN_DIR", path);
+  methods_filenames.setTag("MZML_INPUT_PATH", path + "mzML");
+  methods_filenames.setTag("FEATURES_INPUT_PATH", path + "features");
+  methods_filenames.setTag("FEATURES_OUTPUT_PATH", path + "features");
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setFileVariants(
-      injection.getMetaData().getFilename(), // previous: injection.getMetaData().getSampleName(),
-      key,
-      key,
-      injection.getMetaData().getSampleGroupName(),
-      injection.getMetaData().getSampleGroupName()
-    );
+    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   EXPECT_EQ(sequenceHandler.getSequence().size(), dynamic_filenames.size());
@@ -343,21 +341,19 @@ TEST(SequenceHandler, processSequenceSegments)
 
   Filenames methods_filenames;
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
-  methods_filenames.setRootPaths(path,
-    path + "mzML/",
-    path + "features/",
-    path + "features/");
+  methods_filenames.setTag("MAIN_DIR", path);
+  methods_filenames.setTag("MZML_INPUT_PATH", path + "mzML");
+  methods_filenames.setTag("FEATURES_INPUT_PATH", path + "features");
+  methods_filenames.setTag("FEATURES_OUTPUT_PATH", path + "features");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string key = sequence_segment.getSequenceSegmentName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setFileVariants(
-      "",
-      key,
-      key,
-      key,
-      key
-    );
+    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", "");
+    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", key);
+    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", key);
   }
 
   // Default sequence segment names (i.e., all)
@@ -432,17 +428,15 @@ TEST(SequenceHandler, processSampleGroups)
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setRootPaths(path,
-      path,
-      path,
-      path);
-    dynamic_filenames[key].setFileVariants(
-      injection.getMetaData().getFilename(),
-      key,
-      key,
-      injection.getMetaData().getSampleGroupName(),
-      injection.getMetaData().getSampleGroupName()
-    );
+    dynamic_filenames[key].setTag("MAIN_DIR", path);
+    dynamic_filenames[key].setTag("MZML_INPUT_PATH", path);
+    dynamic_filenames[key].setTag("FEATURES_INPUT_PATH", path);
+    dynamic_filenames[key].setTag("FEATURES_OUTPUT_PATH", path);
+    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
+    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -454,19 +448,17 @@ TEST(SequenceHandler, processSampleGroups)
   { std::make_shared<MergeInjections>() };
   dynamic_filenames.clear();
   Filenames methods_filenames2;
-  methods_filenames2.setRootPaths(path,
-    path + "mzML/",
-    path + "features/",
-    path + "features/");
+  methods_filenames2.setTag("MAIN_DIR", path);
+  methods_filenames2.setTag("MZML_INPUT_PATH", path + "mzML");
+  methods_filenames2.setTag("FEATURES_INPUT_PATH", path + "features");
+  methods_filenames2.setTag("FEATURES_OUTPUT_PATH", path + "features");
   for (const SampleGroupHandler& sampleGroupHandler : sequenceHandler.getSampleGroups()) {
     dynamic_filenames[sampleGroupHandler.getSampleGroupName()] = methods_filenames2;
-    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setFileVariants(
-      "",
-      sampleGroupHandler.getSampleGroupName(),
-      sampleGroupHandler.getSampleGroupName(),
-      sampleGroupHandler.getSampleGroupName(),
-      sampleGroupHandler.getSampleGroupName()
-    );
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag("INPUT_MZML_FILENAME", "");
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag("INPUT_INJECTION_NAME", sampleGroupHandler.getSampleGroupName());
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag("OUTPUT_INJECTION_NAME", sampleGroupHandler.getSampleGroupName());
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag("INPUT_GROUP_NAME", sampleGroupHandler.getSampleGroupName());
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag("OUTPUT_GROUP_NAME", sampleGroupHandler.getSampleGroupName());
   }
 
   // Default sample group names (i.e., all)

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -62,7 +62,7 @@ TEST(SequenceHandler, createSequence_onFilePicked)
   CreateSequence cs(sequenceHandler);
   std::string datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
-  Filenames filenames_;
+  Filenames filenames_ = generateTestFilenames();
   cs.getInputsOutputs(filenames_);
   cs.onFilePicked(filenames_.getFullPathName("sequence_csv_i"), &ah);
 
@@ -85,10 +85,12 @@ TEST(SequenceHandler, createSequence_onFilePicked_windows_separators)
   CreateSequence cs(sequenceHandler);
   std::string datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
-  auto filenames_ = Filenames::getDefaultStaticFilenames(workflow.string());
+  Filenames filenames_ = generateTestFilenames();
+  std::string full_name = filenames_.getFullPathName("sequence_csv_i");
   // replace separators (this way of specifying filename can happen with command line interface actually)
-  std::replace(filenames_.sequence_csv_i.begin(), filenames_.sequence_csv_i.end(), '/', '\\');
-  cs.onFilePicked(filenames_.sequence_csv_i, &ah);
+  std::replace(full_name.begin(), full_name.end(), '/', '\\');
+  filenames_.setFullPathName("sequence_csv_i", full_name);
+  cs.onFilePicked(filenames_.getFullPathName("sequence_csv_i"), &ah);
 
   ASSERT_EQ(sequenceHandler.getSequence().size(), 2);
   InjectionHandler& injection0 = sequenceHandler.getSequence()[0];

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -584,7 +584,7 @@ TEST(SequenceHandler, LoadWorkflow1)
   } workflow_observer;
   sequenceHandler.addWorkflowObserver(&workflow_observer);
   LoadWorkflow processor(sequenceHandler);
-  processor.filename_ = SMARTPEAK_GET_TEST_DATA_PATH("SequenceProcessor_workflow.csv");
+  processor.filenames_.setFullPath("workflow_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SequenceProcessor_workflow.csv"));
   processor.process();
   const auto& commands = sequenceHandler.getWorkflow();
   std::vector<std::string> expected_command_names = {

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -87,7 +87,7 @@ TEST(SequenceHandler, createSequence_onFilePicked_windows_separators)
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
   Filenames filenames_;
   filenames_.setFullPath("sequence_csv_i", workflow / "sequence.csv");
-  std::string full_name = filenames_.getFullPath("sequence_csv_i");
+  std::string full_name = filenames_.getFullPath("sequence_csv_i").generic_string();
   // replace separators (this way of specifying filename can happen with command line interface actually)
   std::replace(full_name.begin(), full_name.end(), '/', '\\');
   filenames_.setFullPath("sequence_csv_i", full_name);

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -35,23 +35,23 @@ Filenames generateTestFilenames()
 {
   const std::string dir = SMARTPEAK_GET_TEST_DATA_PATH("");
   Filenames filenames;
-  filenames.setFullPathName("sequence_csv_i"                                , dir + "SequenceProcessor_sequence.csv");
-  filenames.setFullPathName("parameters_csv_i"                              , dir + "RawDataProcessor_params_1_core.csv");
-  filenames.setFullPathName("traML_csv_i"                                   , dir + "OpenMSFile_traML_1.csv");
-  filenames.setFullPathName("featureFilterComponents_csv_i"                 , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i"            , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
-  filenames.setFullPathName("featureQCComponents_csv_i"                     , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.setFullPathName("featureQCComponentGroups_csv_i"                , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
-  filenames.setFullPathName("featureRSDFilterComponents_csv_i"              , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i"         , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
-  filenames.setFullPathName("featureRSDQCComponents_csv_i"                  , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.setFullPathName("featureRSDQCComponentGroups_csv_i"             , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
-  filenames.setFullPathName("featureBackgroundFilterComponents_csv_i"       , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i"  , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
-  filenames.setFullPathName("featureBackgroundQCComponents_csv_i"           , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i"      , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
-  filenames.setFullPathName("quantitationMethods_csv_i"                     , dir + "OpenMSFile_quantitationMethods_1.csv");
-  filenames.setFullPathName("standardsConcentrations_csv_i"                 , dir + "OpenMSFile_standardsConcentrations_1.csv");
+  filenames.setFullPath("sequence_csv_i"                                , dir + "SequenceProcessor_sequence.csv");
+  filenames.setFullPath("parameters_csv_i"                              , dir + "RawDataProcessor_params_1_core.csv");
+  filenames.setFullPath("traML_csv_i"                                   , dir + "OpenMSFile_traML_1.csv");
+  filenames.setFullPath("featureFilterComponents_csv_i"                 , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPath("featureFilterComponentGroups_csv_i"            , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPath("featureQCComponents_csv_i"                     , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPath("featureQCComponentGroups_csv_i"                , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPath("featureRSDFilterComponents_csv_i"              , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPath("featureRSDFilterComponentGroups_csv_i"         , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPath("featureRSDQCComponents_csv_i"                  , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPath("featureRSDQCComponentGroups_csv_i"             , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPath("featureBackgroundFilterComponents_csv_i"       , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPath("featureBackgroundFilterComponentGroups_csv_i"  , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPath("featureBackgroundQCComponents_csv_i"           , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPath("featureBackgroundQCComponentGroups_csv_i"      , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPath("quantitationMethods_csv_i"                     , dir + "OpenMSFile_quantitationMethods_1.csv");
+  filenames.setFullPath("standardsConcentrations_csv_i"                 , dir + "OpenMSFile_standardsConcentrations_1.csv");
   return filenames;
 }
 
@@ -63,8 +63,8 @@ TEST(SequenceHandler, createSequence_onFilePicked)
   std::string datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
   Filenames filenames_;
-  filenames_.setFullPathName("sequence_csv_i", workflow / "sequence.csv");
-  cs.onFilePicked(filenames_.getFullPathName("sequence_csv_i"), &ah);
+  filenames_.setFullPath("sequence_csv_i", workflow / "sequence.csv");
+  cs.onFilePicked(filenames_.getFullPath("sequence_csv_i"), &ah);
 
   ASSERT_EQ(sequenceHandler.getSequence().size(), 2);
   InjectionHandler& injection0 = sequenceHandler.getSequence()[0];
@@ -86,12 +86,12 @@ TEST(SequenceHandler, createSequence_onFilePicked_windows_separators)
   std::string datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
   Filenames filenames_;
-  filenames_.setFullPathName("sequence_csv_i", workflow / "sequence.csv");
-  std::string full_name = filenames_.getFullPathName("sequence_csv_i");
+  filenames_.setFullPath("sequence_csv_i", workflow / "sequence.csv");
+  std::string full_name = filenames_.getFullPath("sequence_csv_i");
   // replace separators (this way of specifying filename can happen with command line interface actually)
   std::replace(full_name.begin(), full_name.end(), '/', '\\');
-  filenames_.setFullPathName("sequence_csv_i", full_name);
-  cs.onFilePicked(filenames_.getFullPathName("sequence_csv_i"), &ah);
+  filenames_.setFullPath("sequence_csv_i", full_name);
+  cs.onFilePicked(filenames_.getFullPath("sequence_csv_i"), &ah);
 
   ASSERT_EQ(sequenceHandler.getSequence().size(), 2);
   InjectionHandler& injection0 = sequenceHandler.getSequence()[0];
@@ -223,7 +223,7 @@ TEST(SequenceHandler, createSequence)
 
   sequenceHandler.clear();
   Filenames filenames { generateTestFilenames() };
-  filenames.setFullPathName("sequence_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SequenceProcessor_empty_sequence.csv"));
+  filenames.setFullPath("sequence_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SequenceProcessor_empty_sequence.csv"));
 
   cs.filenames_ = filenames;
   cs.process();

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -63,7 +63,6 @@ TEST(SequenceHandler, createSequence_onFilePicked)
   std::string datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
   Filenames filenames_ = generateTestFilenames();
-  cs.getInputsOutputs(filenames_);
   cs.onFilePicked(filenames_.getFullPathName("sequence_csv_i"), &ah);
 
   ASSERT_EQ(sequenceHandler.getSequence().size(), 2);
@@ -259,21 +258,16 @@ TEST(SequenceHandler, processSequence)
     path + "mzML",
     path + "features",
     path + "features");
-  for (const auto& m : raw_data_processing_methods)
-  {
-    m->getInputsOutputs(methods_filenames);
-  }
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string key = injection.getMetaData().getInjectionName();
-    Filenames injection_filenames = methods_filenames;
-    injection_filenames.setFileVariants(
+    dynamic_filenames[key] = methods_filenames;
+    dynamic_filenames[key].setFileVariants(
       injection.getMetaData().getFilename(), // previous: injection.getMetaData().getSampleName(),
       key,
       key,
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
-    dynamic_filenames[key] = injection_filenames;
   }
 
   EXPECT_EQ(sequenceHandler.getSequence().size(), dynamic_filenames.size());
@@ -351,22 +345,17 @@ TEST(SequenceHandler, processSequenceSegments)
     path + "mzML/",
     path + "features/",
     path + "features/");
-  for (const auto& m : sequence_segment_processing_methods)
-  {
-    m->getInputsOutputs(methods_filenames);
-  }
   std::map<std::string, Filenames> dynamic_filenames;
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string key = sequence_segment.getSequenceSegmentName();
-    Filenames sequence_segment_filenames = methods_filenames;
-    sequence_segment_filenames.setFileVariants(
+    dynamic_filenames[key] = methods_filenames;
+    dynamic_filenames[key].setFileVariants(
       "",
       key,
       key,
       key,
       key
     );
-    dynamic_filenames[key] = sequence_segment_filenames;
   }
 
   // Default sequence segment names (i.e., all)
@@ -436,27 +425,22 @@ TEST(SequenceHandler, processSampleGroups)
   // Load in the raw data featureMaps
   const vector<std::shared_ptr<RawDataProcessor>> raw_data_processing_methods = { std::make_shared<LoadFeatures>() };
   Filenames methods_filenames;
-  for (const auto& m : raw_data_processing_methods)
-  {
-    m->getInputsOutputs(methods_filenames);
-  }
   std::map<std::string, Filenames> dynamic_filenames;
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
-    Filenames injection_filenames = methods_filenames;
     const std::string key = injection.getMetaData().getInjectionName();
-    injection_filenames.setRootPaths(path,
+    dynamic_filenames[key] = methods_filenames;
+    dynamic_filenames[key].setRootPaths(path,
       path,
       path,
       path);
-    injection_filenames.setFileVariants(
+    dynamic_filenames[key].setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
-    dynamic_filenames[key] = injection_filenames;
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -472,20 +456,15 @@ TEST(SequenceHandler, processSampleGroups)
     path + "mzML/",
     path + "features/",
     path + "features/");
-  for (const auto& m : raw_data_processing_methods)
-  {
-    m->getInputsOutputs(methods_filenames2);
-  }
   for (const SampleGroupHandler& sampleGroupHandler : sequenceHandler.getSampleGroups()) {
-    Filenames sample_group_filenames = methods_filenames2;
-    sample_group_filenames.setFileVariants(
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()] = methods_filenames2;
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setFileVariants(
       "",
       sampleGroupHandler.getSampleGroupName(),
       sampleGroupHandler.getSampleGroupName(),
       sampleGroupHandler.getSampleGroupName(),
       sampleGroupHandler.getSampleGroupName()
     );
-    dynamic_filenames[sampleGroupHandler.getSampleGroupName()] = sample_group_filenames;
   }
 
   // Default sample group names (i.e., all)

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -257,9 +257,9 @@ TEST(SequenceHandler, processSequence)
   Filenames methods_filenames;
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   methods_filenames.setTag("MAIN_DIR", path);
-  methods_filenames.setTag("MZML_INPUT_PATH", path + "mzML");
-  methods_filenames.setTag("FEATURES_INPUT_PATH", path + "features");
-  methods_filenames.setTag("FEATURES_OUTPUT_PATH", path + "features");
+  methods_filenames.setTag("MZML_INPUT_PATH", path + "/mzML");
+  methods_filenames.setTag("FEATURES_INPUT_PATH", path + "/features");
+  methods_filenames.setTag("FEATURES_OUTPUT_PATH", path + "/features");
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -226,19 +226,19 @@ TEST(SequenceHandler, processSequence)
 
   std::map<std::string, Filenames> dynamic_filenames;
   Filenames methods_filenames;
+  const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
+  methods_filenames.setRootPaths(path,
+    path + "mzML",
+    path + "features",
+    path + "features");
   for (const auto& m : raw_data_processing_methods)
   {
     m->getInputsOutputs(methods_filenames);
   }
-  const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string key = injection.getMetaData().getInjectionName();
     Filenames injection_filenames = methods_filenames;
-    injection_filenames.setPathsAndNames(
-      path,
-      path + "mzML",
-      path + "features",
-      path + "features",
+    injection_filenames.setFileVariants(
       injection.getMetaData().getFilename(), // previous: injection.getMetaData().getSampleName(),
       key,
       key,
@@ -318,20 +318,20 @@ TEST(SequenceHandler, processSequenceSegments)
     { std::make_shared<CalculateCalibration>() };
 
   Filenames methods_filenames;
+  const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
+  methods_filenames.setRootPaths(path,
+    path + "mzML/",
+    path + "features/",
+    path + "features/");
   for (const auto& m : sequence_segment_processing_methods)
   {
     m->getInputsOutputs(methods_filenames);
   }
   std::map<std::string, Filenames> dynamic_filenames;
-  const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string key = sequence_segment.getSequenceSegmentName();
     Filenames sequence_segment_filenames = methods_filenames;
-    sequence_segment_filenames.setPathsAndNames(
-      path,
-      path + "mzML/",
-      path + "features/",
-      path + "features/",
+    sequence_segment_filenames.setFileVariants(
       "",
       key,
       key,
@@ -417,11 +417,11 @@ TEST(SequenceHandler, processSampleGroups)
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     Filenames injection_filenames = methods_filenames;
     const std::string key = injection.getMetaData().getInjectionName();
-    injection_filenames.setPathsAndNames(
+    injection_filenames.setRootPaths(path,
       path,
       path,
-      path,
-      path,
+      path);
+    injection_filenames.setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
@@ -440,17 +440,17 @@ TEST(SequenceHandler, processSampleGroups)
   { std::make_shared<MergeInjections>() };
   dynamic_filenames.clear();
   Filenames methods_filenames2;
+  methods_filenames2.setRootPaths(path,
+    path + "mzML/",
+    path + "features/",
+    path + "features/");
   for (const auto& m : raw_data_processing_methods)
   {
     m->getInputsOutputs(methods_filenames2);
   }
   for (const SampleGroupHandler& sampleGroupHandler : sequenceHandler.getSampleGroups()) {
     Filenames sample_group_filenames = methods_filenames2;
-    sample_group_filenames.setPathsAndNames(
-      path,
-      path + "mzML/",
-      path + "features/",
-      path + "features/",
+    sample_group_filenames.setFileVariants(
       "",
       sampleGroupHandler.getSampleGroupName(),
       sampleGroupHandler.getSampleGroupName(),

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -35,23 +35,23 @@ Filenames generateTestFilenames()
 {
   const std::string dir = SMARTPEAK_GET_TEST_DATA_PATH("");
   Filenames filenames;
-  filenames.sequence_csv_i                                = dir + "SequenceProcessor_sequence.csv";
-  filenames.parameters_csv_i                              = dir + "RawDataProcessor_params_1_core.csv";
-  filenames.traML_csv_i                                   = dir + "OpenMSFile_traML_1.csv";
-  filenames.featureFilterComponents_csv_i                 = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureFilterComponentGroups_csv_i            = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.featureQCComponents_csv_i                     = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureQCComponentGroups_csv_i                = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.featureRSDFilterComponents_csv_i              = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureRSDFilterComponentGroups_csv_i         = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.featureRSDQCComponents_csv_i                  = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureRSDQCComponentGroups_csv_i             = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.featureBackgroundFilterComponents_csv_i       = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureBackgroundFilterComponentGroups_csv_i  = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.featureBackgroundQCComponents_csv_i           = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureBackgroundQCComponentGroups_csv_i      = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.quantitationMethods_csv_i                     = dir + "OpenMSFile_quantitationMethods_1.csv";
-  filenames.standardsConcentrations_csv_i                 = dir + "OpenMSFile_standardsConcentrations_1.csv";
+  filenames.setFullPathName("sequence_csv_i"                                , dir + "SequenceProcessor_sequence.csv");
+  filenames.setFullPathName("parameters_csv_i"                              , dir + "RawDataProcessor_params_1_core.csv");
+  filenames.setFullPathName("traML_csv_i"                                   , dir + "OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i"                 , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i"            , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i"                     , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureQCComponentGroups_csv_i"                , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureRSDFilterComponents_csv_i"              , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i"         , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureRSDQCComponents_csv_i"                  , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureRSDQCComponentGroups_csv_i"             , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureBackgroundFilterComponents_csv_i"       , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i"  , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureBackgroundQCComponents_csv_i"           , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i"      , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("quantitationMethods_csv_i"                     , dir + "OpenMSFile_quantitationMethods_1.csv");
+  filenames.setFullPathName("standardsConcentrations_csv_i"                 , dir + "OpenMSFile_standardsConcentrations_1.csv");
   return filenames;
 }
 
@@ -62,8 +62,8 @@ TEST(SequenceHandler, createSequence_onFilePicked)
   CreateSequence cs(sequenceHandler);
   std::string datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
-  auto filenames_ = Filenames::getDefaultStaticFilenames(workflow.string());
-  cs.onFilePicked(filenames_.sequence_csv_i, &ah);
+  Filenames filenames_;
+  cs.onFilePicked(filenames_.getFullPathName("sequence_csv_i"), &ah);
 
   EXPECT_EQ(sequenceHandler.getSequence().size(), 2);
   InjectionHandler& injection0 = sequenceHandler.getSequence()[0];
@@ -194,7 +194,7 @@ TEST(SequenceHandler, createSequence)
 
   sequenceHandler.clear();
   Filenames filenames { generateTestFilenames() };
-  filenames.sequence_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("SequenceProcessor_empty_sequence.csv");
+  filenames.setFullPathName("sequence_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SequenceProcessor_empty_sequence.csv"));
 
   cs.filenames_ = filenames;
   cs.process();
@@ -225,10 +225,16 @@ TEST(SequenceHandler, processSequence)
   EXPECT_EQ(rawDataHandler0.getExperiment().getChromatograms().size(), 0); // empty (not loaded, yet)
 
   std::map<std::string, Filenames> dynamic_filenames;
+  Filenames methods_filenames;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames);
+  }
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    Filenames injection_filenames = methods_filenames;
+    injection_filenames.setPathsAndNames(
       path,
       path + "mzML",
       path + "features",
@@ -239,6 +245,7 @@ TEST(SequenceHandler, processSequence)
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
+    dynamic_filenames[key] = injection_filenames;
   }
 
   EXPECT_EQ(sequenceHandler.getSequence().size(), dynamic_filenames.size());
@@ -310,11 +317,17 @@ TEST(SequenceHandler, processSequenceSegments)
   const vector<std::shared_ptr<SequenceSegmentProcessor>> sequence_segment_processing_methods =
     { std::make_shared<CalculateCalibration>() };
 
+  Filenames methods_filenames;
+  for (const auto& m : sequence_segment_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames);
+  }
   std::map<std::string, Filenames> dynamic_filenames;
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string key = sequence_segment.getSequenceSegmentName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    Filenames sequence_segment_filenames = methods_filenames;
+    sequence_segment_filenames.setPathsAndNames(
       path,
       path + "mzML/",
       path + "features/",
@@ -325,6 +338,7 @@ TEST(SequenceHandler, processSequenceSegments)
       key,
       key
     );
+    dynamic_filenames[key] = sequence_segment_filenames;
   }
 
   // Default sequence segment names (i.e., all)
@@ -391,12 +405,19 @@ TEST(SequenceHandler, processSampleGroups)
   cs.checkConsistency = false;
   cs.process();
 
-  // Generate the filenames
+  // Load in the raw data featureMaps
+  const vector<std::shared_ptr<RawDataProcessor>> raw_data_processing_methods = { std::make_shared<LoadFeatures>() };
+  Filenames methods_filenames;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames);
+  }
   std::map<std::string, Filenames> dynamic_filenames;
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
+    Filenames injection_filenames = methods_filenames;
     const std::string key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    injection_filenames.setPathsAndNames(
       path,
       path,
       path,
@@ -407,19 +428,25 @@ TEST(SequenceHandler, processSampleGroups)
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
+    dynamic_filenames[key] = injection_filenames;
   }
 
-  // Load in the raw data featureMaps
-  const vector<std::shared_ptr<RawDataProcessor>> raw_data_processing_methods = { std::make_shared<LoadFeatures>() };
   ProcessSequence ps(sequenceHandler);
   ps.filenames_ = dynamic_filenames;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;
   ps.process();
 
-  // Update the filenames
+  const vector<std::shared_ptr<SampleGroupProcessor>> sample_group_processing_methods =
+  { std::make_shared<MergeInjections>() };
   dynamic_filenames.clear();
+  Filenames methods_filenames2;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames2);
+  }
   for (const SampleGroupHandler& sampleGroupHandler : sequenceHandler.getSampleGroups()) {
-    dynamic_filenames[sampleGroupHandler.getSampleGroupName()] = Filenames::getDefaultDynamicFilenames(
+    Filenames sample_group_filenames = methods_filenames2;
+    sample_group_filenames.setPathsAndNames(
       path,
       path + "mzML/",
       path + "features/",
@@ -430,10 +457,8 @@ TEST(SequenceHandler, processSampleGroups)
       sampleGroupHandler.getSampleGroupName(),
       sampleGroupHandler.getSampleGroupName()
     );
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()] = sample_group_filenames;
   }
-
-  const vector<std::shared_ptr<SampleGroupProcessor>> sample_group_processing_methods =
-  { std::make_shared<MergeInjections>() };
 
   // Default sample group names (i.e., all)
   ProcessSampleGroups psg(sequenceHandler);

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -256,18 +256,18 @@ TEST(SequenceHandler, processSequence)
   std::map<std::string, Filenames> dynamic_filenames;
   Filenames methods_filenames;
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
-  methods_filenames.setTag("MAIN_DIR", path);
-  methods_filenames.setTag("MZML_INPUT_PATH", path + "/mzML");
-  methods_filenames.setTag("FEATURES_INPUT_PATH", path + "/features");
-  methods_filenames.setTag("FEATURES_OUTPUT_PATH", path + "/features");
+  methods_filenames.setTag(Filenames::Tag::MAIN_DIR, path);
+  methods_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, path + "/mzML");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, path + "/features");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, path + "/features");
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   EXPECT_EQ(sequenceHandler.getSequence().size(), dynamic_filenames.size());
@@ -341,19 +341,19 @@ TEST(SequenceHandler, processSequenceSegments)
 
   Filenames methods_filenames;
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
-  methods_filenames.setTag("MAIN_DIR", path);
-  methods_filenames.setTag("MZML_INPUT_PATH", path + "mzML");
-  methods_filenames.setTag("FEATURES_INPUT_PATH", path + "features");
-  methods_filenames.setTag("FEATURES_OUTPUT_PATH", path + "features");
+  methods_filenames.setTag(Filenames::Tag::MAIN_DIR, path);
+  methods_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, path + "mzML");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, path + "features");
+  methods_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, path + "features");
   std::map<std::string, Filenames> dynamic_filenames;
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string key = sequence_segment.getSequenceSegmentName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", "");
-    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", key);
-    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", key);
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, "");
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, key);
   }
 
   // Default sequence segment names (i.e., all)
@@ -428,15 +428,15 @@ TEST(SequenceHandler, processSampleGroups)
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string key = injection.getMetaData().getInjectionName();
     dynamic_filenames[key] = methods_filenames;
-    dynamic_filenames[key].setTag("MAIN_DIR", path);
-    dynamic_filenames[key].setTag("MZML_INPUT_PATH", path);
-    dynamic_filenames[key].setTag("FEATURES_INPUT_PATH", path);
-    dynamic_filenames[key].setTag("FEATURES_OUTPUT_PATH", path);
-    dynamic_filenames[key].setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-    dynamic_filenames[key].setTag("INPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("OUTPUT_INJECTION_NAME", key);
-    dynamic_filenames[key].setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-    dynamic_filenames[key].setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::MAIN_DIR, path);
+    dynamic_filenames[key].setTag(Filenames::Tag::MZML_INPUT_PATH, path);
+    dynamic_filenames[key].setTag(Filenames::Tag::FEATURES_INPUT_PATH, path);
+    dynamic_filenames[key].setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, path);
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, key);
+    dynamic_filenames[key].setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+    dynamic_filenames[key].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
   }
 
   ProcessSequence ps(sequenceHandler);
@@ -448,17 +448,17 @@ TEST(SequenceHandler, processSampleGroups)
   { std::make_shared<MergeInjections>() };
   dynamic_filenames.clear();
   Filenames methods_filenames2;
-  methods_filenames2.setTag("MAIN_DIR", path);
-  methods_filenames2.setTag("MZML_INPUT_PATH", path + "mzML");
-  methods_filenames2.setTag("FEATURES_INPUT_PATH", path + "features");
-  methods_filenames2.setTag("FEATURES_OUTPUT_PATH", path + "features");
+  methods_filenames2.setTag(Filenames::Tag::MAIN_DIR, path);
+  methods_filenames2.setTag(Filenames::Tag::MZML_INPUT_PATH, path + "mzML");
+  methods_filenames2.setTag(Filenames::Tag::FEATURES_INPUT_PATH, path + "features");
+  methods_filenames2.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, path + "features");
   for (const SampleGroupHandler& sampleGroupHandler : sequenceHandler.getSampleGroups()) {
     dynamic_filenames[sampleGroupHandler.getSampleGroupName()] = methods_filenames2;
-    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag("INPUT_MZML_FILENAME", "");
-    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag("INPUT_INJECTION_NAME", sampleGroupHandler.getSampleGroupName());
-    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag("OUTPUT_INJECTION_NAME", sampleGroupHandler.getSampleGroupName());
-    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag("INPUT_GROUP_NAME", sampleGroupHandler.getSampleGroupName());
-    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag("OUTPUT_GROUP_NAME", sampleGroupHandler.getSampleGroupName());
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag(Filenames::Tag::INPUT_MZML_FILENAME, "");
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag(Filenames::Tag::INPUT_INJECTION_NAME, sampleGroupHandler.getSampleGroupName());
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, sampleGroupHandler.getSampleGroupName());
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag(Filenames::Tag::INPUT_GROUP_NAME, sampleGroupHandler.getSampleGroupName());
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()].setTag(Filenames::Tag::OUTPUT_GROUP_NAME, sampleGroupHandler.getSampleGroupName());
   }
 
   // Default sample group names (i.e., all)

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -63,6 +63,7 @@ TEST(SequenceHandler, createSequence_onFilePicked)
   std::string datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
   Filenames filenames_;
+  cs.getInputsOutputs(filenames_);
   cs.onFilePicked(filenames_.getFullPathName("sequence_csv_i"), &ah);
 
   ASSERT_EQ(sequenceHandler.getSequence().size(), 2);

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -251,19 +251,19 @@ TEST(SequenceHandler, processSequence)
 
   std::map<std::string, Filenames> dynamic_filenames;
   Filenames methods_filenames;
+  const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
+  methods_filenames.setRootPaths(path,
+    path + "mzML",
+    path + "features",
+    path + "features");
   for (const auto& m : raw_data_processing_methods)
   {
     m->getInputsOutputs(methods_filenames);
   }
-  const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string key = injection.getMetaData().getInjectionName();
     Filenames injection_filenames = methods_filenames;
-    injection_filenames.setPathsAndNames(
-      path,
-      path + "mzML",
-      path + "features",
-      path + "features",
+    injection_filenames.setFileVariants(
       injection.getMetaData().getFilename(), // previous: injection.getMetaData().getSampleName(),
       key,
       key,
@@ -343,20 +343,20 @@ TEST(SequenceHandler, processSequenceSegments)
     { std::make_shared<CalculateCalibration>() };
 
   Filenames methods_filenames;
+  const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
+  methods_filenames.setRootPaths(path,
+    path + "mzML/",
+    path + "features/",
+    path + "features/");
   for (const auto& m : sequence_segment_processing_methods)
   {
     m->getInputsOutputs(methods_filenames);
   }
   std::map<std::string, Filenames> dynamic_filenames;
-  const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string key = sequence_segment.getSequenceSegmentName();
     Filenames sequence_segment_filenames = methods_filenames;
-    sequence_segment_filenames.setPathsAndNames(
-      path,
-      path + "mzML/",
-      path + "features/",
-      path + "features/",
+    sequence_segment_filenames.setFileVariants(
       "",
       key,
       key,
@@ -442,11 +442,11 @@ TEST(SequenceHandler, processSampleGroups)
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     Filenames injection_filenames = methods_filenames;
     const std::string key = injection.getMetaData().getInjectionName();
-    injection_filenames.setPathsAndNames(
+    injection_filenames.setRootPaths(path,
       path,
       path,
-      path,
-      path,
+      path);
+    injection_filenames.setFileVariants(
       injection.getMetaData().getFilename(),
       key,
       key,
@@ -465,17 +465,17 @@ TEST(SequenceHandler, processSampleGroups)
   { std::make_shared<MergeInjections>() };
   dynamic_filenames.clear();
   Filenames methods_filenames2;
+  methods_filenames2.setRootPaths(path,
+    path + "mzML/",
+    path + "features/",
+    path + "features/");
   for (const auto& m : raw_data_processing_methods)
   {
     m->getInputsOutputs(methods_filenames2);
   }
   for (const SampleGroupHandler& sampleGroupHandler : sequenceHandler.getSampleGroups()) {
     Filenames sample_group_filenames = methods_filenames2;
-    sample_group_filenames.setPathsAndNames(
-      path,
-      path + "mzML/",
-      path + "features/",
-      path + "features/",
+    sample_group_filenames.setFileVariants(
       "",
       sampleGroupHandler.getSampleGroupName(),
       sampleGroupHandler.getSampleGroupName(),

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -62,7 +62,8 @@ TEST(SequenceHandler, createSequence_onFilePicked)
   CreateSequence cs(sequenceHandler);
   std::string datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
-  Filenames filenames_ = generateTestFilenames();
+  Filenames filenames_;
+  filenames_.setFullPathName("sequence_csv_i", workflow / "sequence.csv");
   cs.onFilePicked(filenames_.getFullPathName("sequence_csv_i"), &ah);
 
   ASSERT_EQ(sequenceHandler.getSequence().size(), 2);
@@ -84,7 +85,8 @@ TEST(SequenceHandler, createSequence_onFilePicked_windows_separators)
   CreateSequence cs(sequenceHandler);
   std::string datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
-  Filenames filenames_ = generateTestFilenames();
+  Filenames filenames_;
+  filenames_.setFullPathName("sequence_csv_i", workflow / "sequence.csv");
   std::string full_name = filenames_.getFullPathName("sequence_csv_i");
   // replace separators (this way of specifying filename can happen with command line interface actually)
   std::replace(full_name.begin(), full_name.end(), '/', '\\');

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -543,7 +543,7 @@ TEST(SequenceHandler, StoreWorkflow1)
   processor.process();
   // compare with reference file
   const string reference_filename = SMARTPEAK_GET_TEST_DATA_PATH("SequenceProcessor_workflow.csv");
-  EXPECT_STREQ(processor.filename_.c_str(), reference_filename.c_str());
+  EXPECT_STREQ(processor.filename_.generic_string().c_str(), reference_filename.c_str());
 }
 
 TEST(SequenceHandler, LoadWorkflow_onFilePicked)

--- a/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceProcessor_test.cpp
@@ -35,23 +35,23 @@ Filenames generateTestFilenames()
 {
   const std::string dir = SMARTPEAK_GET_TEST_DATA_PATH("");
   Filenames filenames;
-  filenames.sequence_csv_i                                = dir + "SequenceProcessor_sequence.csv";
-  filenames.parameters_csv_i                              = dir + "RawDataProcessor_params_1_core.csv";
-  filenames.traML_csv_i                                   = dir + "OpenMSFile_traML_1.csv";
-  filenames.featureFilterComponents_csv_i                 = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureFilterComponentGroups_csv_i            = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.featureQCComponents_csv_i                     = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureQCComponentGroups_csv_i                = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.featureRSDFilterComponents_csv_i              = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureRSDFilterComponentGroups_csv_i         = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.featureRSDQCComponents_csv_i                  = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureRSDQCComponentGroups_csv_i             = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.featureBackgroundFilterComponents_csv_i       = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureBackgroundFilterComponentGroups_csv_i  = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.featureBackgroundQCComponents_csv_i           = dir + "OpenMSFile_mrmfeatureqccomponents_1.csv";
-  filenames.featureBackgroundQCComponentGroups_csv_i      = dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv";
-  filenames.quantitationMethods_csv_i                     = dir + "OpenMSFile_quantitationMethods_1.csv";
-  filenames.standardsConcentrations_csv_i                 = dir + "OpenMSFile_standardsConcentrations_1.csv";
+  filenames.setFullPathName("sequence_csv_i"                                , dir + "SequenceProcessor_sequence.csv");
+  filenames.setFullPathName("parameters_csv_i"                              , dir + "RawDataProcessor_params_1_core.csv");
+  filenames.setFullPathName("traML_csv_i"                                   , dir + "OpenMSFile_traML_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i"                 , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i"            , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i"                     , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureQCComponentGroups_csv_i"                , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureRSDFilterComponents_csv_i"              , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i"         , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureRSDQCComponents_csv_i"                  , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureRSDQCComponentGroups_csv_i"             , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureBackgroundFilterComponents_csv_i"       , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i"  , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureBackgroundQCComponents_csv_i"           , dir + "OpenMSFile_mrmfeatureqccomponents_1.csv");
+  filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i"      , dir + "OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("quantitationMethods_csv_i"                     , dir + "OpenMSFile_quantitationMethods_1.csv");
+  filenames.setFullPathName("standardsConcentrations_csv_i"                 , dir + "OpenMSFile_standardsConcentrations_1.csv");
   return filenames;
 }
 
@@ -62,8 +62,8 @@ TEST(SequenceHandler, createSequence_onFilePicked)
   CreateSequence cs(sequenceHandler);
   std::string datapath_ = SMARTPEAK_GET_TEST_DATA_PATH("");
   auto workflow = std::filesystem::path{ datapath_ } / std::filesystem::path{ "workflow_csv_files" };
-  auto filenames_ = Filenames::getDefaultStaticFilenames(workflow.string());
-  cs.onFilePicked(filenames_.sequence_csv_i, &ah);
+  Filenames filenames_;
+  cs.onFilePicked(filenames_.getFullPathName("sequence_csv_i"), &ah);
 
   ASSERT_EQ(sequenceHandler.getSequence().size(), 2);
   InjectionHandler& injection0 = sequenceHandler.getSequence()[0];
@@ -219,7 +219,7 @@ TEST(SequenceHandler, createSequence)
 
   sequenceHandler.clear();
   Filenames filenames { generateTestFilenames() };
-  filenames.sequence_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("SequenceProcessor_empty_sequence.csv");
+  filenames.setFullPathName("sequence_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("SequenceProcessor_empty_sequence.csv"));
 
   cs.filenames_ = filenames;
   cs.process();
@@ -250,10 +250,16 @@ TEST(SequenceHandler, processSequence)
   EXPECT_EQ(rawDataHandler0.getExperiment().getChromatograms().size(), 0); // empty (not loaded, yet)
 
   std::map<std::string, Filenames> dynamic_filenames;
+  Filenames methods_filenames;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames);
+  }
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
     const std::string key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    Filenames injection_filenames = methods_filenames;
+    injection_filenames.setPathsAndNames(
       path,
       path + "mzML",
       path + "features",
@@ -264,6 +270,7 @@ TEST(SequenceHandler, processSequence)
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
+    dynamic_filenames[key] = injection_filenames;
   }
 
   EXPECT_EQ(sequenceHandler.getSequence().size(), dynamic_filenames.size());
@@ -335,11 +342,17 @@ TEST(SequenceHandler, processSequenceSegments)
   const vector<std::shared_ptr<SequenceSegmentProcessor>> sequence_segment_processing_methods =
     { std::make_shared<CalculateCalibration>() };
 
+  Filenames methods_filenames;
+  for (const auto& m : sequence_segment_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames);
+  }
   std::map<std::string, Filenames> dynamic_filenames;
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const SequenceSegmentHandler& sequence_segment : sequenceHandler.getSequenceSegments()) {
     const std::string key = sequence_segment.getSequenceSegmentName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    Filenames sequence_segment_filenames = methods_filenames;
+    sequence_segment_filenames.setPathsAndNames(
       path,
       path + "mzML/",
       path + "features/",
@@ -350,6 +363,7 @@ TEST(SequenceHandler, processSequenceSegments)
       key,
       key
     );
+    dynamic_filenames[key] = sequence_segment_filenames;
   }
 
   // Default sequence segment names (i.e., all)
@@ -416,12 +430,19 @@ TEST(SequenceHandler, processSampleGroups)
   cs.checkConsistency = false;
   cs.process();
 
-  // Generate the filenames
+  // Load in the raw data featureMaps
+  const vector<std::shared_ptr<RawDataProcessor>> raw_data_processing_methods = { std::make_shared<LoadFeatures>() };
+  Filenames methods_filenames;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames);
+  }
   std::map<std::string, Filenames> dynamic_filenames;
   const std::string path = SMARTPEAK_GET_TEST_DATA_PATH("");
   for (const InjectionHandler& injection : sequenceHandler.getSequence()) {
+    Filenames injection_filenames = methods_filenames;
     const std::string key = injection.getMetaData().getInjectionName();
-    dynamic_filenames[key] = Filenames::getDefaultDynamicFilenames(
+    injection_filenames.setPathsAndNames(
       path,
       path,
       path,
@@ -432,19 +453,25 @@ TEST(SequenceHandler, processSampleGroups)
       injection.getMetaData().getSampleGroupName(),
       injection.getMetaData().getSampleGroupName()
     );
+    dynamic_filenames[key] = injection_filenames;
   }
 
-  // Load in the raw data featureMaps
-  const vector<std::shared_ptr<RawDataProcessor>> raw_data_processing_methods = { std::make_shared<LoadFeatures>() };
   ProcessSequence ps(sequenceHandler);
   ps.filenames_ = dynamic_filenames;
   ps.raw_data_processing_methods_ = raw_data_processing_methods;
   ps.process();
 
-  // Update the filenames
+  const vector<std::shared_ptr<SampleGroupProcessor>> sample_group_processing_methods =
+  { std::make_shared<MergeInjections>() };
   dynamic_filenames.clear();
+  Filenames methods_filenames2;
+  for (const auto& m : raw_data_processing_methods)
+  {
+    m->getInputsOutputs(methods_filenames2);
+  }
   for (const SampleGroupHandler& sampleGroupHandler : sequenceHandler.getSampleGroups()) {
-    dynamic_filenames[sampleGroupHandler.getSampleGroupName()] = Filenames::getDefaultDynamicFilenames(
+    Filenames sample_group_filenames = methods_filenames2;
+    sample_group_filenames.setPathsAndNames(
       path,
       path + "mzML/",
       path + "features/",
@@ -455,10 +482,8 @@ TEST(SequenceHandler, processSampleGroups)
       sampleGroupHandler.getSampleGroupName(),
       sampleGroupHandler.getSampleGroupName()
     );
+    dynamic_filenames[sampleGroupHandler.getSampleGroupName()] = sample_group_filenames;
   }
-
-  const vector<std::shared_ptr<SampleGroupProcessor>> sample_group_processing_methods =
-  { std::make_shared<MergeInjections>() };
 
   // Default sample group names (i.e., all)
   ProcessSampleGroups psg(sequenceHandler);

--- a/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
@@ -981,7 +981,6 @@ TEST(SequenceSegmentProcessor, processStoreFeatureFilters)
   filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
   filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureFilters storeFeatureFilters;
-  storeFeatureFilters.getInputsOutputs(filenames);
   storeFeatureFilters.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureFilters.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureFilter();
@@ -1034,7 +1033,6 @@ TEST(SequenceSegmentProcessor, processStoreFeatureQCs)
   filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
   filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureQCs storeFeatureQCs;
-  storeFeatureQCs.getInputsOutputs(filenames);
   storeFeatureQCs.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureQCs.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureQC();
@@ -1173,7 +1171,6 @@ TEST(SequenceSegmentProcessor, processStoreFeatureRSDFilters)
   filenames.setFullPathName("featureRSDFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
   filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureRSDFilters storeFeatureRSDFilters;
-  storeFeatureRSDFilters.getInputsOutputs(filenames);
   storeFeatureRSDFilters.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureRSDFilters.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureRSDFilter();
@@ -1226,7 +1223,6 @@ TEST(SequenceSegmentProcessor, processStoreFeatureRSDQCs)
   filenames.setFullPathName("featureRSDQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
   filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureRSDQCs storeFeatureRSDQCs;
-  storeFeatureRSDQCs.getInputsOutputs(filenames);
   storeFeatureRSDQCs.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureRSDQCs.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureRSDQC();
@@ -1365,7 +1361,6 @@ TEST(SequenceSegmentProcessor, processStoreFeatureBackgroundFilters)
   filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
   filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureBackgroundFilters storeFeatureBackgroundFilters;
-  storeFeatureBackgroundFilters.getInputsOutputs(filenames);
   storeFeatureBackgroundFilters.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureBackgroundFilters.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureBackgroundFilter();
@@ -1418,7 +1413,6 @@ TEST(SequenceSegmentProcessor, processStoreFeatureBackgroundQCs)
   filenames.setFullPathName("featureBackgroundQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
   filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureBackgroundQCs storeFeatureBackgroundQCs;
-  storeFeatureBackgroundQCs.getInputsOutputs(filenames);
   storeFeatureBackgroundQCs.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureBackgroundQCs.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureBackgroundQC();
@@ -2473,7 +2467,6 @@ TEST(SequenceSegmentProcessor, processStoreFeatureRSDEstimations)
   filenames.setFullPathName("featureRSDEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
   filenames.setFullPathName("featureRSDEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureRSDEstimations storeFeatureRSDEstimations;
-  storeFeatureRSDEstimations.getInputsOutputs(filenames);
   storeFeatureRSDEstimations.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureRSDEstimations.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureRSDEstimations();
@@ -2526,7 +2519,6 @@ TEST(SequenceSegmentProcessor, processStoreFeatureBackgroundEstimations)
   filenames.setFullPathName("featureBackgroundEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
   filenames.setFullPathName("featureBackgroundEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureBackgroundEstimations storeFeatureBackgroundEstimations;
-  storeFeatureBackgroundEstimations.getInputsOutputs(filenames);
   storeFeatureBackgroundEstimations.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureBackgroundEstimations.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureBackgroundEstimations();

--- a/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
@@ -728,7 +728,7 @@ TEST(SequenceSegmentProcessor, gettersLoadStandardsConcentrations)
 TEST(SequenceSegmentProcessor, processLoadStandardsConcentrations)
 {
   Filenames filenames;
-  filenames.setFullPathName("standardsConcentrations_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_standardsConcentrations_1.csv"));
+  filenames.setFullPath("standardsConcentrations_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_standardsConcentrations_1.csv"));
   SequenceSegmentHandler ssh;
   LoadStandardsConcentrations loadStandardsConcentrations;
   loadStandardsConcentrations.process(ssh, SequenceHandler(), {}, filenames);
@@ -789,7 +789,7 @@ TEST(SequenceSegmentProcessor, gettersLoadQuantitationMethods)
 TEST(SequenceSegmentProcessor, processLoadQuantitationMethods)
 {
   Filenames filenames;
-  filenames.setFullPathName("quantitationMethods_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv"));
+  filenames.setFullPath("quantitationMethods_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv"));
   SequenceSegmentHandler ssh;
   LoadQuantitationMethods loadQuantitationMethods;
   loadQuantitationMethods.process(ssh, SequenceHandler(), {}, filenames);
@@ -888,8 +888,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureFilters)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureFilters loadFeatureFilters;
   loadFeatureFilters.process(ssh, SequenceHandler(), {}, filenames);
@@ -931,8 +931,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureQCs)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureQCs loadFeatureQCs;
   loadFeatureQCs.process(ssh, SequenceHandler(), {}, filenames);
@@ -974,12 +974,12 @@ TEST(SequenceSegmentProcessor, processStoreFeatureFilters)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureFilters loadFeatureFilters;
   loadFeatureFilters.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
-  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
+  filenames.setFullPath("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPath("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureFilters storeFeatureFilters;
   storeFeatureFilters.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureFilters.process(ssh_test, SequenceHandler(), {}, filenames);
@@ -1026,12 +1026,12 @@ TEST(SequenceSegmentProcessor, processStoreFeatureQCs)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureQCs loadFeatureQCs;
   loadFeatureQCs.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
-  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
+  filenames.setFullPath("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPath("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureQCs storeFeatureQCs;
   storeFeatureQCs.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureQCs.process(ssh_test, SequenceHandler(), {}, filenames);
@@ -1078,8 +1078,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureRSDFilters)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.setFullPathName("featureRSDFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureRSDFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureRSDFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureRSDFilters loadFeatureRSDFilters;
   loadFeatureRSDFilters.process(ssh, SequenceHandler(), {}, filenames);
@@ -1121,8 +1121,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureRSDQCs)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.setFullPathName("featureRSDQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureRSDQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureRSDQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureRSDQCs loadFeatureRSDQCs;
   loadFeatureRSDQCs.process(ssh, SequenceHandler(), {}, filenames);
@@ -1164,12 +1164,12 @@ TEST(SequenceSegmentProcessor, processStoreFeatureRSDFilters)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.setFullPathName("featureRSDFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureRSDFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureRSDFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureRSDFilters loadFeatureRSDFilters;
   loadFeatureRSDFilters.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.setFullPathName("featureRSDFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
-  filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
+  filenames.setFullPath("featureRSDFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPath("featureRSDFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureRSDFilters storeFeatureRSDFilters;
   storeFeatureRSDFilters.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureRSDFilters.process(ssh_test, SequenceHandler(), {}, filenames);
@@ -1216,12 +1216,12 @@ TEST(SequenceSegmentProcessor, processStoreFeatureRSDQCs)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.setFullPathName("featureRSDQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureRSDQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureRSDQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureRSDQCs loadFeatureRSDQCs;
   loadFeatureRSDQCs.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.setFullPathName("featureRSDQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
-  filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
+  filenames.setFullPath("featureRSDQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPath("featureRSDQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureRSDQCs storeFeatureRSDQCs;
   storeFeatureRSDQCs.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureRSDQCs.process(ssh_test, SequenceHandler(), {}, filenames);
@@ -1268,8 +1268,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureBackgroundFilters)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureBackgroundFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureBackgroundFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureBackgroundFilters loadFeatureBackgroundFilters;
   loadFeatureBackgroundFilters.process(ssh, SequenceHandler(), {}, filenames);
@@ -1311,8 +1311,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureBackgroundQCs)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.setFullPathName("featureBackgroundQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureBackgroundQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureBackgroundQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureBackgroundQCs loadFeatureBackgroundQCs;
   loadFeatureBackgroundQCs.process(ssh, SequenceHandler(), {}, filenames);
@@ -1354,12 +1354,12 @@ TEST(SequenceSegmentProcessor, processStoreFeatureBackgroundFilters)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureBackgroundFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureBackgroundFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureBackgroundFilters loadFeatureBackgroundFilters;
   loadFeatureBackgroundFilters.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
-  filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
+  filenames.setFullPath("featureBackgroundFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPath("featureBackgroundFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureBackgroundFilters storeFeatureBackgroundFilters;
   storeFeatureBackgroundFilters.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureBackgroundFilters.process(ssh_test, SequenceHandler(), {}, filenames);
@@ -1406,12 +1406,12 @@ TEST(SequenceSegmentProcessor, processStoreFeatureBackgroundQCs)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.setFullPathName("featureBackgroundQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureBackgroundQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureBackgroundQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureBackgroundQCs loadFeatureBackgroundQCs;
   loadFeatureBackgroundQCs.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.setFullPathName("featureBackgroundQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
-  filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
+  filenames.setFullPath("featureBackgroundQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPath("featureBackgroundQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureBackgroundQCs storeFeatureBackgroundQCs;
   storeFeatureBackgroundQCs.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureBackgroundQCs.process(ssh_test, SequenceHandler(), {}, filenames);
@@ -2460,12 +2460,12 @@ TEST(SequenceSegmentProcessor, processStoreFeatureRSDEstimations)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.setFullPathName("featureRSDEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureRSDEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureRSDEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureRSDEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureRSDEstimations loadFeatureRSDEstimations;
   loadFeatureRSDEstimations.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.setFullPathName("featureRSDEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
-  filenames.setFullPathName("featureRSDEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
+  filenames.setFullPath("featureRSDEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPath("featureRSDEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureRSDEstimations storeFeatureRSDEstimations;
   storeFeatureRSDEstimations.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureRSDEstimations.process(ssh_test, SequenceHandler(), {}, filenames);
@@ -2512,12 +2512,12 @@ TEST(SequenceSegmentProcessor, processStoreFeatureBackgroundEstimations)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.setFullPathName("featureBackgroundEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureBackgroundEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureBackgroundEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureBackgroundEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureBackgroundEstimations loadFeatureBackgroundEstimations;
   loadFeatureBackgroundEstimations.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.setFullPathName("featureBackgroundEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
-  filenames.setFullPathName("featureBackgroundEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
+  filenames.setFullPath("featureBackgroundEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPath("featureBackgroundEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureBackgroundEstimations storeFeatureBackgroundEstimations;
   storeFeatureBackgroundEstimations.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureBackgroundEstimations.process(ssh_test, SequenceHandler(), {}, filenames);
@@ -2564,8 +2564,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureRSDEstimations)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.setFullPathName("featureRSDEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureRSDEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureRSDEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureRSDEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureRSDEstimations loadFeatureRSDEstimations;
   loadFeatureRSDEstimations.process(ssh, SequenceHandler(), {}, filenames);
@@ -2608,8 +2608,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureBackgroundEstimations)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.setFullPathName("featureBackgroundEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
-  filenames.setFullPathName("featureBackgroundEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
+  filenames.setFullPath("featureBackgroundEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPath("featureBackgroundEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureBackgroundEstimations loadFeatureBackgroundEstimations;
   loadFeatureBackgroundEstimations.process(ssh, SequenceHandler(), {}, filenames);

--- a/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
@@ -728,7 +728,7 @@ TEST(SequenceSegmentProcessor, gettersLoadStandardsConcentrations)
 TEST(SequenceSegmentProcessor, processLoadStandardsConcentrations)
 {
   Filenames filenames;
-  filenames.standardsConcentrations_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_standardsConcentrations_1.csv");
+  filenames.setFullPathName("standardsConcentrations_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_standardsConcentrations_1.csv"));
   SequenceSegmentHandler ssh;
   LoadStandardsConcentrations loadStandardsConcentrations;
   loadStandardsConcentrations.process(ssh, SequenceHandler(), {}, filenames);
@@ -789,7 +789,7 @@ TEST(SequenceSegmentProcessor, gettersLoadQuantitationMethods)
 TEST(SequenceSegmentProcessor, processLoadQuantitationMethods)
 {
   Filenames filenames;
-  filenames.quantitationMethods_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv");
+  filenames.setFullPathName("quantitationMethods_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_quantitationMethods_1.csv"));
   SequenceSegmentHandler ssh;
   LoadQuantitationMethods loadQuantitationMethods;
   loadQuantitationMethods.process(ssh, SequenceHandler(), {}, filenames);
@@ -888,8 +888,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureFilters)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureFilters loadFeatureFilters;
   loadFeatureFilters.process(ssh, SequenceHandler(), {}, filenames);
@@ -931,8 +931,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureQCs)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.featureQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureQCs loadFeatureQCs;
   loadFeatureQCs.process(ssh, SequenceHandler(), {}, filenames);
@@ -974,13 +974,14 @@ TEST(SequenceSegmentProcessor, processStoreFeatureFilters)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureFilters loadFeatureFilters;
   loadFeatureFilters.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.featureFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv");
-  filenames.featureFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv");
+  filenames.setFullPathName("featureFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPathName("featureFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureFilters storeFeatureFilters;
+  storeFeatureFilters.getInputsOutputs(filenames);
   storeFeatureFilters.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureFilters.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureFilter();
@@ -1026,13 +1027,14 @@ TEST(SequenceSegmentProcessor, processStoreFeatureQCs)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.featureQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureQCs loadFeatureQCs;
   loadFeatureQCs.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.featureQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv");
-  filenames.featureQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv");
+  filenames.setFullPathName("featureQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPathName("featureQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureQCs storeFeatureQCs;
+  storeFeatureQCs.getInputsOutputs(filenames);
   storeFeatureQCs.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureQCs.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureQC();
@@ -1078,8 +1080,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureRSDFilters)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.featureRSDFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureRSDFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureRSDFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureRSDFilters loadFeatureRSDFilters;
   loadFeatureRSDFilters.process(ssh, SequenceHandler(), {}, filenames);
@@ -1121,8 +1123,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureRSDQCs)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.featureRSDQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureRSDQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureRSDQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureRSDQCs loadFeatureRSDQCs;
   loadFeatureRSDQCs.process(ssh, SequenceHandler(), {}, filenames);
@@ -1164,13 +1166,14 @@ TEST(SequenceSegmentProcessor, processStoreFeatureRSDFilters)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.featureRSDFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureRSDFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureRSDFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureRSDFilters loadFeatureRSDFilters;
   loadFeatureRSDFilters.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.featureRSDFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv");
-  filenames.featureRSDFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv");
+  filenames.setFullPathName("featureRSDFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPathName("featureRSDFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureRSDFilters storeFeatureRSDFilters;
+  storeFeatureRSDFilters.getInputsOutputs(filenames);
   storeFeatureRSDFilters.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureRSDFilters.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureRSDFilter();
@@ -1216,13 +1219,14 @@ TEST(SequenceSegmentProcessor, processStoreFeatureRSDQCs)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.featureRSDQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureRSDQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureRSDQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureRSDQCs loadFeatureRSDQCs;
   loadFeatureRSDQCs.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.featureRSDQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv");
-  filenames.featureRSDQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv");
+  filenames.setFullPathName("featureRSDQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPathName("featureRSDQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureRSDQCs storeFeatureRSDQCs;
+  storeFeatureRSDQCs.getInputsOutputs(filenames);
   storeFeatureRSDQCs.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureRSDQCs.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureRSDQC();
@@ -1268,8 +1272,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureBackgroundFilters)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.featureBackgroundFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureBackgroundFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureBackgroundFilters loadFeatureBackgroundFilters;
   loadFeatureBackgroundFilters.process(ssh, SequenceHandler(), {}, filenames);
@@ -1311,8 +1315,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureBackgroundQCs)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.featureBackgroundQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureBackgroundQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureBackgroundQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureBackgroundQCs loadFeatureBackgroundQCs;
   loadFeatureBackgroundQCs.process(ssh, SequenceHandler(), {}, filenames);
@@ -1354,13 +1358,14 @@ TEST(SequenceSegmentProcessor, processStoreFeatureBackgroundFilters)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.featureBackgroundFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureBackgroundFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureBackgroundFilters loadFeatureBackgroundFilters;
   loadFeatureBackgroundFilters.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.featureBackgroundFilterComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv");
-  filenames.featureBackgroundFilterComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv");
+  filenames.setFullPathName("featureBackgroundFilterComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPathName("featureBackgroundFilterComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureBackgroundFilters storeFeatureBackgroundFilters;
+  storeFeatureBackgroundFilters.getInputsOutputs(filenames);
   storeFeatureBackgroundFilters.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureBackgroundFilters.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureBackgroundFilter();
@@ -1406,13 +1411,14 @@ TEST(SequenceSegmentProcessor, processStoreFeatureBackgroundQCs)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.featureBackgroundQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureBackgroundQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureBackgroundQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureBackgroundQCs loadFeatureBackgroundQCs;
   loadFeatureBackgroundQCs.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.featureBackgroundQCComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv");
-  filenames.featureBackgroundQCComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv");
+  filenames.setFullPathName("featureBackgroundQCComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPathName("featureBackgroundQCComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureBackgroundQCs storeFeatureBackgroundQCs;
+  storeFeatureBackgroundQCs.getInputsOutputs(filenames);
   storeFeatureBackgroundQCs.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureBackgroundQCs.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureBackgroundQC();
@@ -2460,13 +2466,14 @@ TEST(SequenceSegmentProcessor, processStoreFeatureRSDEstimations)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.featureRSDEstimationComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureRSDEstimationComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureRSDEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureRSDEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureRSDEstimations loadFeatureRSDEstimations;
   loadFeatureRSDEstimations.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.featureRSDEstimationComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv");
-  filenames.featureRSDEstimationComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv");
+  filenames.setFullPathName("featureRSDEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPathName("featureRSDEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureRSDEstimations storeFeatureRSDEstimations;
+  storeFeatureRSDEstimations.getInputsOutputs(filenames);
   storeFeatureRSDEstimations.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureRSDEstimations.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureRSDEstimations();
@@ -2512,13 +2519,14 @@ TEST(SequenceSegmentProcessor, processStoreFeatureBackgroundEstimations)
   SequenceSegmentHandler ssh, ssh_test;
 
   Filenames filenames;
-  filenames.featureBackgroundEstimationComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureBackgroundEstimationComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureBackgroundEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureBackgroundEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
   LoadFeatureBackgroundEstimations loadFeatureBackgroundEstimations;
   loadFeatureBackgroundEstimations.process(ssh, SequenceHandler(), {}, filenames);
-  filenames.featureBackgroundEstimationComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv");
-  filenames.featureBackgroundEstimationComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv");
+  filenames.setFullPathName("featureBackgroundEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1_test.csv"));
+  filenames.setFullPathName("featureBackgroundEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1_test.csv"));
   StoreFeatureBackgroundEstimations storeFeatureBackgroundEstimations;
+  storeFeatureBackgroundEstimations.getInputsOutputs(filenames);
   storeFeatureBackgroundEstimations.process(ssh, SequenceHandler(), {}, filenames);
   loadFeatureBackgroundEstimations.process(ssh_test, SequenceHandler(), {}, filenames);
   const OpenMS::MRMFeatureQC& fQC = ssh.getFeatureBackgroundEstimations();
@@ -2564,8 +2572,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureRSDEstimations)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.featureRSDEstimationComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureRSDEstimationComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureRSDEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureRSDEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureRSDEstimations loadFeatureRSDEstimations;
   loadFeatureRSDEstimations.process(ssh, SequenceHandler(), {}, filenames);
@@ -2608,8 +2616,8 @@ TEST(SequenceSegmentProcessor, processLoadFeatureBackgroundEstimations)
   SequenceSegmentHandler ssh;
 
   Filenames filenames;
-  filenames.featureBackgroundEstimationComponents_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv");
-  filenames.featureBackgroundEstimationComponentGroups_csv_i = SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv");
+  filenames.setFullPathName("featureBackgroundEstimationComponents_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponents_1.csv"));
+  filenames.setFullPathName("featureBackgroundEstimationComponentGroups_csv_i", SMARTPEAK_GET_TEST_DATA_PATH("OpenMSFile_mrmfeatureqccomponentgroups_1.csv"));
 
   LoadFeatureBackgroundEstimations loadFeatureBackgroundEstimations;
   loadFeatureBackgroundEstimations.process(ssh, SequenceHandler(), {}, filenames);

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -48,9 +48,9 @@ struct TestData {
       LoadFeatures loadFeatures;
       Filenames method_filenames;
       method_filenames.setTag("MAIN_DIR", pathname);
-      method_filenames.setTag("MZML_INPUT_PATH", pathname + "mzML");
-      method_filenames.setTag("FEATURES_INPUT_PATH", pathname + "features");
-      method_filenames.setTag("FEATURES_OUTPUT_PATH", pathname + "features");
+      method_filenames.setTag("MZML_INPUT_PATH", pathname + "/mzML");
+      method_filenames.setTag("FEATURES_INPUT_PATH", pathname + "/features");
+      method_filenames.setTag("FEATURES_OUTPUT_PATH", pathname + "/features");
       for (auto& injection : sequenceHandler.getSequence()) {
         Filenames filenames_ = method_filenames;
         filenames_.setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
@@ -69,9 +69,9 @@ struct TestData {
       LoadRawData loadRawData;
       Filenames method_filenames;
       method_filenames.setTag("MAIN_DIR", pathname);
-      method_filenames.setTag("MZML_INPUT_PATH", pathname + "mzML");
-      method_filenames.setTag("FEATURES_INPUT_PATH", pathname + "features");
-      method_filenames.setTag("FEATURES_OUTPUT_PATH", pathname + "features");
+      method_filenames.setTag("MZML_INPUT_PATH", pathname + "/mzML");
+      method_filenames.setTag("FEATURES_INPUT_PATH", pathname + "/features");
+      method_filenames.setTag("FEATURES_OUTPUT_PATH", pathname + "/features");
       for (auto& injection : sequenceHandler.getSequence()) {
         Filenames filenames_ = method_filenames;
         filenames_.setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -35,7 +35,8 @@ struct TestData {
     const std::string pathname = SMARTPEAK_GET_TEST_DATA_PATH("workflow_csv_files");
     // Load the sequence
     if (load_sequence) {
-      Filenames filenames_ = Filenames::getDefaultStaticFilenames(pathname);
+      Filenames filenames_;
+      filenames_.setRootPaths(pathname, "", "", "");
       CreateSequence cs(sequenceHandler);
       cs.filenames_ = filenames_;
       cs.delimiter = ",";
@@ -45,8 +46,11 @@ struct TestData {
     // Load the picked features
     if (load_features) {
       LoadFeatures loadFeatures;
+      Filenames method_filenames;
+      loadFeatures.getInputsOutputs(method_filenames);
       for (auto& injection : sequenceHandler.getSequence()) {
-        Filenames filenames_ = Filenames::getDefaultDynamicFilenames(
+        Filenames filenames_ = method_filenames;
+        filenames_.setPathsAndNames(
           pathname,
           pathname + "/mzML",
           pathname + "/features",
@@ -65,8 +69,11 @@ struct TestData {
       params.addFunctionParameters(FunctionParameters("mzML"));
       params.addFunctionParameters(FunctionParameters("ChromatogramExtractor"));
       LoadRawData loadRawData;
+      Filenames method_filenames;
+      loadRawData.getInputsOutputs(method_filenames);
       for (auto& injection : sequenceHandler.getSequence()) {
-        Filenames filenames_ = Filenames::getDefaultDynamicFilenames(
+        Filenames filenames_ = method_filenames;
+        filenames_.setPathsAndNames(
           pathname,
           pathname + "/mzML",
           pathname + "/features",

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -51,7 +51,6 @@ struct TestData {
         pathname + "/mzML",
         pathname + "/features",
         pathname + "/features");
-      loadFeatures.getInputsOutputs(method_filenames);
       for (auto& injection : sequenceHandler.getSequence()) {
         Filenames filenames_ = method_filenames;
         filenames_.setFileVariants(
@@ -74,7 +73,6 @@ struct TestData {
         pathname + "/mzML",
         pathname + "/features",
         pathname + "/features");
-      loadRawData.getInputsOutputs(method_filenames);
       for (auto& injection : sequenceHandler.getSequence()) {
         Filenames filenames_ = method_filenames;
         filenames_.setFileVariants(

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -36,7 +36,7 @@ struct TestData {
     // Load the sequence
     if (load_sequence) {
       Filenames filenames_;
-      filenames_.setRootPaths(pathname, "", "", "");
+      filenames_.setTag("MAIN_DIR", pathname);
       CreateSequence cs(sequenceHandler);
       cs.filenames_ = filenames_;
       cs.delimiter = ",";
@@ -47,18 +47,17 @@ struct TestData {
     if (load_features) {
       LoadFeatures loadFeatures;
       Filenames method_filenames;
-      method_filenames.setRootPaths(pathname,
-        pathname + "/mzML",
-        pathname + "/features",
-        pathname + "/features");
+      method_filenames.setTag("MAIN_DIR", pathname);
+      method_filenames.setTag("MZML_INPUT_PATH", pathname + "mzML");
+      method_filenames.setTag("FEATURES_INPUT_PATH", pathname + "features");
+      method_filenames.setTag("FEATURES_OUTPUT_PATH", pathname + "features");
       for (auto& injection : sequenceHandler.getSequence()) {
         Filenames filenames_ = method_filenames;
-        filenames_.setFileVariants(
-          injection.getMetaData().getFilename(),
-          injection.getMetaData().getInjectionName(),
-          injection.getMetaData().getInjectionName(),
-          injection.getMetaData().getSampleGroupName(),
-          injection.getMetaData().getSampleGroupName());
+        filenames_.setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+        filenames_.setTag("INPUT_INJECTION_NAME", injection.getMetaData().getInjectionName());
+        filenames_.setTag("OUTPUT_INJECTION_NAME", injection.getMetaData().getInjectionName());
+        filenames_.setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+        filenames_.setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
         loadFeatures.process(injection.getRawData(), {}, filenames_);
       }
     }
@@ -69,18 +68,17 @@ struct TestData {
       params.addFunctionParameters(FunctionParameters("ChromatogramExtractor"));
       LoadRawData loadRawData;
       Filenames method_filenames;
-      method_filenames.setRootPaths(pathname,
-        pathname + "/mzML",
-        pathname + "/features",
-        pathname + "/features");
+      method_filenames.setTag("MAIN_DIR", pathname);
+      method_filenames.setTag("MZML_INPUT_PATH", pathname + "mzML");
+      method_filenames.setTag("FEATURES_INPUT_PATH", pathname + "features");
+      method_filenames.setTag("FEATURES_OUTPUT_PATH", pathname + "features");
       for (auto& injection : sequenceHandler.getSequence()) {
         Filenames filenames_ = method_filenames;
-        filenames_.setFileVariants(
-          injection.getMetaData().getFilename(),
-          injection.getMetaData().getSampleName(),
-          injection.getMetaData().getSampleName(),
-          injection.getMetaData().getSampleGroupName(),
-          injection.getMetaData().getSampleGroupName());
+        filenames_.setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
+        filenames_.setTag("INPUT_INJECTION_NAME", injection.getMetaData().getInjectionName());
+        filenames_.setTag("OUTPUT_INJECTION_NAME", injection.getMetaData().getInjectionName());
+        filenames_.setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+        filenames_.setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
         loadRawData.process(injection.getRawData(), params, filenames_);
       }
     }

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -47,14 +47,14 @@ struct TestData {
     if (load_features) {
       LoadFeatures loadFeatures;
       Filenames method_filenames;
+      method_filenames.setRootPaths(pathname,
+        pathname + "/mzML",
+        pathname + "/features",
+        pathname + "/features");
       loadFeatures.getInputsOutputs(method_filenames);
       for (auto& injection : sequenceHandler.getSequence()) {
         Filenames filenames_ = method_filenames;
-        filenames_.setPathsAndNames(
-          pathname,
-          pathname + "/mzML",
-          pathname + "/features",
-          pathname + "/features",
+        filenames_.setFileVariants(
           injection.getMetaData().getFilename(),
           injection.getMetaData().getInjectionName(),
           injection.getMetaData().getInjectionName(),
@@ -70,14 +70,14 @@ struct TestData {
       params.addFunctionParameters(FunctionParameters("ChromatogramExtractor"));
       LoadRawData loadRawData;
       Filenames method_filenames;
+      method_filenames.setRootPaths(pathname,
+        pathname + "/mzML",
+        pathname + "/features",
+        pathname + "/features");
       loadRawData.getInputsOutputs(method_filenames);
       for (auto& injection : sequenceHandler.getSequence()) {
         Filenames filenames_ = method_filenames;
-        filenames_.setPathsAndNames(
-          pathname,
-          pathname + "/mzML",
-          pathname + "/features",
-          pathname + "/features",
+        filenames_.setFileVariants(
           injection.getMetaData().getFilename(),
           injection.getMetaData().getSampleName(),
           injection.getMetaData().getSampleName(),

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -36,7 +36,7 @@ struct TestData {
     // Load the sequence
     if (load_sequence) {
       Filenames filenames_;
-      filenames_.setTag("MAIN_DIR", pathname);
+      filenames_.setTag(Filenames::Tag::MAIN_DIR, pathname);
       CreateSequence cs(sequenceHandler);
       cs.filenames_ = filenames_;
       cs.delimiter = ",";
@@ -47,17 +47,17 @@ struct TestData {
     if (load_features) {
       LoadFeatures loadFeatures;
       Filenames method_filenames;
-      method_filenames.setTag("MAIN_DIR", pathname);
-      method_filenames.setTag("MZML_INPUT_PATH", pathname + "/mzML");
-      method_filenames.setTag("FEATURES_INPUT_PATH", pathname + "/features");
-      method_filenames.setTag("FEATURES_OUTPUT_PATH", pathname + "/features");
+      method_filenames.setTag(Filenames::Tag::MAIN_DIR, pathname);
+      method_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, pathname + "/mzML");
+      method_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, pathname + "/features");
+      method_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, pathname + "/features");
       for (auto& injection : sequenceHandler.getSequence()) {
         Filenames filenames_ = method_filenames;
-        filenames_.setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-        filenames_.setTag("INPUT_INJECTION_NAME", injection.getMetaData().getInjectionName());
-        filenames_.setTag("OUTPUT_INJECTION_NAME", injection.getMetaData().getInjectionName());
-        filenames_.setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-        filenames_.setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+        filenames_.setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+        filenames_.setTag(Filenames::Tag::INPUT_INJECTION_NAME, injection.getMetaData().getInjectionName());
+        filenames_.setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, injection.getMetaData().getInjectionName());
+        filenames_.setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+        filenames_.setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
         loadFeatures.process(injection.getRawData(), {}, filenames_);
       }
     }
@@ -68,17 +68,17 @@ struct TestData {
       params.addFunctionParameters(FunctionParameters("ChromatogramExtractor"));
       LoadRawData loadRawData;
       Filenames method_filenames;
-      method_filenames.setTag("MAIN_DIR", pathname);
-      method_filenames.setTag("MZML_INPUT_PATH", pathname + "/mzML");
-      method_filenames.setTag("FEATURES_INPUT_PATH", pathname + "/features");
-      method_filenames.setTag("FEATURES_OUTPUT_PATH", pathname + "/features");
+      method_filenames.setTag(Filenames::Tag::MAIN_DIR, pathname);
+      method_filenames.setTag(Filenames::Tag::MZML_INPUT_PATH, pathname + "/mzML");
+      method_filenames.setTag(Filenames::Tag::FEATURES_INPUT_PATH, pathname + "/features");
+      method_filenames.setTag(Filenames::Tag::FEATURES_OUTPUT_PATH, pathname + "/features");
       for (auto& injection : sequenceHandler.getSequence()) {
         Filenames filenames_ = method_filenames;
-        filenames_.setTag("INPUT_MZML_FILENAME", injection.getMetaData().getFilename());
-        filenames_.setTag("INPUT_INJECTION_NAME", injection.getMetaData().getInjectionName());
-        filenames_.setTag("OUTPUT_INJECTION_NAME", injection.getMetaData().getInjectionName());
-        filenames_.setTag("INPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
-        filenames_.setTag("OUTPUT_GROUP_NAME", injection.getMetaData().getSampleGroupName());
+        filenames_.setTag(Filenames::Tag::INPUT_MZML_FILENAME, injection.getMetaData().getFilename());
+        filenames_.setTag(Filenames::Tag::INPUT_INJECTION_NAME, injection.getMetaData().getInjectionName());
+        filenames_.setTag(Filenames::Tag::OUTPUT_INJECTION_NAME, injection.getMetaData().getInjectionName());
+        filenames_.setTag(Filenames::Tag::INPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
+        filenames_.setTag(Filenames::Tag::OUTPUT_GROUP_NAME, injection.getMetaData().getSampleGroupName());
         loadRawData.process(injection.getRawData(), params, filenames_);
       }
     }

--- a/src/tests/class_tests/smartpeak/source/Task_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Task_test.cpp
@@ -34,7 +34,7 @@ struct TaskFixture : public ::testing::Test
     /* ctor/dtor */
     TaskFixture() 
     {
-        std::string seq = std::string{SMARTPEAK_GET_TEST_DATA_PATH("/SequenceProcessor_sequence.csv")};
+        std::string seq = std::string{SMARTPEAK_GET_TEST_DATA_PATH("SequenceProcessor_sequence.csv")};
         m_args = std::vector<std::string>{
             "Task_test", 
                 "--report", "featureDB", "pivottable",

--- a/src/tests/class_tests/smartpeak/source/Widget_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Widget_test.cpp
@@ -67,7 +67,7 @@ void getDummyTableEntries(Eigen::Tensor<std::string, 2>& rows_out)
     metaDataHandler.scan_mass_low = 60;
 
     SmartPeak::Filenames filenames;
-    filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH(metaDataHandler.getInjectionName() + ".featureXML"));
+    filenames.setFullPath("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH(metaDataHandler.getInjectionName() + ".featureXML"));
     SmartPeak::RawDataHandler rawDataHandler;
     SmartPeak::LoadFeatures loadFeatures;
     loadFeatures.process(rawDataHandler, {}, filenames);

--- a/src/tests/class_tests/smartpeak/source/Widget_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Widget_test.cpp
@@ -67,7 +67,7 @@ void getDummyTableEntries(Eigen::Tensor<std::string, 2>& rows_out)
     metaDataHandler.scan_mass_low = 60;
 
     SmartPeak::Filenames filenames;
-    filenames.featureXML_i = SMARTPEAK_GET_TEST_DATA_PATH(metaDataHandler.getInjectionName() + ".featureXML");
+    filenames.setFullPathName("featureXML_i", SMARTPEAK_GET_TEST_DATA_PATH(metaDataHandler.getInjectionName() + ".featureXML"));
     SmartPeak::RawDataHandler rawDataHandler;
     SmartPeak::LoadFeatures loadFeatures;
     loadFeatures.process(rawDataHandler, {}, filenames);


### PR DESCRIPTION
The aim of this work is to enforce encapsulation, and autonomy of the processors. Filenames class was listing a set of files that are part of the processor information. This is also the first step to prepare the migration to the implementation of the session.

each processor inherits now from the ``IInputsOutputsProvider`` (note: not sure it's a nice name...) interface, giving a chance to the processor to declare the files they depend on (the file that they will read or the file that they will create).

the list of file are templates where some placeholder (tags) will be filled by the Filename class (which still exist, with a more limited responsibility).

For example:
```
  void LoadFeatures::getInputsOutputs(Filenames& filenames) const
  {
    filenames.addFileName("featureXML_i", "${FEATURES_INPUT_PATH}/${INPUT_INJECTION_NAME}.featureXML");
  };
```

The list of tags is not a fixed list.
however across the application, the list used so far is:

```
	MAIN_DIR
	MZML_INPUT_PATH
	FEATURES_INPUT_PATH
	FEATURES_OUTPUT_PATH
	INPUT_MZML_FILENAME
	INPUT_INJECTION_NAME
	OUTPUT_INJECTION_NAME
	INPUT_GROUP_NAME
	OUTPUT_GROUP_NAME
```

the tags are set using ``Filename::setTag(id, value)``

Along with this PR some modifications, related to filename handling has been also included:
* std::filesystem::path has been used whenever possible (with side effect, perfectible, changes to RunWorkflowWidget).
* The validation of files has been changed, it's now based on the processor.
* Some utility functions have been introduced to be used in the process method of the processor. it will check the existence of the input file and avoid code redundancy.
