### PR TITLE
Fixed Cancel button size for directory selection dialog box

### DIFF
--- a/src/widgets/source/ui/FilePicker.cpp
+++ b/src/widgets/source/ui/FilePicker.cpp
@@ -226,7 +226,7 @@ namespace SmartPeak
     ImGui::EndChild();
     ImGui::Separator();
 
-    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * 0.9f);
+    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * 0.8f);
     if (mode_ == Mode::EDirectory)
     {
       ImGui::InputTextWithHint("", "Directory name", &selected_filename_);
@@ -238,10 +238,11 @@ namespace SmartPeak
     ImGui::PopItemWidth();
 
     ImGui::SameLine();
-    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * 0.5f);
-    if (ImGui::Button(open_button_text_.c_str()))
+    auto button_width = ImGui::GetContentRegionAvail().x * 0.5f;
+    if (ImGui::Button(open_button_text_.c_str(), ImVec2(button_width, 0)))
     {
-      picked_pathname_ = current_pathname_.string();      if (picked_pathname_.back() != '/')
+      picked_pathname_ = current_pathname_.string();
+      if (picked_pathname_.back() != '/')
       {
         picked_pathname_.append("/");
       }
@@ -255,18 +256,16 @@ namespace SmartPeak
         doOpenFile();
       }
     }
-    ImGui::PopItemWidth();
 
     ImGui::SameLine();
-    ImGui::PushItemWidth(ImGui::GetContentRegionAvailWidth());
-    if (ImGui::Button("Cancel"))
+    button_width = ImGui::GetContentRegionAvail().x;
+    if (ImGui::Button("Cancel", ImVec2(button_width, 0)))
     {
       picked_pathname_.clear();
       selected_entry_ = -1;
       visible_ = false;
       ImGui::CloseCurrentPopup();
     }
-    ImGui::PopItemWidth();
 
     if (show_confirmation_popup)
     {


### PR DESCRIPTION
Little esthetic fix on the cancel button that is not fully displayed when we select a new session directory.

the incorrect size comes for 2 reasons:
- PushItemWidth does not work for buttons, you have to pass size in the Button() function
- The main field takes 90% of the width which let not enough space for the buttons anyway

before: (the cancel button is cropped)
![image](https://user-images.githubusercontent.com/1705849/146210333-7d11f74e-936f-4491-b011-b58f20e2a064.png)

fixed:
![image](https://user-images.githubusercontent.com/1705849/146209932-b1e30a6c-bf1e-4fcc-bd65-2ffc4831a7e2.png)
