### PR TITLE
Support for small screens

### DIFF
--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -375,10 +375,12 @@ int main(int argc, char** argv)
   SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
-  SDL_DisplayMode current;
-  SDL_GetCurrentDisplayMode(0, &current);
+  SDL_DisplayMode display_mode;
+  SDL_GetCurrentDisplayMode(0, &display_mode);
+  auto starting_window_width = display_mode.w * 0.75;
+  auto starting_window_height = display_mode.h * 0.75;
   SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
-  SDL_Window* window = SDL_CreateWindow(getMainWindowTitle(application_handler_).c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
+  SDL_Window* window = SDL_CreateWindow(getMainWindowTitle(application_handler_).c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, starting_window_width, starting_window_height, window_flags);
   SDL_GLContext gl_context = SDL_GL_CreateContext(window);
   SDL_GL_SetSwapInterval(1); // Enable vsync
 
@@ -541,6 +543,10 @@ int main(int argc, char** argv)
             }
           }
           ImGui::EndMenu();
+        }
+        ImGui::Separator();
+        if (ImGui::MenuItem("Exit")) {
+          done = true;
         }
         ImGui::EndMenu();
         showQuickHelpToolTip("export_file");


### PR DESCRIPTION
Starting size of the main window on 75% width and height of the screen
added exit menu item

before, no way to access window's title bar and resizing controls, no exit possibility
![image](https://user-images.githubusercontent.com/1705849/145764805-404fea74-e882-4d09-890f-01289fd1f231.png)

after
![image](https://user-images.githubusercontent.com/1705849/145764713-2c7d1aa2-00d2-47ea-9d53-535ce58c44ca.png)
