### PR TITLE
Fix/fix sample group processing

### DIFF
--- a/src/smartpeak/source/core/ProgessInfo.cpp
+++ b/src/smartpeak/source/core/ProgessInfo.cpp
@@ -202,7 +202,14 @@ namespace SmartPeak
 
   const std::vector<std::string>& ProgressInfo::runningBatch() const
   {
-    return running_batch_->running_items_;
+    if (running_batch_)
+    {
+      return running_batch_->running_items_;
+    }
+    else
+    {
+      return {};
+    }
   }
 
 }


### PR DESCRIPTION
Running FIAMS Workflow on MacOS leads to an infinite loop on merging injections.

It seems to be due to the SampleGroupProcessorMultithread called from inside a sample group iteration loop.
another side effect about that was the progress bar jumping from different, not monotonic, increasing values.

In this PR, is also fixed:
- a crash if you expend details of the progress information while the first event is not yet received (at the beginning of the workflow)
- ProcessSequenceSegments and ProcessSampleGroups use spawn_workers instead of run_processor which makes it use threading processing.

