### PR TITLE
AUT-993 - UI Splitting and Docking

### DIFF
--- a/external/imgui.cmake
+++ b/external/imgui.cmake
@@ -3,13 +3,12 @@ include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 set_property (DIRECTORY PROPERTY EP_BASE Dependencies)
 
 set (DEPENDENCIES)
-#set (IMGUI_VERSION 6a0d0dab5a9f0b9518a2bc9bb456a69895ae0962) # tag: v1.72b, 2019/07/31
-set (IMGUI_VERSION v1.81) # tables
+set (IMGUI_VERSION 848d21b6b56d369fb7976bd88b5f4094ab9ea50a) # on Docking branch
 message (STATUS "Adding imgui ${IMGUI_VERSION} as an external project.")
 
 ExternalProject_Add(imgui
   GIT_REPOSITORY https://github.com/ocornut/imgui.git
-  GIT_TAG 848d21b6b56d369fb7976bd88b5f4094ab9ea50a
+  GIT_TAG ${IMGUI_VERSION}
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""

--- a/external/imgui.cmake
+++ b/external/imgui.cmake
@@ -9,7 +9,7 @@ message (STATUS "Adding imgui ${IMGUI_VERSION} as an external project.")
 
 ExternalProject_Add(imgui
   GIT_REPOSITORY https://github.com/ocornut/imgui.git
-  GIT_TAG ${IMGUI_VERSION}
+  GIT_TAG 848d21b6b56d369fb7976bd88b5f4094ab9ea50a
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""

--- a/src/tests/class_tests/smartpeak/source/WindowSizesAndPositions_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/WindowSizesAndPositions_test.cpp
@@ -25,6 +25,9 @@
 #include <SmartPeak/test_config.h>
 #include <SmartPeak/ui/WindowSizesAndPositions.h>
 #include <SmartPeak/io/SessionDB.h>
+
+#include <imgui.h>
+
 #include <thread>
 
 using namespace SmartPeak;
@@ -39,141 +42,42 @@ TEST(WindowSizesAndPositions, constructor)
   delete p1;
 }
 
-TEST(WindowSizesAndPositions, defaults)
+class WindowSizesAndPositions_Test : public WindowSizesAndPositions
 {
-  WindowSizesAndPositions win_size_and_pos;
-  EXPECT_NEAR(win_size_and_pos.main_menu_bar_y_size_, 18.0f, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.y_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.x_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_and_top_window_x_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_and_right_window_y_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_window_x_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.right_window_x_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_pos_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_and_top_window_x_pos_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_pos_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_and_right_window_y_pos_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_window_x_pos_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.right_window_x_pos_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_perc_, 0.25, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_window_x_perc_, 0.25, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.right_window_x_perc_, 0, 1e-3);
-}
+public:
+  // wrappers to protected methods
+  std::string wrapper_get_imgui_ini_() const
+  {
+    return imgui_ini_;
+  }
 
-TEST(WindowSizesAndPositions, setXAndYSizes)
-{
-  WindowSizesAndPositions win_size_and_pos;
-  win_size_and_pos.setXAndYSizes(10, 10);
-  EXPECT_NEAR(win_size_and_pos.y_size_, -8, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.x_size_, 10, 1e-3);
-}
-
-TEST(WindowSizesAndPositions, setLeftWindowXSize)
-{
-  WindowSizesAndPositions win_size_and_pos;
-  win_size_and_pos.setXAndYSizes(100, 100);
-  win_size_and_pos.setLeftWindowXSize(10);
-  win_size_and_pos.setWindowsVisible(true, true, true, false);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_size_, 20.5 , 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_size_, 61.5, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_and_top_window_x_size_, 90, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_and_right_window_y_size_, 82, 1e-3); //
-  EXPECT_NEAR(win_size_and_pos.left_window_x_size_, 10, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.right_window_x_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_pos_, 79.5, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_pos_, 18, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_and_top_window_x_pos_, 10, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_and_right_window_y_pos_, 18, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_window_x_pos_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.right_window_x_pos_, 100, 1e-3);
-}
-
-TEST(WindowSizesAndPositions, setTopWindowYSize)
-{
-  WindowSizesAndPositions win_size_and_pos;
-  win_size_and_pos.setXAndYSizes(100, 100);
-  win_size_and_pos.setTopWindowYSize(10);
-  win_size_and_pos.setWindowsVisible(true, true, true, false);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_size_, 72, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_size_, 10, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_and_top_window_x_size_, 75, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_and_right_window_y_size_, 82, 1e-3); //
-  EXPECT_NEAR(win_size_and_pos.left_window_x_size_, 25, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.right_window_x_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_pos_, 28, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_pos_, 18, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_and_top_window_x_pos_, 25, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_and_right_window_y_pos_, 18, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_window_x_pos_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.right_window_x_pos_, 100, 1e-3);
-}
-
-TEST(WindowSizesAndPositions, showHide)
-{
-  WindowSizesAndPositions win_size_and_pos;
-  win_size_and_pos.setXAndYSizes(100, 100);
-  win_size_and_pos.setTopWindowYSize(10);
-  win_size_and_pos.setWindowsVisible(true, true, true, false);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_size_, 72, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_size_, 10, 1e-3);
-  win_size_and_pos.setWindowsVisible(true, false, true, false);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_size_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_size_, 82, 1e-3);
-  win_size_and_pos.setWindowsVisible(true, true, true, false);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_size_, 20.5, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_size_, 61.5, 1e-3);
-}
-
-TEST(WindowSizesAndPositions, setWindowPercentages)
-{
-  WindowSizesAndPositions win_size_and_pos;
-  win_size_and_pos.setWindowPercentages(0.1, 0.2, 0.3);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_perc_, 0.1, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_window_x_perc_, 0.2, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.right_window_x_perc_, 0.3, 1e-3);
-}
-
-TEST(WindowSizesAndPositions, setWindowSizesAndPositions_)
-{
-  WindowSizesAndPositions win_size_and_pos;
-  win_size_and_pos.setXAndYSizes(100, 100);
-  win_size_and_pos.setWindowSizesAndPositions_(0.2, 0.2, 0.2);
-  EXPECT_NEAR(win_size_and_pos.main_menu_bar_y_size_, 18.0f, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.y_size_, 82, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.x_size_, 100, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_size_, 16.4, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_and_top_window_x_size_, 60, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_size_, 65.6, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_and_right_window_y_size_, 82, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_window_x_size_, 20, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.right_window_x_size_, 20, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_pos_, 83.6, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_and_top_window_x_pos_, 20, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.top_window_y_pos_, 18, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_and_right_window_y_pos_, 18, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.left_window_x_pos_, 0, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.right_window_x_pos_, 80, 1e-3);
-  EXPECT_NEAR(win_size_and_pos.bottom_window_y_perc_, 0.25, 1e-3); // Defaults
-  EXPECT_NEAR(win_size_and_pos.left_window_x_perc_, 0.25, 1e-3); // Defaults
-  EXPECT_NEAR(win_size_and_pos.right_window_x_perc_, 0, 1e-3); // Defaults
-}
+  bool wrapper_get_imgui_ini_updated_() const
+  {
+    return imgui_ini_updated_;
+  }
+};
 
 TEST(WindowSizesAndPositions, widget_WriteAndReadWindowSizesAndPositions)
 {
-  WindowSizesAndPositions win_size_and_pos_write;
-  win_size_and_pos_write.setWindowPercentages(0.1, 0.3, 0.6);
+  ImGui::CreateContext();
+  WindowSizesAndPositions_Test win_size_and_pos_write;
+  EXPECT_EQ(win_size_and_pos_write.wrapper_get_imgui_ini_(), std::string(""));
+  EXPECT_EQ(win_size_and_pos_write.wrapper_get_imgui_ini_updated_(), false);
 
   SessionDB session_db;
   auto path_db = std::tmpnam(nullptr);
   session_db.setDBFilePath(path_db);
 
   session_db.writePropertiesHandler(win_size_and_pos_write);
+  EXPECT_EQ(win_size_and_pos_write.wrapper_get_imgui_ini_(), std::string(""));
+  EXPECT_EQ(win_size_and_pos_write.wrapper_get_imgui_ini_updated_(), false);
 
-  WindowSizesAndPositions win_size_and_pos_read;
+  WindowSizesAndPositions_Test win_size_and_pos_read;
   session_db.readPropertiesHandler(win_size_and_pos_read);
-  EXPECT_FLOAT_EQ(win_size_and_pos_read.bottom_window_y_perc_, 0.1);
-  EXPECT_FLOAT_EQ(win_size_and_pos_read.left_window_x_perc_, 0.3);
-  EXPECT_FLOAT_EQ(win_size_and_pos_read.right_window_x_perc_, 0.6);
+
+  // Unfortunately, we would need to create a full graphic context to create windows 
+  // in order to get a proper, populated ini file from imgui.
+  // so we just check that it's empty and it didn"t crashed.
+  EXPECT_EQ(win_size_and_pos_read.wrapper_get_imgui_ini_(), std::string(""));
+  EXPECT_EQ(win_size_and_pos_read.wrapper_get_imgui_ini_updated_(), true);
 }

