### PR TITLE
Feat/aut997 Display Errors in Info Panel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,7 @@ jobs:
             mkdir arts
 
             # Get all job numbers for this workflow: 
-            JOB_NUMBERS_CONTENT=$(curl --request GET \
+            JOB_NUMBERS_CONTENT=$(curl --insecure --request GET \
               --url "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/job" \
               --header "Circle-Token: ${CIRCLE_TOKEN}" \
               --header 'content-type: application/json')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,7 @@ jobs:
             mkdir arts
 
             # Get all job numbers for this workflow: 
-            JOB_NUMBERS_CONTENT=$(curl --insecure --request GET \
+            JOB_NUMBERS_CONTENT=$(curl --request GET \
               --url "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/job" \
               --header "Circle-Token: ${CIRCLE_TOKEN}" \
               --header 'content-type: application/json')

--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -111,8 +111,8 @@ int main(int argc, char** argv)
 
   // widgets: pop ups
   auto file_picker_ = std::make_shared<FilePicker>();
-  auto session_files_widget_create_ = std::make_shared<SessionFilesWidget>(application_handler_, SessionFilesWidget::Mode::ECreation);
-  auto session_files_widget_modify_ = std::make_shared<SessionFilesWidget>(application_handler_, SessionFilesWidget::Mode::EModification);
+  auto session_files_widget_create_ = std::make_shared<SessionFilesWidget>(application_handler_, SessionFilesWidget::Mode::ECreation, &event_dispatcher);
+  auto session_files_widget_modify_ = std::make_shared<SessionFilesWidget>(application_handler_, SessionFilesWidget::Mode::EModification, &event_dispatcher);
   auto create_session_widget_ = std::make_shared<CreateSessionWidget>(application_handler_, session_files_widget_create_);
   auto run_workflow_widget_ = std::make_shared<RunWorkflowWidget>(application_handler_,
     session_handler_,
@@ -124,7 +124,7 @@ int main(int argc, char** argv)
   auto about_widget_ = std::make_shared<AboutWidget>();
   auto report_ = std::make_shared<Report>(application_handler_);
 
-  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(session_files_widget_modify_);
+  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(session_files_widget_modify_, &event_dispatcher);
 
   // widgets: windows
   auto quickInfoText_= std::make_shared<InfoWidget>("Info", application_handler_,
@@ -404,7 +404,6 @@ int main(int argc, char** argv)
       file_loading_is_done_ = file_picker_->fileLoadingIsDone();
 
       // Make the quick info text
-      quickInfoText_->setFileLoadingDone(file_loading_is_done_, file_picker_->errorLoadingFile());
       quickInfoText_->clearErrorMessages();
       if (exceeding_plot_points_) quickInfoText_->addErrorMessage("Plot rendering limit reached.  Not plotting all selected data.");
       if (exceeding_table_size_) quickInfoText_->addErrorMessage("Table rendering limit reached.  Not showing all selected data.");

--- a/src/smartpeak/include/SmartPeak/cli/Task.h
+++ b/src/smartpeak/include/SmartPeak/cli/Task.h
@@ -123,6 +123,7 @@ public:
     virtual void onApplicationProcessorCommandStart(size_t command_index, const std::string& command_name) override {}
     virtual void onApplicationProcessorCommandEnd(size_t command_index, const std::string& command_name) override {}
     virtual void onApplicationProcessorEnd() override {}
+    virtual void onApplicationProcessorError(const std::string& error) override {}
 
     /**
       ISequenceProcessorObserver

--- a/src/smartpeak/include/SmartPeak/cli/Task.h
+++ b/src/smartpeak/include/SmartPeak/cli/Task.h
@@ -135,6 +135,10 @@ public:
     }
     virtual void onSequenceProcessorSampleEnd(const std::string& sample) override {}
     virtual void onSequenceProcessorEnd() override {}
+    virtual void onSequenceProcessorError(
+      const std::string& sample_name,
+      const std::string& processor_name,
+      const std::string& error) override {};
 
     /**
       ISequenceSegmentProcessorObserver
@@ -147,18 +151,20 @@ public:
     }
     virtual void onSequenceSegmentProcessorSampleEnd(const std::string& segment_name) override {}
     virtual void onSequenceSegmentProcessorEnd() override {}
+    virtual void onSequenceSegmentProcessorError(const std::string& segment_name, const std::string& processor_name, const std::string& error) override {};
 
     /**
       ISampleGroupProcessorObserver
     */
-    virtual void onSampleGroupProcessorStart(const size_t nb_segments) override {}
-    virtual void onSampleGroupProcessorSampleStart(const std::string& segment_name) override
+    virtual void onSampleGroupProcessorStart(const size_t nb_groups) override {}
+    virtual void onSampleGroupProcessorSampleStart(const std::string& group_name) override
     { 
         m_event_type = 2; 
-        m_event_name = segment_name;
+        m_event_name = group_name;
     }
-    virtual void onSampleGroupProcessorSampleEnd(const std::string& segment_name) override {}
+    virtual void onSampleGroupProcessorSampleEnd(const std::string& group_name) override {}
     virtual void onSampleGroupProcessorEnd() override {}
+    virtual void onSampleGroupProcessorError(const std::string& group_name, const std::string& processor_name, const std::string& error) override {};
 
 private:
     std::string formatted_time(const std::chrono::steady_clock::duration& duration) const;

--- a/src/smartpeak/include/SmartPeak/core/ApplicationProcessorObservable.h
+++ b/src/smartpeak/include/SmartPeak/core/ApplicationProcessorObservable.h
@@ -75,6 +75,13 @@ namespace SmartPeak
         observer->onApplicationProcessorEnd();
       }
     }
+    void notifyApplicationProcessorError(const std::string& error)
+    {
+      for (auto& observer : observers_)
+      {
+        observer->onApplicationProcessorError(error);
+      }
+    }
   protected:
     std::vector<IApplicationProcessorObserver*> observers_;
   };

--- a/src/smartpeak/include/SmartPeak/core/EventDispatcher.h
+++ b/src/smartpeak/include/SmartPeak/core/EventDispatcher.h
@@ -88,10 +88,12 @@ namespace SmartPeak
     virtual void onSequenceProcessorSampleStart(const std::string& sample_name) override;
     virtual void onSequenceProcessorSampleEnd(const std::string& sample_name) override;
     virtual void onSequenceProcessorEnd() override;
+    virtual void onSequenceProcessorError(const std::string& sample_name, const std::string& processor_name, const std::string& error) override;
     virtual void onSequenceSegmentProcessorStart(const size_t nb_segments) override;
     virtual void onSequenceSegmentProcessorSampleStart(const std::string& segment_name) override;
     virtual void onSequenceSegmentProcessorSampleEnd(const std::string& segment_name) override;
     virtual void onSequenceSegmentProcessorEnd() override;
+    virtual void onSequenceSegmentProcessorError(const std::string& segment_name, const std::string& processor_name, const std::string& error) override;
 
     /**
       ISampleGroupProcessorObserver
@@ -100,6 +102,7 @@ namespace SmartPeak
     virtual void onSampleGroupProcessorSampleStart(const std::string& group_name) override;
     virtual void onSampleGroupProcessorSampleEnd(const std::string& group_name) override;
     virtual void onSampleGroupProcessorEnd() override;
+    virtual void onSampleGroupProcessorError(const std::string& group_name, const std::string& processor_name, const std::string& error) override;
 
     /**
       ISequenceObserver

--- a/src/smartpeak/include/SmartPeak/core/EventDispatcher.h
+++ b/src/smartpeak/include/SmartPeak/core/EventDispatcher.h
@@ -75,6 +75,7 @@ namespace SmartPeak
     virtual void onApplicationProcessorCommandStart(size_t command_index, const std::string& command_name) override;
     virtual void onApplicationProcessorCommandEnd(size_t command_index, const std::string& command_name) override;
     virtual void onApplicationProcessorEnd() override;
+    virtual void onApplicationProcessorError(const std::string& error) override;
     
     /**
       IFeaturesObserver

--- a/src/smartpeak/include/SmartPeak/core/ProgressInfo.h
+++ b/src/smartpeak/include/SmartPeak/core/ProgressInfo.h
@@ -78,6 +78,7 @@ namespace SmartPeak
     virtual void onSequenceProcessorSampleStart(const std::string& sample) override;
     virtual void onSequenceProcessorSampleEnd(const std::string& sample) override;
     virtual void onSequenceProcessorEnd() override;
+    virtual void onSequenceProcessorError(const std::string& sample_name, const std::string& processor_name, const std::string& error) override;
 
     /**
       ISequenceSegmentProcessorObserver
@@ -86,6 +87,7 @@ namespace SmartPeak
     virtual void onSequenceSegmentProcessorSampleStart(const std::string& segment_name) override;
     virtual void onSequenceSegmentProcessorSampleEnd(const std::string& segment_name) override;
     virtual void onSequenceSegmentProcessorEnd() override;
+    virtual void onSequenceSegmentProcessorError(const std::string& segment_name, const std::string& processor_name, const std::string& error) override;
 
     /**
       ISampleGroupProcessorObserver
@@ -94,7 +96,8 @@ namespace SmartPeak
     virtual void onSampleGroupProcessorSampleStart(const std::string& segment_name) override;
     virtual void onSampleGroupProcessorSampleEnd(const std::string& segment_name) override;
     virtual void onSampleGroupProcessorEnd() override;
-  
+    virtual void onSampleGroupProcessorError(const std::string& group_name, const std::string& processor_name, const std::string& error) override;
+
   public:
 
     /**
@@ -141,6 +144,11 @@ namespace SmartPeak
     */
     std::chrono::steady_clock::duration lastRunTime() const { return last_run_time_; };
 
+    /**
+      @brief detailed about errors
+    */
+    const std::vector<std::string>& errors() const { return errors_; };
+
   private:
     void onRunningBatchEndItem(const std::string& item_name);
 
@@ -166,5 +174,6 @@ namespace SmartPeak
     };
     std::shared_ptr<RunningBatch> running_batch_;
     std::chrono::steady_clock::duration last_run_time_ = std::chrono::steady_clock::duration::zero();
