### PR TITLE
Fixed session error due to regex

### DIFF
--- a/src/smartpeak/include/SmartPeak/core/Utilities.h
+++ b/src/smartpeak/include/SmartPeak/core/Utilities.h
@@ -405,5 +405,9 @@ public:
       const std::string& parameter_name,
       const std::filesystem::path main_path);
 
+    /**
+     @brief returns true if the string is a list of items matching the regex.
+     */
+    static bool isList(const std::string& str, const std::regex& re);
   };
 }

--- a/src/smartpeak/source/core/Utilities.cpp
+++ b/src/smartpeak/source/core/Utilities.cpp
@@ -250,6 +250,23 @@ namespace SmartPeak
     }
   }
 
+  bool Utilities::isList(const std::string& str, const std::regex& re)
+  {
+    auto items = Utilities::splitString(str, ',');
+    if (items.empty())
+    {
+      return false;
+    }
+    for (const auto& item : items)
+    {
+      if (!std::regex_match(item, re))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
   void Utilities::parseString(const std::string& str_I, CastValue& cast)
   {
     std::regex re_integer_number("[+-]?\\d+");
@@ -279,16 +296,13 @@ namespace SmartPeak
           if (c != ' ')
             stripped.push_back(c);
         });
-        const std::regex re_integer_list("[+-]?\\d+(?:,[+-]?\\d+)*");
-        const std::regex re_float_list("[+-]?\\d+(?:\\.\\d+)?(?:,[+-]?\\d+(?:\\.\\d+)?)*");
-        const std::regex re_bool_list("(?:true|false)(?:,(?:true|false))*", std::regex::icase);
-        if (std::regex_match(stripped, re_integer_list)) {
+        if (Utilities::isList(stripped, re_integer_number)) {
           cast = std::vector<int>();
           parseList(stripped, re_integer_number, cast);
-        } else if (std::regex_match(stripped, re_float_list)) {
+        } else if (Utilities::isList(stripped, re_float_number)) {
           cast = std::vector<float>();
           parseList(stripped, re_float_number, cast);
-        } else if (std::regex_match(stripped, re_bool_list)) {
+        } else if (Utilities::isList(stripped, re_bool)) {
           cast = std::vector<bool>();
           parseList(stripped, re_bool, cast);
         } else {

--- a/src/tests/class_tests/smartpeak/source/Utilities_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Utilities_test.cpp
@@ -263,6 +263,49 @@ TEST(utilities, parseString)
   EXPECT_STREQ(c.sl_[2].c_str(), "third string");
 }
 
+TEST(utilities, parseString_bigString)
+{
+  std::vector<bool> bool_list;
+  std::ostringstream os;
+  os << "[";
+  std::string sep;
+  for (int i = 0; i < 1000; ++i)
+  {
+    os << sep;
+    os << "false";
+    bool_list.push_back(false);
+    sep = ",";
+  }
+  os << "]";
+  std::string big_string = os.str();
+  CastValue c;
+
+  Utilities::parseString(big_string, c);
+  ASSERT_EQ(c.getTag(), CastValue::Type::BOOL_LIST);
+  EXPECT_EQ(c.bl_ , bool_list);
+}
+
+TEST(utilities, isList)
+{
+  std::regex re_integer_number("[+-]?\\d+");
+  EXPECT_TRUE(Utilities::isList("1,2,3", re_integer_number));
+  EXPECT_FALSE(Utilities::isList("1,3.14,3", re_integer_number));
+  EXPECT_FALSE(Utilities::isList("", re_integer_number));
+
+  std::regex re_float_number("[+-]?\\d+(?:\\.\\d+)?"); // can match also integers: check for integer before checking for float
+  EXPECT_TRUE(Utilities::isList("1,2,3", re_float_number));
+  EXPECT_TRUE(Utilities::isList("1,3.14,3", re_float_number));
+  EXPECT_FALSE(Utilities::isList("1,one,two", re_float_number));
+
+  std::regex re_bool("true|false", std::regex::icase);
+  EXPECT_TRUE(Utilities::isList("false,TRUE,fAlse", re_bool));
+  EXPECT_FALSE(Utilities::isList("1,one,two", re_bool));
+
+  std::regex re_s("[\"']([^,]+)[\"']");
+  EXPECT_TRUE(Utilities::isList("\"1\",\"one\",\"two\"", re_s));
+  EXPECT_FALSE(Utilities::isList("false,TRUE,fAlse", re_s));
+}
+
 TEST(utilities, parseList)
 {
   const string floats = "[1.1,-2.1,+3.1,4]";


### PR DESCRIPTION
The regexes that we use to check if we are parsing boolean, integer or floats lists use too much memory (and are slow).

one unit test is created to show the issue (bigString).

``Utilities`` offers an isList method that returns whether the list is composed of types determined by a (hopefully not greedy) regex.