--- a/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
+++ b/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
@@ -60,11 +60,11 @@ namespace SmartPeak
     }
     void draw() override;
   protected:
-    const std::vector<std::vector<float>>* x_fit_data_;
-    const std::vector<std::vector<float>>* y_fit_data_;
-    const std::vector<std::vector<float>>* x_raw_data_;
-    const std::vector<std::vector<float>>* y_raw_data_;
-    const std::vector<std::string>* series_names_;
+    const std::vector<std::vector<float>>* x_fit_data_ = nullptr;
+    const std::vector<std::vector<float>>* y_fit_data_ = nullptr;
+    const std::vector<std::vector<float>>* x_raw_data_ = nullptr;
+    const std::vector<std::vector<float>>* y_raw_data_ = nullptr;
+    const std::vector<std::string>* series_names_ = nullptr;
     std::string x_axis_title_;
     std::string y_axis_title_;
     float x_min_;

--- a/src/widgets/include/SmartPeak/ui/SplitWindow.h
+++ b/src/widgets/include/SmartPeak/ui/SplitWindow.h
@@ -17,7 +17,7 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Bertrand Boudaud $
 // $Authors: Douglas McCloskey, Bertrand Boudaud $
 // --------------------------------------------------------------------------
 #pragma once
@@ -48,9 +48,14 @@ namespace SmartPeak
     */
     void setupLayoutLoader(LayoutLoader& layout_loader);
 
