### PR TITLE
Display error in info panel when user select incorrect session file

### DIFF
--- a/src/smartpeak/include/SmartPeak/ui/LoadSessionWizard.h
+++ b/src/smartpeak/include/SmartPeak/ui/LoadSessionWizard.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <SmartPeak/iface/IFilePickerHandler.h>
+#include <SmartPeak/core/ApplicationProcessorObservable.h>
 #include <SmartPeak/ui/SessionFilesWidget.h>
 #include <SmartPeak/ui/SetInputOutputWidget.h>
 #include <string>
@@ -34,7 +35,10 @@
 */
 namespace SmartPeak
 {
-  struct LoadSessionWizard : IFilePickerHandler, ISetInputOutputWidgetObserver
+  struct LoadSessionWizard : 
+    IFilePickerHandler, 
+    ISetInputOutputWidgetObserver,
+    ApplicationProcessorObservable
   {
     LoadSessionWizard(std::shared_ptr<SessionFilesWidget>& session_files_widget_manage,
                       WorkflowManager& workflow_manager,
@@ -52,6 +56,7 @@ namespace SmartPeak
       sample_group_processor_observer_(sample_group_processor_observer)
     {
       set_input_output_widget = std::make_shared<SetInputOutputWidget>(application_handler);
+      addApplicationProcessorObserver(application_processor_observer_);
     };
 
     /**

--- a/src/smartpeak/source/ui/LoadSessionWizard.cpp
+++ b/src/smartpeak/source/ui/LoadSessionWizard.cpp
@@ -32,7 +32,7 @@ namespace SmartPeak
     loaded_filenames_ = LoadFilenames::loadFilenamesFromDB(filename);
     if (!loaded_filenames_)
     {
-      LOGE << "Failed to load input filenames list from session DB. Loading aborted.";
+      notifyApplicationProcessorError("Failed to load session file.");
       return false;
     }
     // Popup Session Files management if some files are not existing

--- a/src/tests/class_tests/smartpeak/source/Widget_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Widget_test.cpp
@@ -704,6 +704,37 @@ TEST(SessionFilesWidget, LoadSessionWizard_PopupError)
   }
 }
 
+TEST(SessionFilesWidget, LoadSessionWizard_IncorrectSessionFile)
+{
+  ApplicationHandler application_handler;
+  WorkflowManager workflow_manager;
+
+  struct TestApplicationObserver : IApplicationProcessorObserver
+  {
+    virtual void onApplicationProcessorStart(const std::vector<std::string>& commands) override {}
+    virtual void onApplicationProcessorCommandStart(size_t command_index, const std::string& command_name) override {}
+    virtual void onApplicationProcessorCommandEnd(size_t command_index, const std::string& command_name) override {}
+    virtual void onApplicationProcessorEnd() override {}
+    virtual void onApplicationProcessorError(const std::string& error) override 
+    {
+      error_ = error;
+    }
+    std::string error_;
+  };
+  // load session (incorrect file: we will use one parameter file instead)
+  TestApplicationObserver test_application_observer;
+  auto session_widget_test_modify = std::make_shared<SessionFilesWidget_Test>(application_handler, SessionFilesWidget::Mode::EModification, workflow_manager);
+  auto session_widget_modify = std::static_pointer_cast<SessionFilesWidget>(session_widget_test_modify);
+  auto load_session_wizard_ = std::make_shared<LoadSessionWizard>(
+    session_widget_modify,
+    workflow_manager,
+    application_handler,
+    &test_application_observer);
+  auto db_path = SMARTPEAK_GET_TEST_DATA_PATH("RawDataProcessor_params_2.csv");
+  load_session_wizard_->onFilePicked(db_path, &application_handler);
+  EXPECT_EQ(test_application_observer.error_, "Failed to load session file.");
+}
+
 TEST(SessionFilesWidget, SessionFilesWidget_EmbedAllFiles)
 {
   // More integration test like, 


### PR DESCRIPTION
The original bug report was about a crash when the user selects a file that is not a session file (for example, he selects  sequence.csv file).

Now the crash seems to have disappeared but no error is displayed on the info panel. This pr fixes it.