### PR TITLE
Increased max points to be displayed to 10 millions

### DIFF
--- a/external/imgui.cmake
+++ b/external/imgui.cmake
@@ -13,4 +13,5 @@ ExternalProject_Add(imgui
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
+  PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/patches/imgui.patch
 )

--- a/external/patches/imgui.patch
+++ b/external/patches/imgui.patch
@@ -1,0 +1,16 @@
+ imconfig.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/imconfig.h b/imconfig.h
+index 7082c550..01a0718b 100644
+--- a/imconfig.h
++++ b/imconfig.h
+@@ -93,7 +93,7 @@
+ // Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).
+ // Another way to allow large meshes while keeping 16-bit indices is to handle ImDrawCmd::VtxOffset in your renderer.
+ // Read about ImGuiBackendFlags_RendererHasVtxOffset for details.
+-//#define ImDrawIdx unsigned int
++#define ImDrawIdx unsigned int
+ 
+ //---- Override ImDrawCallback signature (will need to modify renderer backends accordingly)
+ //struct ImDrawList;

--- a/src/smartpeak/source/core/SessionHandler.cpp
+++ b/src/smartpeak/source/core/SessionHandler.cpp
@@ -31,6 +31,8 @@
 
 namespace SmartPeak
 {
+  static int max_nb_points = 1000000;
+  
   void SessionHandler::onSequenceUpdated()
   {
     sequence_table.clear();
@@ -1652,7 +1654,7 @@ namespace SmartPeak
     {
       LOGD << "Making the chromatogram data for plotting";
       // Set the axes titles and min/max defaults
-      result.reset("Time (sec)", "Intensity (au)", {}, 6000);
+      result.reset("Time (sec)", "Intensity (au)", {}, max_nb_points);
       for (const auto& injection : sequence_handler.getSequence()) {
         if (sample_names.count(injection.getMetaData().getSampleName()) == 0) continue;
         // Extract out the raw data for plotting
@@ -1703,7 +1705,7 @@ namespace SmartPeak
   {
     LOGD << "Making the chromatogram TIC data for plotting";
     // Set the axes titles and min/max defaults
-    result.reset("Time (sec)", "Intensity (au)", {}, 6000);
+    result.reset("Time (sec)", "Intensity (au)", {}, max_nb_points);
     for (const auto& injection : sequence_handler.getSequence())
     {
       if (sample_names.count(injection.getMetaData().getSampleName()) == 0) continue;
@@ -1739,7 +1741,7 @@ namespace SmartPeak
     {
       LOGD << "Making the chromatogram data for plotting";
       // Set the axes titles and min/max defaults
-      result.reset("Time (sec)", "Intensity (au)", {}, 6000);
+      result.reset("Time (sec)", "Intensity (au)", {}, max_nb_points);
       for (const auto& injection : sequence_handler.getSequence())
       {
         // Extract out the smoothed points for plotting
@@ -1805,7 +1807,7 @@ namespace SmartPeak
     {
       LOGD << "Making the spectra data for plotting";
       // Set the axes titles and min/max defaults
-      result.reset("m/z (Da)", "Intensity (au)", {}, 6000);
+      result.reset("m/z (Da)", "Intensity (au)", {}, max_nb_points);
       for (const auto& injection : sequence_handler.getSequence()) {
         if (sample_names.count(injection.getMetaData().getSampleName()) == 0) continue;
         // Extract out the raw data for plotting
@@ -1861,7 +1863,7 @@ namespace SmartPeak
         sequence_handler.getSequence().at(0).getRawData().getFeatureMapHistory().size() > 0)) {
       LOGD << "Making the spectra data for plotting";
       // Set the axes titles and min/max defaults
-      result.reset("m/z (Da)", "Intensity (au)", "Retention Time (s)", 10000);
+      result.reset("m/z (Da)", "Intensity (au)", "Retention Time (s)", max_nb_points);
       int total_nb_points = 0;
       for (const auto& injection : sequence_handler.getSequence())
       {

--- a/src/smartpeak/source/core/SessionHandler.cpp
+++ b/src/smartpeak/source/core/SessionHandler.cpp
@@ -31,7 +31,7 @@
 
 namespace SmartPeak
 {
-  static int max_nb_points = 1000000;
+  static int max_nb_points = 10000000;
   
   void SessionHandler::onSequenceUpdated()
   {


### PR DESCRIPTION
imgui is by default limited to 64k vertices display, which prevents us to display large plots (overflow displays a corrupted graph).

It's possible and safe to break this limitation by changing ImDrawIdx to unsigned int

```
 // Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).
 // Another way to allow large meshes while keeping 16-bit indices is to handle ImDrawCmd::VtxOffset in your renderer.
 // Read about ImGuiBackendFlags_RendererHasVtxOffset for details.
//#define ImDrawIdx unsigned int
```

the number of points is increased to 10.000.000
tested with a graph using 2.500.000 points, and it looks smooth enough on a DTU machine.