+    std::vector<std::string> errors_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/ProgressInfo.h
+++ b/src/smartpeak/include/SmartPeak/core/ProgressInfo.h
@@ -70,6 +70,7 @@ namespace SmartPeak
     virtual void onApplicationProcessorCommandStart(size_t command_index, const std::string& command_name) override;
     virtual void onApplicationProcessorCommandEnd(size_t command_index, const std::string& command_name) override;
     virtual void onApplicationProcessorEnd() override;
+    virtual void onApplicationProcessorError(const std::string& error) override;
 
     /**
       ISequenceProcessorObserver

--- a/src/smartpeak/include/SmartPeak/core/SampleGroupProcessorObservable.h
+++ b/src/smartpeak/include/SmartPeak/core/SampleGroupProcessorObservable.h
@@ -75,6 +75,13 @@ namespace SmartPeak
         observer->onSampleGroupProcessorEnd();
       }
     }
+    void notifySampleGroupProcessorError(const std::string& group_name, const std::string& processor_name, const std::string& error)
+    {
+      for (auto& observer : observers_)
+      {
+        observer->onSampleGroupProcessorError(group_name, processor_name, error);
+      }
+    }
   protected:
     std::vector<ISampleGroupProcessorObserver*> observers_;
   };

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessorObservable.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessorObservable.h
@@ -75,6 +75,13 @@ namespace SmartPeak
         observer->onSequenceProcessorEnd();
       }
     }
+    void notifySequenceError(const std::string& sample_name, const std::string& processor_name, const std::string& error)
+    {
+      for (auto& observer : observers_)
+      {
+        observer->onSequenceProcessorError(sample_name, processor_name, error);
+      }
+    }
   protected:
     std::vector<ISequenceProcessorObserver*> observers_;
   };

--- a/src/smartpeak/include/SmartPeak/core/SequenceProcessorObservable.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceProcessorObservable.h
@@ -75,7 +75,7 @@ namespace SmartPeak
         observer->onSequenceProcessorEnd();
       }
     }
-    void notifySequenceError(const std::string& sample_name, const std::string& processor_name, const std::string& error)
+    void notifySequenceProcessorError(const std::string& sample_name, const std::string& processor_name, const std::string& error)
     {
       for (auto& observer : observers_)
       {

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessorObservable.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessorObservable.h
@@ -75,6 +75,13 @@ namespace SmartPeak
         observer->onSequenceSegmentProcessorEnd();
       }
     }
+    void notifySequenceSegmentProcessorError(const std::string& segment_name, const std::string& processor_name, const std::string& error)
+    {
+      for (auto& observer : observers_)
+      {
+        observer->onSequenceSegmentProcessorError(segment_name, processor_name, error);
+      }
+    }
   protected:
     std::vector<ISequenceSegmentProcessorObserver*> observers_;
   };

--- a/src/smartpeak/include/SmartPeak/iface/IApplicationProcessorObserver.h
+++ b/src/smartpeak/include/SmartPeak/iface/IApplicationProcessorObserver.h
@@ -30,12 +30,10 @@ namespace SmartPeak
 {
   struct IApplicationProcessorObserver
   {
-    /**
-      Parameters have been updated
-    */
     virtual void onApplicationProcessorStart(const std::vector<std::string>& commands) = 0;
     virtual void onApplicationProcessorCommandStart(size_t command_index, const std::string& command_name) = 0;
     virtual void onApplicationProcessorCommandEnd(size_t command_index, const std::string& command_name) = 0;
     virtual void onApplicationProcessorEnd() = 0;
+    virtual void onApplicationProcessorError(const std::string& error) = 0;
   };
 }

--- a/src/smartpeak/include/SmartPeak/iface/ISampleGroupProcessorObserver.h
+++ b/src/smartpeak/include/SmartPeak/iface/ISampleGroupProcessorObserver.h
@@ -31,5 +31,6 @@ namespace SmartPeak
     virtual void onSampleGroupProcessorSampleStart(const std::string& segment_name) = 0;
     virtual void onSampleGroupProcessorSampleEnd(const std::string& segment_name) = 0;
     virtual void onSampleGroupProcessorEnd() = 0;