-    WindowSizesAndPositions win_size_and_pos;
-    std::vector<std::shared_ptr<Widget>> top_windows;
-    std::vector<std::shared_ptr<Widget>> bottom_windows;
-    std::vector<std::shared_ptr<Widget>> left_windows;
+    WindowSizesAndPositions win_size_and_pos_;
+    std::vector<std::shared_ptr<Widget>> top_windows_;
+    std::vector<std::shared_ptr<Widget>> bottom_windows_;
+    std::vector<std::shared_ptr<Widget>> left_windows_;
+
+    bool reset_layout_ = true;
+
+  protected:
+    void showWindows(std::vector<std::shared_ptr<Widget>> &windows);
   };
 }

--- a/src/widgets/include/SmartPeak/ui/Widget.h
+++ b/src/widgets/include/SmartPeak/ui/Widget.h
@@ -399,7 +399,6 @@ namespace SmartPeak
   */
   static void showQuickHelpToolTip(const std::string& ui_element_name)
   {
-    return;
     if (ImGui::IsItemHovered() && enable_quick_help && tooltip_info.find(ui_element_name) != tooltip_info.end()) {
       ImGui::SetTooltip("%s", tooltip_info.find(ui_element_name)->second.c_str());
     }

--- a/src/widgets/include/SmartPeak/ui/Widget.h
+++ b/src/widgets/include/SmartPeak/ui/Widget.h
@@ -72,12 +72,8 @@ namespace SmartPeak
     */
     virtual void draw() = 0;
 
-    void setWindowSize(float width, float height) { width_ = width; height_ = height; };
-
     bool visible_ = false;
     std::string title_;
-    float width_ = 0.0;
-    float height_ = 0.0;
   };
 
   class GenericTextWidget : public Widget
