### PR TITLE
Report Doalog box now confirms success or error once the report is created

### DIFF
--- a/src/smartpeak/include/SmartPeak/io/CSVWriter.h
+++ b/src/smartpeak/include/SmartPeak/io/CSVWriter.h
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <optional>
 #include <plog/Log.h>
 
 namespace SmartPeak
@@ -66,14 +67,14 @@ public:
       @param last Iterator to the last element
     */
     template<typename T>
-    size_t writeDataInRow(T first, T last)
+    std::optional<size_t> writeDataInRow(T first, T last)
     {
       // Open the file in truncate mode if first line, else in append mode
       std::ofstream ofs(filename_, line_count_ ? std::ios::app : std::ios::trunc);
 
       if (!ofs.is_open()) {
         LOGE << "Cannot open file: " << filename_;
-        return -1;
+        return std::nullopt;
       }
 
       size_t cnt {0};

--- a/src/smartpeak/source/core/SequenceProcessor.cpp
+++ b/src/smartpeak/source/core/SequenceProcessor.cpp
@@ -880,7 +880,7 @@ namespace SmartPeak
 
       std::vector<std::string> headers = { "command_name" };
       CSVWriter writer(filenames_I.getFullPath("workflow").generic_string(), ",");
-      const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
+      const std::optional<size_t> cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
       if (cnt < headers.size()) {
         LOGD << "END writeDataTableFromMetaValue";

--- a/src/smartpeak/source/io/ParametersParser.cpp
+++ b/src/smartpeak/source/io/ParametersParser.cpp
@@ -138,7 +138,7 @@ namespace SmartPeak
     };
 
     CSVWriter writer(filename, ",");
-    const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
+    const std::optional<size_t> cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
     std::vector<std::vector<std::string>> rows;
     for (const auto& parameter_function : parameter_set)

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -598,7 +598,7 @@ namespace SmartPeak
     const std::optional<size_t> cnt0 = writer.writeDataInRow(pre_headers.cbegin(), pre_headers.cend());
     const std::optional<size_t> cnt1 = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
-    if ((!cnt0 || *cnt0 < headers.size()) || (!cnt1 || *cnt1 < headers.size())){
+    if ((!cnt0 || *cnt0 < headers.size()) || (!cnt1 || *cnt1 < headers.size())) {
       LOGD << "END writeSequenceFileXcalibur";
     }
 

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -376,9 +376,9 @@ namespace SmartPeak
 
     // Write the output file
     CSVWriter writer(filename.generic_string(), delimiter);
-    const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
+    const std::optional<size_t> cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
-    if (cnt < headers.size()) {
+    if (!cnt || *cnt < headers.size()) {
       LOGD << "END writeSequenceFileSmartPeak";
     }
 
@@ -449,9 +449,9 @@ namespace SmartPeak
 
     // Write the output file
     CSVWriter writer(filename.generic_string(), delimiter);
-    const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
+    const std::optional<size_t> cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
-    if (cnt < headers.size()) {
+    if (!cnt || *cnt < headers.size()) {
       LOGD << "END writeSequenceFileAnalyst";
     }
 
@@ -515,9 +515,9 @@ namespace SmartPeak
 
     // Write the output file
     CSVWriter writer(filename.generic_string(), delimiter);
-    const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
+    const std::optional<size_t> cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
-    if (cnt < headers.size()) {
+    if (!cnt || *cnt < headers.size()) {
       LOGD << "END writeSequenceFileMasshunter";
     }
 
@@ -595,10 +595,10 @@ namespace SmartPeak
       if (i == 0) pre_headers.push_back("Bracket Type=4");
       else pre_headers.push_back("");
     }
-    const size_t cnt0 = writer.writeDataInRow(pre_headers.cbegin(), pre_headers.cend());
-    const size_t cnt1 = writer.writeDataInRow(headers.cbegin(), headers.cend());
+    const std::optional<size_t> cnt0 = writer.writeDataInRow(pre_headers.cbegin(), pre_headers.cend());
+    const std::optional<size_t> cnt1 = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
-    if (cnt0 < headers.size() || cnt1 < headers.size()) {
+    if ((!cnt0 || *cnt0 < headers.size()) || (!cnt1 || *cnt1 < headers.size())){
       LOGD << "END writeSequenceFileXcalibur";
     }
 
@@ -875,9 +875,9 @@ namespace SmartPeak
     makeDataTableFromMetaValue(sequenceHandler, rows, headers, meta_data_strings, sample_types, std::set<std::string>(), std::set<std::string>(), std::set<std::string>());
 
     CSVWriter writer(filename.generic_string(), ",");
-    const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
+    const std::optional<size_t> cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
-    if (cnt < headers.size()) {
+    if (!cnt || *cnt < headers.size()) {
       LOGD << "END writeDataTableFromMetaValue";
       return false;
     }
@@ -909,9 +909,9 @@ namespace SmartPeak
     makeGroupDataTableFromMetaValue(sequenceHandler, rows, headers, meta_data_strings, sample_types, std::set<std::string>(), std::set<std::string>(), std::set<std::string>());
 
     CSVWriter writer(filename.generic_string(), ",");
-    const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
+    const std::optional<size_t> cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
-    if (cnt < headers.size()) {
+    if (!cnt || *cnt < headers.size()) {
       LOGD << "END writeDataTableFromMetaValue";
       return false;
     }
@@ -1105,9 +1105,9 @@ namespace SmartPeak
     for (int i=0;i<columns.size();++i) headers.push_back(columns(i));
 
     CSVWriter writer(filename.generic_string(), ",");
-    const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
+    const std::optional<size_t> cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
-    if (cnt < headers.size()) {
+    if (!cnt || *cnt < headers.size()) {
       LOGD << "END writeDataMatrixFromMetaValue";
       return false;
     }
@@ -1268,9 +1268,9 @@ namespace SmartPeak
     for (int i = 0; i < columns.size(); ++i) headers.push_back(columns(i));
 
     CSVWriter writer(filename.generic_string(), ",");
-    const size_t cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
+    const std::optional<size_t> cnt = writer.writeDataInRow(headers.cbegin(), headers.cend());
 
-    if (cnt < headers.size()) {
+    if (!cnt || *cnt < headers.size()) {
       LOGD << "END writeDataMatrixFromMetaValue";
       return false;
     }

--- a/src/tests/class_tests/smartpeak/source/CSVWriter_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/CSVWriter_test.cpp
@@ -71,11 +71,17 @@ TEST(CSVWriter, writeDataInRow)
 
   // Write the data to file
   headers = {"Column1", "Column2", "Column3"};
-  csvwriter.writeDataInRow(headers.begin(), headers.end());
+  std::optional<size_t> cnt = csvwriter.writeDataInRow(headers.begin(), headers.end());
+  ASSERT_TRUE(cnt);
+  EXPECT_EQ(*cnt, 3);
   line = {"a", "b", "c" };
-  csvwriter.writeDataInRow(line.begin(), line.end());
+  cnt = csvwriter.writeDataInRow(line.begin(), line.end());
+  ASSERT_TRUE(cnt);
+  EXPECT_EQ(*cnt, 3);
   line = {"1", "2", "3" };
-  csvwriter.writeDataInRow(line.begin(), line.end());
+  cnt = csvwriter.writeDataInRow(line.begin(), line.end());
+  ASSERT_TRUE(cnt);
+  EXPECT_EQ(*cnt, 3);
 
   // Read the data back in
   io::CSVReader<3> test_in(filename);

--- a/src/widgets/include/SmartPeak/ui/Report.h
+++ b/src/widgets/include/SmartPeak/ui/Report.h
@@ -55,7 +55,8 @@ namespace SmartPeak
       const SequenceHandler sequence,
       const std::filesystem::path& pathname,
       const std::vector<FeatureMetadata>& meta_data,
-      const std::set<SampleType>& sample_types
+      const std::set<SampleType>& sample_types,
+      std::optional<std::string>& result_message
     );
 
   public:
@@ -64,20 +65,25 @@ namespace SmartPeak
     void draw() override;
 
   protected:
+
+    void drawResultMessage();
+
+    std::optional<std::string> result_message_;
+
     struct ReportFilePickerHandler : IFilePickerHandler
     {
       typedef  bool (*WriterMethod)(const SequenceHandler&, 
                                        const std::filesystem::path&,
                                        const std::vector<FeatureMetadata>&,
                                        const std::set<SampleType>&);
-      ReportFilePickerHandler(const Report& report, const std::string title, WriterMethod writer_method) :
+      ReportFilePickerHandler(Report& report, const std::string title, WriterMethod writer_method) :
         report_(report), title_(title), writer_method_(writer_method) { };
       /**
       IFilePickerHandler
       */
       bool onFilePicked(const std::filesystem::path& filename, ApplicationHandler* application_handler) override;
     protected:
-      const Report& report_;
+      Report& report_;
       const std::string title_;
       WriterMethod writer_method_;
     };


### PR DESCRIPTION
The report dialog box was missing some feedback.
no notification on success or on error. the user had to check the log (which most probably will not do).
it's problematic when a report is opened with Excel, you don't know that you failed to overwrite it.

![image](https://user-images.githubusercontent.com/1705849/148266800-10363c35-4c13-48e8-80a3-8720602ff2bd.png)

One issue on that is the size_t that is been set to -1 on error in the cvswriter's writeDataInRow which is incorrect since it's an unsigned type. A std::optional has been used there.