+    virtual void onSampleGroupProcessorError(const std::string& group_name, const std::string& processor_name, const std::string& error) = 0;
   };
 }

--- a/src/smartpeak/include/SmartPeak/iface/ISequenceProcessorObserver.h
+++ b/src/smartpeak/include/SmartPeak/iface/ISequenceProcessorObserver.h
@@ -31,5 +31,6 @@ namespace SmartPeak
     virtual void onSequenceProcessorSampleStart(const std::string& sample_name) = 0;
     virtual void onSequenceProcessorSampleEnd(const std::string& sample_name) = 0;
     virtual void onSequenceProcessorEnd() = 0;
+    virtual void onSequenceProcessorError(const std::string& sample_name, const std::string& processor_name, const std::string& error) = 0;
   };
 }

--- a/src/smartpeak/include/SmartPeak/iface/ISequenceSegmentProcessorObserver.h
+++ b/src/smartpeak/include/SmartPeak/iface/ISequenceSegmentProcessorObserver.h
@@ -31,5 +31,6 @@ namespace SmartPeak
     virtual void onSequenceSegmentProcessorSampleStart(const std::string& segment_name) = 0;
     virtual void onSequenceSegmentProcessorSampleEnd(const std::string& segment_name) = 0;
     virtual void onSequenceSegmentProcessorEnd() = 0;
+    virtual void onSequenceSegmentProcessorError(const std::string& segment_name, const std::string& processor_name, const std::string& error) = 0;
   };
 }

--- a/src/smartpeak/include/SmartPeak/ui/InfoWidget.h
+++ b/src/smartpeak/include/SmartPeak/ui/InfoWidget.h
@@ -72,13 +72,11 @@ namespace SmartPeak
 
     void setTransitions(const Eigen::Tensor<std::string, 2>* transitions) { transitions_ = transitions; };
 
-    void setFileLoadingDone(bool done, bool load_error)  { file_loading_is_done_ = done; file_load_error_ = load_error;};
     void clearErrorMessages() { error_messages_.clear(); };
     void addErrorMessage(const std::string& error_message) { error_messages_.push_back(error_message); };
 
   private:
     void drawWorkflowStatus();
-    void drawFileloadingStatus();
     void drawErrorMessages();
     void drawChromatograms();
     void drawSpectrums();

--- a/src/smartpeak/include/SmartPeak/ui/InfoWidget.h
+++ b/src/smartpeak/include/SmartPeak/ui/InfoWidget.h
@@ -86,6 +86,7 @@ namespace SmartPeak
     void drawTransition();
     void drawLastRunTime();
     void drawWorkflowProgress();
+    void drawListOfErrors();
     std::string formattedTime(const std::chrono::steady_clock::duration& duration) const;
 
   protected:

--- a/src/smartpeak/include/SmartPeak/ui/LoadSessionWizard.h
+++ b/src/smartpeak/include/SmartPeak/ui/LoadSessionWizard.h
@@ -35,7 +35,9 @@ namespace SmartPeak
 {
   struct LoadSessionWizard : IFilePickerHandler
   {
-    LoadSessionWizard(std::shared_ptr<SessionFilesWidget>& session_files_widget_manage) :
+    LoadSessionWizard(std::shared_ptr<SessionFilesWidget>& session_files_widget_manage,
+                      IApplicationProcessorObserver* application_observer) :
+      application_observer_(application_observer),
       session_files_widget_manage_(session_files_widget_manage)
     {};
 
@@ -44,6 +46,7 @@ namespace SmartPeak
     */
     bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
   protected:
+    IApplicationProcessorObserver* application_observer_ = nullptr;
     std::shared_ptr<SessionFilesWidget> session_files_widget_manage_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/ui/SessionFilesWidget.h
+++ b/src/smartpeak/include/SmartPeak/ui/SessionFilesWidget.h
@@ -41,7 +41,7 @@ namespace SmartPeak
       EModification
     };
 
-    SessionFilesWidget(ApplicationHandler& application_handler, SessionFilesWidget::Mode mode);
+    SessionFilesWidget(ApplicationHandler& application_handler, SessionFilesWidget::Mode mode, IApplicationProcessorObserver* application_observer);
 
     void draw() override;
     void open(const Filenames& filenames, const std::set<std::string>& requirements = {});
@@ -101,6 +101,7 @@ namespace SmartPeak
     bool one_missing_requirement_ = false;
     bool one_invalid_ = false;
     int id_ = 1;
+    IApplicationProcessorObserver* application_observer_ = nullptr;
     static std::vector<std::string> file_modes_strings_;
   };
 }

--- a/src/smartpeak/source/core/EventDispatcher.cpp
+++ b/src/smartpeak/source/core/EventDispatcher.cpp
@@ -108,7 +108,7 @@ namespace SmartPeak
     void EventDispatcher::onSequenceProcessorError(const std::string& sample_name, const std::string& processor_name, const std::string& error)
     {
       queueEvent(std::make_shared<std::future<void>>(std::async(std::launch::deferred,
-        [this, sample_name, processor_name, error] { this->notifySequenceError(sample_name, processor_name, error); }
+        [this, sample_name, processor_name, error] { this->notifySequenceProcessorError(sample_name, processor_name, error); }
       )));
     }
     void EventDispatcher::onSequenceSegmentProcessorStart(const size_t nb_segments)

--- a/src/smartpeak/source/core/EventDispatcher.cpp
+++ b/src/smartpeak/source/core/EventDispatcher.cpp
@@ -61,6 +61,12 @@ namespace SmartPeak
         [this] { this->notifyApplicationProcessorEnd(); }
       )));
     }