@@ -403,6 +399,7 @@ namespace SmartPeak
   */
   static void showQuickHelpToolTip(const std::string& ui_element_name)
   {
+    return;
     if (ImGui::IsItemHovered() && enable_quick_help && tooltip_info.find(ui_element_name) != tooltip_info.end()) {
       ImGui::SetTooltip("%s", tooltip_info.find(ui_element_name)->second.c_str());
     }

--- a/src/widgets/include/SmartPeak/ui/WindowSizesAndPositions.h
+++ b/src/widgets/include/SmartPeak/ui/WindowSizesAndPositions.h
@@ -36,41 +36,10 @@ namespace SmartPeak
     virtual std::map<std::string, CastValue::Type> getPropertiesSchema() const override;
     virtual std::optional<CastValue> getProperty(const std::string& property, const size_t row) const override;
     virtual void setProperty(const std::string& property, const CastValue& value, const size_t row) override;
+    void applyLayout();
 
-    void setXAndYSizes(const float& x, const float& y);
-    void setWindowPercentages(const float& bottom_window_y_perc, const float& left_window_x_perc, const float& right_window_x_perc);
-    void setWindowSizesAndPositions_(const float& bottom_window_y_perc, const float& left_window_x_perc, const float& right_window_x_perc);
-    void setWindowsVisible(const bool& show_top_window, const bool& show_bottom_window, const bool& show_left_window, const bool& show_right_window);
-    void setLeftWindowXSize(const float& left_window_x_size);
-    void setTopWindowYSize(const float& top_window_y_size);
-
-    // Absolute application size
-    float main_menu_bar_y_size_ = 18.0f;
-    float y_size_ = 0;
-    float x_size_ = 0;
-
-    // Absolute window sizes
-    float bottom_window_y_size_ = 0;
-    float bottom_and_top_window_x_size_ = 0;
-    float top_window_y_size_ = 0;
-    float left_and_right_window_y_size_ = 0;
-    float left_window_x_size_ = 0;
-    float right_window_x_size_ = 0;
-
-    // Absolute window positions
-    float bottom_window_y_pos_ = 0;
-    float bottom_and_top_window_x_pos_ = 0;
-    float top_window_y_pos_ = 0;
-    float left_and_right_window_y_pos_ = 0;
-    float left_window_x_pos_ = 0;
-    float right_window_x_pos_ = 0;
-
-    // Relative percent offsets of the window sizes
-    float bottom_window_y_perc_ = 0.25;
-    float left_window_x_perc_ = 0.25;
-    float right_window_x_perc_ = 0;
-
-  private:
-    bool show_bottom_window_ = true;
+  protected:
+    std::string imgui_ini_;
+    bool imgui_ini_updated_ = false;
   };
 }

