### PR TITLE
Fix some file picker don't popup when selecting file in the New Session Dialog Box

### DIFF
--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -449,7 +449,10 @@ int main(int argc, char** argv)
     {
       if (popup->visible_)
       {
-        ImGui::OpenPopup(popup->title_.c_str());
+        if (!ImGui::IsPopupOpen(popup->title_.c_str()))
+        {
+          ImGui::OpenPopup(popup->title_.c_str());
+        }
         popup->draw();
       }
     }

--- a/src/widgets/source/ui/SessionFilesWidget.cpp
+++ b/src/widgets/source/ui/SessionFilesWidget.cpp
@@ -181,7 +181,7 @@ namespace SmartPeak
 
     if (popup_file_picker_)
     {
-      file_picker_.open(filenames_.getDescription(*popup_file_picker_),
+      file_picker_.open(std::string("Select ") + filenames_.getDescription(*popup_file_picker_),
         std::make_shared<SetInputFile>(file_editor_fields_.at(*popup_file_picker_).text_editor_),
         FilePicker::Mode::EFileRead,
         application_handler_);


### PR DESCRIPTION
Probably since the move to the docking branch of imgui, the new session dialog box was not working properly; it's impossible with some line of the dialog box to select the file: this happens for "Injections", "Transitions" and some others.

It's only a problem if you want to select different file names other than the default one, for some of these files.

this comes from a conflict where we have several windows with the same name ("Injections" is already used for the injection explorer). 

This is fixed by adding a "Select" to the name of the titles for the file picker for these files.

also avoid to spam OpenPopup in the GUI. while debugging, we can see that imgui get confused about this.