### PR TITLE
Feat/aut1052 Enable Viewports

### DIFF
--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -413,6 +413,8 @@ int main(int argc, char** argv)
       ImGui_ImplSDL2_ProcessEvent(&event);
       if (event.type == SDL_QUIT)
         done = true;
+      if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(window))
+        done = true;
     }
 
     // Start the Dear ImGui frame

--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -389,6 +389,7 @@ int main(int argc, char** argv)
   ImGui::CreateContext();
   ImGuiIO& io = ImGui::GetIO(); (void)io;
   ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+  ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
   //io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;  // Enable Keyboard Controls
 
   // Setup Dear ImGui style
@@ -840,6 +841,18 @@ int main(int argc, char** argv)
     glClear(GL_COLOR_BUFFER_BIT);
     //glUseProgram(0); // You may want this if using this code in an OpenGL 3+ context where shaders may be bound
     ImGui_ImplOpenGL2_RenderDrawData(ImGui::GetDrawData());
+
+    // Update and Render additional Platform Windows
+    // (Platform functions may change the current OpenGL context, so we save/restore it to make it easier to paste this code elsewhere.
+    //  For this specific demo app we could also call SDL_GL_MakeCurrent(window, gl_context) directly)
+    if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+    {
+      SDL_Window* backup_current_window = SDL_GL_GetCurrentWindow();
+      SDL_GLContext backup_current_context = SDL_GL_GetCurrentContext();
+      ImGui::UpdatePlatformWindows();
+      ImGui::RenderPlatformWindowsDefault();
+      SDL_GL_MakeCurrent(backup_current_window, backup_current_context);
+    }
     SDL_GL_SwapWindow(window);
   }
 

--- a/src/widgets/source/ui/SplitWindow.cpp
+++ b/src/widgets/source/ui/SplitWindow.cpp
@@ -66,8 +66,9 @@ namespace SmartPeak
     ImGuiIO& io = ImGui::GetIO();
     static const int menu_height = 18;
     static const int padding_height = 50;
+    auto main_view_pos = ImGui::GetMainViewport()->Pos;
     ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x, io.DisplaySize.y - menu_height));
-    ImGui::SetNextWindowPos(ImVec2(0, menu_height));
+    ImGui::SetNextWindowPos(ImVec2(main_view_pos.x, main_view_pos.y + menu_height));
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0);
     static bool visible = true;
     if (ImGui::Begin("Splitter", &visible, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus))
@@ -105,9 +106,8 @@ namespace SmartPeak
       showWindows(left_windows_);
       showWindows(top_windows_);
       showWindows(bottom_windows_);
-
-      ImGui::End();
     }
+    ImGui::End();
     ImGui::PopStyleVar();
     return;
   }


### PR DESCRIPTION
Thanks to imgui's Viewport system (on Docking branch), it's now possible to drop out windows from the main window.

window positioning is absolute instead of relative.
another nice side effect is that all the popups also are displayed out of the main window.

![capt_chromatogram](https://user-images.githubusercontent.com/1705849/146053361-f957cfbd-0578-4342-9219-267d52a8a615.gif)