--- a/src/widgets/source/ui/CalibratorsPlotWidget.cpp
+++ b/src/widgets/source/ui/CalibratorsPlotWidget.cpp
@@ -28,10 +28,15 @@ namespace SmartPeak
 {
   void CalibratorsPlotWidget::draw()
   {
+    if (!x_raw_data_)
+    {
+      return;
+    }
     showQuickHelpToolTip("CalibratorsPlotWidget");
     // Main graphic
     ImPlot::SetNextPlotLimits(x_min_, x_max_, y_min_, y_max_, ImGuiCond_Always);
-    if (ImPlot::BeginPlot(plot_title_.c_str(), x_axis_title_.c_str(), y_axis_title_.c_str(), ImVec2(width_ - 25, height_ - 40))) {
+    auto window_size = ImGui::GetWindowSize();
+    if (ImPlot::BeginPlot(plot_title_.c_str(), x_axis_title_.c_str(), y_axis_title_.c_str(), ImVec2(window_size.x - 25, window_size.y - 40))) {
       for (int i = 0; i < x_raw_data_->size(); ++i) {
         assert(x_raw_data_->at(i).size() == y_raw_data_->at(i).size());
         ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);

--- a/src/widgets/source/ui/GraphicDataVizWidget.cpp
+++ b/src/widgets/source/ui/GraphicDataVizWidget.cpp
@@ -127,12 +127,13 @@ namespace SmartPeak
     }
     else
     {
+      auto window_size = ImGui::GetWindowSize();
       auto [plot_min_x, plot_max_x, plot_min_y, plot_max_y] = plotLimits();
       ImPlot::SetNextPlotLimits(plot_min_x, plot_max_x, plot_min_y, plot_max_y, ImGuiCond_Always);
       ImPlotFlags plotFlags = show_legend_ ? ImPlotFlags_Default | ImPlotFlags_Legend : ImPlotFlags_Default & ~ImPlotFlags_Legend;
       plotFlags |= ImPlotFlags_Crosshairs;
-      float graphic_height = height_ - sliders_height_;
-      if (ImPlot::BeginPlot(plot_title_.c_str(), graph_viz_data_.x_axis_title_.c_str(), graph_viz_data_.y_axis_title_.c_str(), ImVec2(width_ - 25, graphic_height - 85), plotFlags)) {
+      float graphic_height = window_size.y - sliders_height_;
+      if (ImPlot::BeginPlot(plot_title_.c_str(), graph_viz_data_.x_axis_title_.c_str(), graph_viz_data_.y_axis_title_.c_str(), ImVec2(window_size.x - 25, graphic_height - 85), plotFlags)) {
         int i = 0;
         for (const auto& serie_name_scatter : graph_viz_data_.series_names_area_)
         {

--- a/src/widgets/source/ui/Heatmap2DWidget.cpp
+++ b/src/widgets/source/ui/Heatmap2DWidget.cpp
@@ -146,15 +146,16 @@ namespace SmartPeak
           {
             bool is_hovered = false;
             ImPlotPoint plot_point;
+            auto window_size = ImGui::GetWindowSize();
             ImPlot::SetColormap(ImPlotColormap_Jet);
-            ImPlot::ShowColormapScale(heatmap_data_.feat_value_min_, heatmap_data_.feat_value_max_, height_ - 70);
+            ImPlot::ShowColormapScale(heatmap_data_.feat_value_min_, heatmap_data_.feat_value_max_, window_size.y - 70);
             float available_width = ImGui::GetContentRegionAvailWidth();
             ImGui::SameLine();
             const ImPlotFlags imPlotFlags = ImPlotAxisFlags_LockMin | ImPlotAxisFlags_LockMax | ImPlotAxisFlags_TickLabels;
             if (ImPlot::BeginPlot(plot_title_.c_str(),
               heatmap_data_.feat_heatmap_x_axis_title.c_str(),
               heatmap_data_.feat_heatmap_y_axis_title.c_str(),
-              ImVec2(available_width - 80, height_ - 70),
+              ImVec2(available_width - 80, window_size.y - 70),
               imPlotFlags,
               ImPlotAxisFlags_GridLines,
               ImPlotAxisFlags_GridLines))

--- a/src/widgets/source/ui/StatisticsWidget.cpp
+++ b/src/widgets/source/ui/StatisticsWidget.cpp
@@ -33,6 +33,13 @@ namespace SmartPeak
   void StatisticsWidget::draw()
   {
 
+    if (!transitions_)
+    {
+      return;
+    }
+
+    auto window_size = ImGui::GetWindowSize();
+
     // number of items from which the basic graph 
     // will be replaced by simplified graph to support large number of data
     static const int max_samples = 50;
@@ -170,7 +177,9 @@ namespace SmartPeak
     {
       ImPlot::SetNextPlotLimits(-0.5, +0.5, 0, 1, ImGuiCond_Always);
     }
-    if (ImPlot::BeginPlot(title, x_label, y_label, ImVec2((width_/2.0f) - 10, height_ - 40), ImPlotFlags_Default & ~ImPlotFlags_Legend & ~ImPlotFlags_MousePos, ImPlotAxisFlags_GridLines | ImPlotAxisFlags_TickMarks)) {
+
+    auto window_size = ImGui::GetWindowSize();
+    if (ImPlot::BeginPlot(title, x_label, y_label, ImVec2((window_size .x/2.0f) - 10, window_size.y - 40), ImPlotFlags_Default & ~ImPlotFlags_Legend & ~ImPlotFlags_MousePos, ImPlotAxisFlags_GridLines | ImPlotAxisFlags_TickMarks)) {
       if (chart_data.values_.size() > 0)
       {
         ImPlot::PlotBars("Unselected", &chart_data.unselected_values_.front(), chart_data.unselected_values_.size());

--- a/src/widgets/source/ui/Widget.cpp
+++ b/src/widgets/source/ui/Widget.cpp
@@ -377,10 +377,11 @@ namespace SmartPeak
     bool is_hovered = false;
     ImPlotPoint plot_point;
     ImPlotPoint plot_threshold;
+    auto window_size = ImGui::GetWindowSize();
     if (ImPlot::BeginPlot(plot_title_.c_str(),
                           x_axis_title_.c_str(),
                           y_axis_title_.c_str(),
-                          ImVec2(width_ - 25, height_ - 40),
+                          ImVec2(window_size.x - 25, window_size.y - 40),
                           imPlotFlags,
                           imPlotAxisFlagsX)) {
       for (int i = 0; i < x_data_.dimension(1); ++i) {

--- a/src/widgets/source/ui/WindowSizesAndPositions.cpp
+++ b/src/widgets/source/ui/WindowSizesAndPositions.cpp
@@ -22,6 +22,7 @@
 // --------------------------------------------------------------------------
 
 #include <SmartPeak/ui/WindowSizesAndPositions.h>
+#include <imgui.h>
 
 namespace SmartPeak
 {
@@ -34,144 +35,35 @@ namespace SmartPeak
   std::map<std::string, CastValue::Type> WindowSizesAndPositions::getPropertiesSchema() const
   {
     std::map<std::string, CastValue::Type> properties;
-    properties.emplace("bottom_window_y_perc_", CastValue::Type::FLOAT);
-    properties.emplace("left_window_x_perc_", CastValue::Type::FLOAT);
-    properties.emplace("right_window_x_perc_", CastValue::Type::FLOAT);
+    properties.emplace("imgui_ini", CastValue::Type::STRING);
     return properties;
   }
 
   std::optional<CastValue> WindowSizesAndPositions::getProperty(const std::string& property, const size_t row) const
   {
-    if (property == "bottom_window_y_perc_")
+    if (property == "imgui_ini")
     {
-      return bottom_window_y_perc_;
-    }
-    if (property == "left_window_x_perc_")
-    {
-      return left_window_x_perc_;
-    }
-    if (property == "right_window_x_perc_")
-    {
-      return right_window_x_perc_;
+      std::string imgui_ini(ImGui::SaveIniSettingsToMemory());
+      return imgui_ini;
     }
     return std::nullopt;
   }
 
   void WindowSizesAndPositions::setProperty(const std::string& property, const CastValue& value, const size_t row)
   {
-    if (property == "bottom_window_y_perc_")
+    if (property == "imgui_ini")
     {
-      bottom_window_y_perc_ = value.f_;
-    }
-    if (property == "left_window_x_perc_")
-    {
-      left_window_x_perc_ = value.f_;
-    }
-    if (property == "right_window_x_perc_")
-    {
-      right_window_x_perc_ = value.f_;
+      imgui_ini_ = value.s_;
+      imgui_ini_updated_ = true;
     }
   }
 
-  void WindowSizesAndPositions::setXAndYSizes(const float & x, const float & y) {
-    x_size_ = x; 
-    y_size_ = y - main_menu_bar_y_size_;
-  }
-  void WindowSizesAndPositions::setWindowPercentages(const float& bottom_window_y_perc, const float& left_window_x_perc, const float& right_window_x_perc) {
-    bottom_window_y_perc_ = bottom_window_y_perc;
-    left_window_x_perc_ = left_window_x_perc;
-    right_window_x_perc_ = right_window_x_perc;
-    // TODO: check that the percentages equal 1
-  }
-  void WindowSizesAndPositions::setLeftWindowXSize(const float& left_window_x_size) {
-    left_window_x_perc_ = left_window_x_size / x_size_;
-  }
-  void WindowSizesAndPositions::setTopWindowYSize(const float& top_window_y_size) {
-    bottom_window_y_perc_ = 1 - (top_window_y_size / y_size_);
-  }
-  void WindowSizesAndPositions::setWindowSizesAndPositions_(const float& bottom_window_y_perc, const float& left_window_x_perc, const float& right_window_x_perc) {
-    // Absolute sizes
-    bottom_window_y_size_ = bottom_window_y_perc * y_size_;
-    top_window_y_size_ = (1 - bottom_window_y_perc) * y_size_;
-    bottom_and_top_window_x_size_ = (1 - left_window_x_perc - right_window_x_perc) * x_size_;
-    left_and_right_window_y_size_ = y_size_;
-    left_window_x_size_ = left_window_x_perc * x_size_;
-    right_window_x_size_ = right_window_x_perc * x_size_;
-    // Absolute positions
-    bottom_window_y_pos_ = top_window_y_size_ + main_menu_bar_y_size_;
-    top_window_y_pos_ = main_menu_bar_y_size_;
-    bottom_and_top_window_x_pos_ = left_window_x_size_;
-    left_and_right_window_y_pos_ = main_menu_bar_y_size_;
-    left_window_x_pos_ = 0;
-    right_window_x_pos_ = left_window_x_size_ + bottom_and_top_window_x_size_;
-  }
-  void WindowSizesAndPositions::setWindowsVisible(const bool& show_top_window, const bool& show_bottom_window, const bool& show_left_window, const bool& show_right_window) {
-    // reset perc for bottom if needed
-    if (!show_bottom_window_ && show_bottom_window)
+  void WindowSizesAndPositions::applyLayout()
+  {
+    if (imgui_ini_updated_)
     {
-      bottom_window_y_perc_ = 0.25;
-    }
-    show_bottom_window_ = show_bottom_window;
-
-    if (show_top_window && show_bottom_window && show_left_window && show_right_window) 
-    {
-      setWindowSizesAndPositions_(bottom_window_y_perc_, left_window_x_perc_, right_window_x_perc_);
-    }
-    else if (show_top_window && show_bottom_window && show_left_window) 
-    {
-      setWindowSizesAndPositions_(bottom_window_y_perc_, left_window_x_perc_, 0);
-    }
-    else if (show_top_window && show_bottom_window && show_right_window) 
-    {
-      setWindowSizesAndPositions_(bottom_window_y_perc_, 0, right_window_x_perc_);
-    }
-    else if (show_top_window && show_left_window && show_right_window) 
-    {
-      setWindowSizesAndPositions_(0, left_window_x_perc_, right_window_x_perc_);
-    }
-    else if (show_bottom_window && show_left_window && show_right_window) 
-    {
-      setWindowSizesAndPositions_(1, left_window_x_perc_, right_window_x_perc_);
-    }
-    else if (show_left_window && show_right_window) 
-    {
-      setWindowSizesAndPositions_(bottom_window_y_perc_, left_window_x_perc_, right_window_x_perc_);
-    }
-    else if (show_top_window && show_bottom_window) 
-    {
-      setWindowSizesAndPositions_(bottom_window_y_perc_, 0, 0);
-    }
-    else if (show_top_window && show_left_window) 
-    {
-      setWindowSizesAndPositions_(0, left_window_x_perc_, 0);
-    }
-    else if (show_top_window && show_right_window) 
-    {
-      setWindowSizesAndPositions_(0, 0, right_window_x_perc_);
-    }
-    else if (show_bottom_window && show_left_window) 
-    {
-      setWindowSizesAndPositions_(1, left_window_x_perc_, 0);
-    }
-    else if (show_bottom_window && show_right_window) 
-    {
-      setWindowSizesAndPositions_(1, 0, right_window_x_perc_);
-    }
-    else if (show_top_window) 
-    {
-      setWindowSizesAndPositions_(0, 0, 0);
-    }
-    else if (show_bottom_window) 
-    {
-      setWindowSizesAndPositions_(1, 0, 0);
-    }
-    else if (show_left_window || show_right_window) 
-    {
-      setWindowSizesAndPositions_(bottom_window_y_perc_, left_window_x_perc_, right_window_x_perc_);
-    }
-    else 
-    {
-      // TODO: logging...
+      ImGui::LoadIniSettingsFromMemory(imgui_ini_.c_str());
+      imgui_ini_updated_ = false;
     }
   }
 }


### PR DESCRIPTION
This new layout uses the Docking branch of imgui, which is WIP, but stable enough to be used as described here:
https://github.com/ocornut/imgui/wiki/Docking

User can:

- Resize panels (improved compared to the in-house made code)
- Dock tabs to other panel
- Dock out windows
- Split windows to more get more complex layout

Layout is saved in the session db, as previously, but using in file from imgui, which handle docking settings.

Window -> Reset Window Layout will reset the layout as it is as usual, with the 3 panels, left, top, bottom.

![Docking](https://user-images.githubusercontent.com/1705849/145161916-bf4049ed-347e-44f7-b75d-9db9be407359.gif)