+    void EventDispatcher::onApplicationProcessorError(const std::string& error)
+    {
+      queueEvent(std::make_shared<std::future<void>>(std::async(std::launch::deferred,
+        [this, error] { this->notifyApplicationProcessorError(error); }
+      )));
+    }
 
     /**
       IFeaturesObserver

--- a/src/smartpeak/source/core/EventDispatcher.cpp
+++ b/src/smartpeak/source/core/EventDispatcher.cpp
@@ -99,6 +99,12 @@ namespace SmartPeak
         [this] { this->notifySequenceProcessorEnd(); }
       )));
     }
+    void EventDispatcher::onSequenceProcessorError(const std::string& sample_name, const std::string& processor_name, const std::string& error)
+    {
+      queueEvent(std::make_shared<std::future<void>>(std::async(std::launch::deferred,
+        [this, sample_name, processor_name, error] { this->notifySequenceError(sample_name, processor_name, error); }
+      )));
+    }
     void EventDispatcher::onSequenceSegmentProcessorStart(const size_t nb_segments)
     {
       queueEvent(std::make_shared<std::future<void>>(std::async(std::launch::deferred,
@@ -121,6 +127,12 @@ namespace SmartPeak
     {
       queueEvent(std::make_shared<std::future<void>>(std::async(std::launch::deferred,
         [this] { this->notifySequenceSegmentProcessorEnd(); }
+      )));
+    }
+    void EventDispatcher::onSequenceSegmentProcessorError(const std::string& segment_name, const std::string& processor_name, const std::string& error)
+    {
+      queueEvent(std::make_shared<std::future<void>>(std::async(std::launch::deferred,
+        [this, segment_name, processor_name, error] { this->notifySequenceSegmentProcessorError(segment_name, processor_name, error); }
       )));
     }
 
@@ -149,6 +161,12 @@ namespace SmartPeak
     {
       queueEvent(std::make_shared<std::future<void>>(std::async(std::launch::deferred,
         [this] { this->notifySampleGroupProcessorEnd(); }
+      )));
+    }
+    void EventDispatcher::onSampleGroupProcessorError(const std::string& group_name, const std::string& processor_name, const std::string& error)
+    {
+      queueEvent(std::make_shared<std::future<void>>(std::async(std::launch::deferred,
+        [this, group_name, processor_name, error] { this->notifySampleGroupProcessorError(group_name, processor_name, error); }
       )));
     }
 

--- a/src/smartpeak/source/core/ProgessInfo.cpp
+++ b/src/smartpeak/source/core/ProgessInfo.cpp
@@ -57,6 +57,11 @@ namespace SmartPeak
     running_ = false;
   }
 
+  void ProgressInfo::onApplicationProcessorError(const std::string& error)
+  {
+    errors_.push_back(error);
+  }
+
   void ProgressInfo::onSequenceProcessorStart(const size_t nb_injections)
   {
     running_batch_ = std::make_shared<RunningBatch>(nb_injections);

--- a/src/smartpeak/source/core/ProgessInfo.cpp
+++ b/src/smartpeak/source/core/ProgessInfo.cpp
@@ -33,6 +33,7 @@ namespace SmartPeak
     commands_step_ = 0;
     all_commands_ = commands;
     application_processor_start_time_ = std::chrono::steady_clock::now();
+    errors_.clear();
   }
 
   void ProgressInfo::onApplicationProcessorCommandStart(size_t command_index, const std::string& command_name)
@@ -75,6 +76,11 @@ namespace SmartPeak
   {
   }
 
+  void ProgressInfo::onSequenceProcessorError(const std::string& sample_name, const std::string& processor_name, const std::string& error)
+  {
+    errors_.push_back(sample_name + ", " + processor_name + ": " + error);
+  }
+
   void ProgressInfo::onSequenceSegmentProcessorStart(const size_t nb_segments)
   {
     running_batch_ = std::make_shared<RunningBatch>(nb_segments);
@@ -94,6 +100,11 @@ namespace SmartPeak
   {
   }
 
+  void ProgressInfo::onSequenceSegmentProcessorError(const std::string& segment_name, const std::string& processor_name, const std::string& error)
+  {
+    errors_.push_back(segment_name + ", " + processor_name + ": " + error);
+  }
+
   void ProgressInfo::onSampleGroupProcessorStart(const size_t nb_groups)
   {
     running_batch_ = std::make_shared<RunningBatch>(nb_groups);
@@ -111,6 +122,11 @@ namespace SmartPeak
 
   void ProgressInfo::onSampleGroupProcessorEnd()
   {
+  }
+
+  void ProgressInfo::onSampleGroupProcessorError(const std::string& group_name, const std::string& processor_name, const std::string& error)
+  {
+    errors_.push_back(group_name + ", " + processor_name + ": " + error);
   }
 
   void ProgressInfo::onRunningBatchEndItem(const std::string& item_name)

--- a/src/smartpeak/source/core/RawDataProcessor.cpp
+++ b/src/smartpeak/source/core/RawDataProcessor.cpp
@@ -2548,7 +2548,7 @@ namespace SmartPeak
       f.setSubordinates(f_map.second);
       fmap.push_back(f);
     }
-
+    rawDataHandler_IO.setFeatureMap(fmap);
     rawDataHandler_IO.updateFeatureMapHistory();
 
     LOGI << "MergeFeatures output size: " << rawDataHandler_IO.getFeatureMap().size();

--- a/src/smartpeak/source/core/RawDataProcessor.cpp
+++ b/src/smartpeak/source/core/RawDataProcessor.cpp
@@ -334,8 +334,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToStore(filenames_I, "mzML_i"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to store output file");
     }
 
     OpenMS::MzMLFile mzmlfile;
@@ -366,8 +365,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToLoad(filenames_I, "featureXML_i"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to load input file");
     }
 
     try {
@@ -410,8 +408,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToStore(filenames_I, "featureXML_o"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to store output file");
     }
 
     // Store outfile as featureXML
@@ -437,8 +434,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToLoad(filenames_I, "mzTab_i"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to load input file");
     }
 
     try {
@@ -477,8 +473,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToStore(filenames_I, "mzTab_o"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to store output file");
     }
 
     // Store outfile as mzTab
@@ -630,9 +625,7 @@ namespace SmartPeak
       params_I.at("MRMFeatureSelector.schedule_MRMFeatures_score").empty();
 
     if (qmip_params_passed_but_empty || score_params_passed_but_empty) {
-      LOGE << "Parameters missing for selectFeatures. Not selecting";
-      LOGD << "END selectFeatures";
-      return;
+      throw std::invalid_argument("Missing parameters");
     }
 
     OpenMS::FeatureMap output;
@@ -827,16 +820,14 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToLoad(filenames_I, "traML"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to load input file");
     }
 
     const auto format_param = params.findParameter("LoadTransitions", "format");
     if (!format_param)
     {
       // should actually not happen since we merge with the default params
-      LOGE << "LoadTransitions/format parameter not found";
-      return;
+      throw std::invalid_argument("LoadTransitions/format parameter not found");
     }
 
     const std::string format = format_param->getValueAsString();
@@ -1067,8 +1058,7 @@ namespace SmartPeak
     getFilenames(filenames_I);
     if (!InputDataValidation::prepareToLoad(filenames_I, "referenceData"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to load input file");
     }
 
     try
@@ -1134,7 +1124,7 @@ namespace SmartPeak
         );
         if (!db_context)
         {
-          return;
+          throw std::runtime_error("Failed to load from session database");
         }
         while (filenames_I.getSessionDB().read(
           *db_context,
@@ -1302,8 +1292,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToStore(filenames_I, "referenceData"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to load input file");
     }
     if (filenames_I.isEmbedded("referenceData"))
     {
@@ -1329,7 +1318,7 @@ namespace SmartPeak
       );
       if (!db_context)
       {
-        return;
+        throw std::runtime_error("Failed to save in session database");
       }
       std::vector<std::map<std::string, CastValue>>& reference_data = rawDataHandler_IO.getReferenceData();
       for (const auto& ref : reference_data)
@@ -1397,8 +1386,7 @@ namespace SmartPeak
     getFilenames(filenames_I);
     if (!InputDataValidation::prepareToLoad(filenames_I, "parameters"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to load input file");
     }
     if (filenames_I.isEmbedded("parameters"))
     {
@@ -1411,7 +1399,7 @@ namespace SmartPeak
       );
       if (!db_context)
       {
-        return;
+        throw std::runtime_error("Failed to load from session database");
       }
       ParameterSet parameters;
       std::string function;
@@ -1529,8 +1517,7 @@ namespace SmartPeak
     LOGD << "START StoreParameters";
     if (!InputDataValidation::prepareToStore(filenames_I, "parameters"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to store output file");
     }
     if (filenames_I.isEmbedded("parameters"))
     {
@@ -1543,7 +1530,7 @@ namespace SmartPeak
       );
       if (!db_context)
       {
-        return;
+        throw std::runtime_error("Failed to save in session database");
       }
       const auto& parameters = rawDataHandler_IO.getParameters();
       for (const auto& parameter_function : parameters)
@@ -1566,9 +1553,7 @@ namespace SmartPeak
       getFilenames(filenames_I);
       LOGI << "Storing " << filename_;
       if (filenames_I.getFullPath("parameters").empty()) {
-        LOGE << "Filename is empty";
-        LOGD << "END readRawDataProcessingParameters";
-        return;
+        throw std::invalid_argument("Failed to store output file");
       }
       ParametersParser::write(filenames_I.getFullPath("parameters").generic_string(), rawDataHandler_IO.getParameters());
     }
@@ -1742,9 +1727,7 @@ namespace SmartPeak
     }
 
     if (stop == 0) {
-      LOGE << "No parameters passed to ExtractSpectraWindows.  Spectra will not be extracted.";
-      LOGD << "END ExtractSpectraWindows";
-      return;
+      throw std::invalid_argument("No parameters passed to ExtractSpectraWindows.  Spectra will not be extracted.");
     }
 
     std::vector<OpenMS::MSSpectrum> output;
@@ -2104,9 +2087,7 @@ namespace SmartPeak
     }
 
     if (resolution == 0 || max_mz == 0 || bin_step == 0) {
-      LOGE << "Missing parameters for MergeSpectra.  Spectra will not be merged.";
-      LOGD << "END MergeSpectra";
-      return;
+      throw std::invalid_argument("Missing parameters");
     }
 
     // calculate the bin sizes and mass buckets
@@ -2294,9 +2275,7 @@ namespace SmartPeak
       }
     }
     if (sn_window == 0) {
-      LOGE << "Missing sne:window parameter for PickMS1Features. Not picking";
-      LOGD << "END PickMS1Features";
-      return;
+      throw std::invalid_argument("Missing sne : window parameter for PickMS1Features. Not picking.");
     }
     
     OpenMS::SavitzkyGolayFilter sgfilter;
@@ -3106,9 +3085,8 @@ namespace SmartPeak
     }
     if (ms_peakmap.empty())
     {
-      LOGW << "The given file does not contain any conventional peak data, but might"
-        " contain chromatograms. This tool currently cannot handle them, sorry.";
-      return;
+      throw std::invalid_argument("The given file does not contain any conventional peak data, but might"
+                                  " contain chromatograms. This tool currently cannot handle them, sorry.");
     }
 
     // determine type of spectral data (profile or centroided)
@@ -3119,8 +3097,7 @@ namespace SmartPeak
       Parameter* force_processing = pick_ms2_feature_params.findParameter("force_processing");
       if (!force_processing || force_processing->getValueAsString() == "false")
       {
-        LOGE << "Error: Profile data provided but centroided spectra expected. To enforce processing of the data set the force_processing parameter.";
-        return;
+        throw std::invalid_argument("Error: Profile data provided but centroided spectra expected. To enforce processing of the data set the force_processing parameter.");
       }
     }
 
@@ -3196,8 +3173,7 @@ namespace SmartPeak
     {
       if (!feat.metaValueExists("num_of_masstraces"))
       {
-        LOGE << "MetaValue 'num_of_masstraces' missing from FFMetabo output!";
-        return;
+        throw std::invalid_argument("MetaValue 'num_of_masstraces' missing from FFMetabo output!");
       }
       trace_count += (size_t)feat.getMetaValue("num_of_masstraces");
     }
@@ -3205,8 +3181,7 @@ namespace SmartPeak
     {
       if (!ffmet_parameters.getValue("remove_single_traces").toBool())
       {
-        LOGE << "FF-Metabo: Internal error. Not all mass traces have been assembled to features! Aborting.";
-        return;
+        throw std::invalid_argument("FF-Metabo: Internal error. Not all mass traces have been assembled to features! Aborting.");
       }
       else
       {

--- a/src/smartpeak/source/core/SampleGroupProcessor.cpp
+++ b/src/smartpeak/source/core/SampleGroupProcessor.cpp
@@ -213,9 +213,7 @@ namespace SmartPeak
 
     // Check the parameters
     if (params_I.at("MergeInjections").empty() && params_I.at("MergeInjections").empty()) {
-      LOGE << "Parameters not found for MergeInjections. Returning";
-      LOGD << "END MergeInjections";
-      return;
+      throw std::invalid_argument("Parameters not found");
     }
 
     // Extract out the parameters
@@ -276,9 +274,7 @@ namespace SmartPeak
     }
     if (scan_polarity_merge_rule.empty() || mass_range_merge_rule.empty() || dilution_series_merge_rule.empty() || 
       scan_polarity_merge_feature_name.empty() || mass_range_merge_feature_name.empty() || dilution_series_merge_feature_name.empty()) {
-      LOGE << "Missing parameters for MergeInjections. Not merging.";
-      LOGD << "END MergeInjections";
-      return;
+      throw std::invalid_argument("Parameters not found");
     }
 
     // Get the injection names for all the different scan polarities, mass ranges and dilutions
@@ -718,8 +714,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToLoad(filenames_I, "featureXMLSampleGroup_i"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to load input file");
     }
 
     try {
@@ -757,8 +752,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToStore(filenames_I, "featureXMLSampleGroup_o"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to store output file");
     }
 
     // Store outfile as featureXML

--- a/src/smartpeak/source/core/SampleGroupProcessor.cpp
+++ b/src/smartpeak/source/core/SampleGroupProcessor.cpp
@@ -77,7 +77,7 @@ namespace SmartPeak
     catch (const std::exception& e)
     {
       LOGE << "Failed to read select dilutions file [" << filenames_I.getFullPath("selectDilutions").generic_string() << "] : " << e.what();
-      return;
+      throw e;
     }
 
     std::map<std::string, std::set<int>> existing_dilutions_map;
@@ -730,6 +730,7 @@ namespace SmartPeak
       LOGE << e.what();
       sampleGroupHandler_IO.getFeatureMap().clear();
       LOGE << "feature map clear";
+      throw e;
     }
 
     LOGD << "END LoadFeaturesSampleGroup";
@@ -760,14 +761,9 @@ namespace SmartPeak
       return;
     }
 
-    try {
-      // Store outfile as featureXML
-      OpenMS::FeatureXMLFile featurexml;
-      featurexml.store(filenames_I.getFullPath("featureXMLSampleGroup_o").generic_string(), sampleGroupHandler_IO.getFeatureMap());
-    }
-    catch (const std::exception& e) {
-      LOGE << e.what();
-    }
+    // Store outfile as featureXML
+    OpenMS::FeatureXMLFile featurexml;
+    featurexml.store(filenames_I.getFullPath("featureXMLSampleGroup_o").generic_string(), sampleGroupHandler_IO.getFeatureMap());
 
     LOGD << "END storeFeaturesSampleGroup";
   }

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -482,7 +482,7 @@ namespace SmartPeak
         {
           if (observable_)
           {
-            observable_->notifySequenceError(
+            observable_->notifySequenceProcessorError(
               e.item(),
               e.processor(),
               e.what());

--- a/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessor.cpp
@@ -110,9 +110,7 @@ namespace SmartPeak
 
     // check if there are any standards to calculate the calibrators from
     if (standards_indices.empty()) {
-      LOGE << "standards_indices argument is empty. Returning";
-      LOGD << "END optimizeCalibrationCurves";
-      return;
+      throw std::invalid_argument("standards_indices argument is empty.");
     }
 
     std::vector<OpenMS::FeatureMap> standards_featureMaps;
@@ -221,8 +219,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToLoad(filenames_I, "standardsConcentrations"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to load input file");
     }
 
     try
@@ -241,7 +238,7 @@ namespace SmartPeak
         );
         if (!db_context)
         {
-          return;
+          throw std::runtime_error("Failed to load from session database");
         }
         OpenMS::AbsoluteQuantitationStandards::runConcentration run_concentration;
         while (filenames_I.getSessionDB().read(
@@ -314,8 +311,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToStore(filenames_I, "standardsConcentrations"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to store output file");
     }
     if (filenames_I.isEmbedded("standardsConcentrations"))
     {
@@ -331,7 +327,7 @@ namespace SmartPeak
         );
       if (!db_context)
       {
-        return;
+        throw std::runtime_error("Failed to save in session database");
       }
       for (const auto& concentration : sequenceSegmentHandler_IO.getStandardsConcentrations())
       {
@@ -396,8 +392,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToLoad(filenames_I, "quantitationMethods"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to load input file");
     }
 
     try {
@@ -440,8 +435,7 @@ namespace SmartPeak
 
     if (!InputDataValidation::prepareToStore(filenames_I, "quantitationMethods"))
     {
-      LOGD << "END " << getName();
-      return;
+      throw std::invalid_argument("Failed to store output file");
     }
 
     try {
@@ -1266,9 +1260,7 @@ namespace SmartPeak
 
     // check if there are any standards or QCs to estimate the feature filter parameters from
     if (standards_indices.empty() && qcs_indices.empty()) {
-      LOGE << "standards_indices and/or qcs_indices argument is empty. Returning";
-      LOGD << "END estimateFeatureFilterValues";
-      return;
+      throw std::invalid_argument("standards_indices and/or qcs_indices argument is empty. Returning");
     }
 
     // OPTIMIZATION: it would be prefered to only use those standards that are part of the optimized calibration curve for each component
@@ -1331,9 +1323,7 @@ namespace SmartPeak
 
     // check if there are any standards or QCs to estimate the feature filter parameters from
     if (standards_indices.empty() && qcs_indices.empty()) {
-      LOGE << "standards_indices and/or qcs_indices argument is empty. Returning";
-      LOGD << "END estimateFeatureQCValues";
-      return;
+      throw std::invalid_argument("standards_indices and/or qcs_indices argument is empty.");
     }
 
     // OPTIMIZATION: it would be prefered to only use those standards that are part of the optimized calibration curve for each component
@@ -1378,9 +1368,7 @@ namespace SmartPeak
 
     // check if there are any quantitation methods
     if (sequenceSegmentHandler_IO.getQuantitationMethods().empty()) {
-      LOGE << "quantitation methods is empty. Returning";
-      LOGD << "END TransferLOQToFeatureFilters";
-      return;
+      throw std::invalid_argument("quantitation methods is empty.");
     }
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1414,9 +1402,7 @@ namespace SmartPeak
 
     // check if there are any quantitation methods
     if (sequenceSegmentHandler_IO.getQuantitationMethods().empty()) {
-      LOGE << "quantitation methods is empty. Returning";
-      LOGD << "END TransferLOQToFeatureQCs";
-      return;
+      throw std::invalid_argument("quantitation methods is empty.");
     }
 
     OpenMS::MRMFeatureFilter featureFilter;
@@ -1459,9 +1445,7 @@ namespace SmartPeak
 
     // check if there are any standards or QCs to estimate the feature filter parameters from
     if (qcs_indices.empty()) {
-      LOGE << "qcs_indices argument is empty. Returning";
-      LOGD << "END EstimateFeatureRSDs";
-      return;
+      throw std::invalid_argument("qcs_indices argument is empty.");
     }
 
     std::vector<OpenMS::FeatureMap> qcs_featureMaps;
@@ -1512,9 +1496,7 @@ namespace SmartPeak
 
     // check if there are any Blanks to estimate the background interference from
     if (blanks_indices.empty()) {
-      LOGE << "blanks_indices argument is empty. Returning";
-      LOGD << "END EstimateFeatureBackgroundInterferences";
-      return;
+      throw std::invalid_argument("blanks_indices argument is empty.");
     }
 
     std::vector<OpenMS::FeatureMap> blanks_featureMaps;

--- a/src/smartpeak/source/ui/InfoWidget.cpp
+++ b/src/smartpeak/source/ui/InfoWidget.cpp
@@ -38,6 +38,7 @@ namespace SmartPeak
     showQuickHelpToolTip("Info");
     
     drawWorkflowStatus();
+    drawListOfErrors();
 
     ImGui::Separator();
 
@@ -235,8 +236,32 @@ namespace SmartPeak
         }
         ImGui::TreePop();
       }
-
       spinner_counter_++;
+    }
+  }
+
+  void InfoWidget::drawListOfErrors()
+  {
+    static const int max_number_of_errors = 10;
+    if (!progress_info_.errors().empty())
+    {
+      ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.0f, 0.0f, 1.0f));
+      if (ImGui::TreeNode("Errors (see logs for details)"))
+      {
+        int cpt = 0;
+        for (const auto& error : progress_info_.errors())
+        {
+          ImGui::Text("%s", error.c_str());
+          ++cpt;
+          if (cpt == max_number_of_errors)
+          {
+            ImGui::Text("... and %d more errors.", progress_info_.errors().size() - cpt);
+            break;
+          }
+        }
+        ImGui::TreePop();
+      }
+      ImGui::PopStyleColor();
     }
   }
 

--- a/src/smartpeak/source/ui/InfoWidget.cpp
+++ b/src/smartpeak/source/ui/InfoWidget.cpp
@@ -39,10 +39,6 @@ namespace SmartPeak
     
     drawWorkflowStatus();
     drawListOfErrors();
-
-    ImGui::Separator();
-
-    drawFileloadingStatus();
     drawLastRunTime();
     drawErrorMessages();
 
@@ -65,22 +61,6 @@ namespace SmartPeak
     else
     {
       ImGui::Text("Workflow status: done");
-    }
-  }
-
-  void InfoWidget::drawFileloadingStatus()
-  {
-    if (file_load_error_)
-    {
-      std::ostringstream os;
-      os << "File loading failed.  Check the `Information` log.";
-      ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.0f, 0.0f, 1.0f));
-      ImGui::Text("%s", os.str().c_str());
-      ImGui::PopStyleColor();
-    }
-    else
-    {
-      ImGui::Text(file_loading_is_done_ ? "File loading status: done" : "File loading status: running...");
     }
   }
 

--- a/src/smartpeak/source/ui/LoadSessionWizard.cpp
+++ b/src/smartpeak/source/ui/LoadSessionWizard.cpp
@@ -55,8 +55,15 @@ namespace SmartPeak
         application_handler->filenames_ = *filenames;
         application_handler->main_dir_ = filenames->getTag(Filenames::Tag::MAIN_DIR);
         LoadSession load_session(*application_handler);
+        load_session.addApplicationProcessorObserver(application_observer_);
         load_session.filenames_ = filenames;
-        load_session.process();
+        load_session.notifyApplicationProcessorStart({}); // we need a proper loading in thread to profit from the progressbar
+        if (!load_session.process())
+        {
+          // load failed
+          application_handler->closeSession();
+        }
+        load_session.notifyApplicationProcessorEnd();
       }
     }
     return true;

--- a/src/smartpeak/source/ui/SessionFilesWidget.cpp
+++ b/src/smartpeak/source/ui/SessionFilesWidget.cpp
@@ -189,7 +189,11 @@ namespace SmartPeak
     const auto full_path_name = filenames_.getFullPath(file_id);
     std::string displayed_path;
     std::filesystem::path main_dir_path(filenames_.getTag(Filenames::Tag::MAIN_DIR));
-    std::string relative_path = std::filesystem::relative(full_path_name, main_dir_path).generic_string();
+    std::string relative_path;
+    if (!full_path_name.empty())
+    {
+      relative_path = std::filesystem::relative(full_path_name, main_dir_path).generic_string();
+    }
     bool is_embedded = filenames_.isEmbedded(file_id);
     bool file_exists = std::filesystem::exists(full_path_name);
     if (mode_ == Mode::EModification)

--- a/src/tests/class_tests/smartpeak/source/EventDispatcher_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/EventDispatcher_test.cpp
@@ -86,11 +86,11 @@ struct EventDispatcherFixture : public ::testing::Test
     }
     virtual void onApplicationProcessorError(const std::string& error) override
     {
-      // TODO
+      events_.push_back(std::make_tuple("onApplicationProcessorError", 0, "", std::vector<std::string>({ error })));
     }
 
     /**
-      ISequenceSegmentProcessorObserver
+      ISequenceProcessorObserver
     */
     virtual void onSequenceProcessorStart(const size_t nb_injections) override
     {
@@ -100,10 +100,6 @@ struct EventDispatcherFixture : public ::testing::Test
     {
       events_.push_back(std::make_tuple("onSequenceProcessorSampleStart", 0, sample_name, std::vector<std::string>()));
     }
-    virtual void onSequenceProcessorError(const std::string& sample_name, const std::string& processor_name, const std::string& error) override
-    {
-      // TODO
-    }
     virtual void onSequenceProcessorSampleEnd(const std::string& sample_name) override
     {
       events_.push_back(std::make_tuple("onSequenceProcessorSampleEnd", 0, sample_name, std::vector<std::string>()));
@@ -112,6 +108,14 @@ struct EventDispatcherFixture : public ::testing::Test
     {
       events_.push_back(std::make_tuple("onSequenceProcessorEnd", 0, "", std::vector<std::string>()));
     }
+    virtual void onSequenceProcessorError(const std::string& sample_name, const std::string& processor_name, const std::string& error) override
+    {
+      events_.push_back(std::make_tuple("onSequenceProcessorError", 0, sample_name, std::vector<std::string>({ processor_name , error })));
+    }
+
+    /**
+      ISequenceSegmentProcessorObserver
+    */
     virtual void onSequenceSegmentProcessorStart(const size_t nb_segments) override
     {
       events_.push_back(std::make_tuple("onSequenceSegmentProcessorStart", nb_segments, "", std::vector<std::string>()));
@@ -130,7 +134,7 @@ struct EventDispatcherFixture : public ::testing::Test
     }
     virtual void onSequenceSegmentProcessorError(const std::string& segment_name, const std::string& processor_name, const std::string& error) override
     {
-      // TODO
+      events_.push_back(std::make_tuple("onSequenceSegmentProcessorError", 0, segment_name, std::vector<std::string>({ processor_name , error })));
     }
 
     /**
@@ -154,7 +158,7 @@ struct EventDispatcherFixture : public ::testing::Test
     }
     virtual void onSampleGroupProcessorError(const std::string& group_name, const std::string& processor_name, const std::string& error)
     {
-      // TODO
+      events_.push_back(std::make_tuple("onSampleGroupProcessorError", 0, group_name, std::vector<std::string>({ processor_name , error})));
     }
 
     /**
@@ -219,6 +223,7 @@ TEST_F(EventDispatcherFixture, dispatchEvents)
   event_dispatcher_observable.notifyApplicationProcessorCommandStart(2, "command2");
   event_dispatcher_observable.notifySequenceProcessorStart(2);
   event_dispatcher_observable.notifySequenceProcessorSampleStart("injection1");
+  event_dispatcher_observable.notifySequenceProcessorError("injection1", "processor1", "error1");
   event_dispatcher_observable.notifySequenceProcessorSampleEnd("injection1");
   event_dispatcher_observable.notifySequenceProcessorSampleStart("injection2");
   event_dispatcher_observable.notifySequenceProcessorSampleEnd("injection2");
@@ -231,6 +236,7 @@ TEST_F(EventDispatcherFixture, dispatchEvents)
   event_dispatcher_observable.notifySequenceProcessorSampleStart("sample1");
   event_dispatcher_observable.notifySequenceProcessorSampleEnd("sample1");
   event_dispatcher_observable.notifySequenceProcessorSampleStart("sample2");
+  event_dispatcher_observable.notifySequenceProcessorError("sample2", "processor2", "error2");
   event_dispatcher_observable.notifySequenceProcessorSampleEnd("sample2");
   event_dispatcher_observable.notifySampleGroupProcessorEnd();
   event_dispatcher_observable.notifyApplicationProcessorCommandEnd(3, "command3");
@@ -248,6 +254,7 @@ TEST_F(EventDispatcherFixture, dispatchEvents)
     {"onApplicationProcessorCommandStart",2,"command2", std::vector<std::string>()},
     {"onSequenceProcessorStart",2,"", std::vector<std::string>()},
     {"onSequenceProcessorSampleStart",0,"injection1", std::vector<std::string>()},
+    {"onSequenceProcessorError",0,"injection1", std::vector<std::string>({"processor1","error1"})},
     {"onSequenceProcessorSampleEnd",0,"injection1", std::vector<std::string>()},
     {"onSequenceProcessorSampleStart",0,"injection2", std::vector<std::string>()},
     {"onSequenceProcessorSampleEnd",0,"injection2", std::vector<std::string>()},
@@ -260,6 +267,7 @@ TEST_F(EventDispatcherFixture, dispatchEvents)
     {"onSequenceProcessorSampleStart",0,"sample1", std::vector<std::string>()},
     {"onSequenceProcessorSampleEnd",0,"sample1", std::vector<std::string>()},
     {"onSequenceProcessorSampleStart",0,"sample2", std::vector<std::string>()},
+    {"onSequenceProcessorError",0,"sample2", std::vector<std::string>({"processor2","error2"})},
     {"onSequenceProcessorSampleEnd",0,"sample2", std::vector<std::string>()},
     {"onSampleGroupProcessorEnd",0,"", std::vector<std::string>()},
     {"onApplicationProcessorCommandEnd",3,"command3", std::vector<std::string>()},

--- a/src/tests/class_tests/smartpeak/source/EventDispatcher_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/EventDispatcher_test.cpp
@@ -84,6 +84,11 @@ struct EventDispatcherFixture : public ::testing::Test
     {
       events_.push_back(std::make_tuple("onApplicationProcessorEnd", 0, "", std::vector<std::string>()));
     }
+    virtual void onApplicationProcessorError(const std::string& error) override
+    {
+      // TODO
+    }
+
     /**
       ISequenceSegmentProcessorObserver
     */

--- a/src/tests/class_tests/smartpeak/source/EventDispatcher_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/EventDispatcher_test.cpp
@@ -95,6 +95,10 @@ struct EventDispatcherFixture : public ::testing::Test
     {
       events_.push_back(std::make_tuple("onSequenceProcessorSampleStart", 0, sample_name, std::vector<std::string>()));
     }
+    virtual void onSequenceProcessorError(const std::string& sample_name, const std::string& processor_name, const std::string& error) override
+    {
+      // TODO
+    }
     virtual void onSequenceProcessorSampleEnd(const std::string& sample_name) override
     {
       events_.push_back(std::make_tuple("onSequenceProcessorSampleEnd", 0, sample_name, std::vector<std::string>()));
@@ -119,6 +123,10 @@ struct EventDispatcherFixture : public ::testing::Test
     {
       events_.push_back(std::make_tuple("onSequenceSegmentProcessorEnd", 0, "", std::vector<std::string>()));
     }
+    virtual void onSequenceSegmentProcessorError(const std::string& segment_name, const std::string& processor_name, const std::string& error) override
+    {
+      // TODO
+    }
 
     /**
       ISampleGroupProcessorObserver
@@ -138,6 +146,10 @@ struct EventDispatcherFixture : public ::testing::Test
     virtual void onSampleGroupProcessorEnd() override
     {
       events_.push_back(std::make_tuple("onSampleGroupProcessorEnd", 0, "", std::vector<std::string>()));
+    }
+    virtual void onSampleGroupProcessorError(const std::string& group_name, const std::string& processor_name, const std::string& error)
+    {
+      // TODO
     }
 
     /**

--- a/src/tests/class_tests/smartpeak/source/Widget_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Widget_test.cpp
@@ -309,7 +309,7 @@ class SessionFilesWidget_Test : public SessionFilesWidget
 {
 public:
   SessionFilesWidget_Test(ApplicationHandler& application_handler, SessionFilesWidget::Mode mode) :
-  SessionFilesWidget(application_handler, mode)
+  SessionFilesWidget(application_handler, mode, nullptr)
   {};
 
 public:
@@ -493,8 +493,8 @@ TEST(SessionFilesWidget, SessionFilesWidget_Modify_ChangeFromExternalToEmbedded)
   auto db_path = tmp_dir_path / "session.db";
   SaveSession save_session(application_handler);
   save_session.onFilePicked(db_path, &application_handler);
-  auto session_widget_test_modify2 = std::make_shared<SessionFilesWidget>(application_handler, SessionFilesWidget::Mode::EModification);
-  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(session_widget_test_modify2);
+  auto session_widget_test_modify2 = std::make_shared<SessionFilesWidget>(application_handler, SessionFilesWidget::Mode::EModification, nullptr);
+  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(session_widget_test_modify2, nullptr);
   load_session_wizard_->onFilePicked(db_path, &application_handler);
   ParameterSet& parameter_set3 = application_handler.sequenceHandler_.getSequence().at(0).getRawData().getParameters();
   auto parameter3 = parameter_set3.findParameter("MRMFeatureFinderScoring", "TransitionGroupPicker:peak_integration");
@@ -555,8 +555,8 @@ TEST(SessionFilesWidget, SessionFilesWidget_Modify_NoPopupError)
   save_session.onFilePicked(db_path, &application_handler);
 
   // load session
-  auto session_widget_test_modify = std::make_shared<SessionFilesWidget>(application_handler, SessionFilesWidget::Mode::EModification);
-  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(session_widget_test_modify);
+  auto session_widget_test_modify = std::make_shared<SessionFilesWidget>(application_handler, SessionFilesWidget::Mode::EModification, nullptr);
+  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(session_widget_test_modify, nullptr);
   load_session_wizard_->onFilePicked(db_path, &application_handler);
   
   // popup should not be displayed
@@ -603,7 +603,7 @@ TEST(SessionFilesWidget, LoadSessionWizard_PopupError)
   // load session
   auto session_widget_test_modify = std::make_shared<SessionFilesWidget_Test>(application_handler, SessionFilesWidget::Mode::EModification);
   auto session_widget_modify = std::static_pointer_cast<SessionFilesWidget>(session_widget_test_modify);
-  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(session_widget_modify);
+  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(session_widget_modify, nullptr);
   load_session_wizard_->onFilePicked(db_path, &application_handler);
 
   // check that the wizard is displayed.
@@ -654,7 +654,7 @@ TEST(SessionFilesWidget, SessionFilesWidget_EmbedAllFiles)
 
   auto session_widget_test_modify = std::make_shared<SessionFilesWidget_Test>(application_handler, SessionFilesWidget::Mode::EModification);
   auto session_widget_modify = std::static_pointer_cast<SessionFilesWidget>(session_widget_test_modify);
-  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(session_widget_modify);
+  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(session_widget_modify, nullptr);
   load_session_wizard_->onFilePicked(db_path, &application_handler);
 
   ParameterSet& parameter_set3 = application_handler.sequenceHandler_.getSequence().at(0).getRawData().getParameters();


### PR DESCRIPTION
Errors are now displayed on the info panel.
details like injection, sample group ... and processor name are displayed along with the error message.

![image](https://user-images.githubusercontent.com/1705849/137485146-16139e1f-0976-46af-a798-f05007d52306.png)

However - not all:
We are catching exceptions from the processor and displaying the message of it. the user at least is aware that something has been stopped, so the rule for a processor is when an error is fatal to its execution, a std::exception is thrown. Errors that are not fatal (which kind of - should be avoided) will not be displayed in the info panel.

Some workarounds have been made to support this also when loading sessions (as it does not use SequenceProcessor where the error handling is made). It should be acceptable since, at some point, we may want to use the SequenceProcessor also to load the sessions (and profit from the progress bar...).

Along with this modification, START and END logs in the processors have been removed for several reasons:
- The mechanism of exception requires properly log the end of the processor to keep the log readable.
- at the same time, more context is added to the START and END logs.
- less code, less chance of making errors, and reduced maintenance.
