### PR TITLE
Fixing compilation and unit test issues coming with the latest updates from OpenMS.

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -76,7 +76,7 @@ endif(OpenMS_FOUND)
 #------------------------------------------------------------------------------
 # OpenMS QT5 dependencies
 #------------------------------------------------------------------------------
-find_package(Qt5 COMPONENTS Core Network REQUIRED)
+find_package(Qt5 COMPONENTS Core Network Sql REQUIRED)
 
 if (NOT Qt5Network_FOUND)
   message(STATUS "[examples] : QtNetwork module not found!")
@@ -85,6 +85,11 @@ endif()
 
 if (NOT Qt5Core_FOUND)
   message(STATUS "[examples] : QtCore module not found!")
+  message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -D QT_QMAKE_EXECUTABLE='<path_to_qmake(.exe)' <src-dir>")
+endif()
+
+if (NOT Qt5Sql_FOUND)
+  message(STATUS "[examples] : QtSql module not found!")
   message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -D QT_QMAKE_EXECUTABLE='<path_to_qmake(.exe)' <src-dir>")
 endif()
 

--- a/src/tests/class_tests/smartpeak/CMakeLists.txt
+++ b/src/tests/class_tests/smartpeak/CMakeLists.txt
@@ -61,7 +61,7 @@ endif(OpenMS_FOUND)
 #------------------------------------------------------------------------------
 # OpenMS QT5 dependencies
 #------------------------------------------------------------------------------
-find_package(Qt5 COMPONENTS Core Network REQUIRED)
+find_package(Qt5 COMPONENTS Core Network Sql REQUIRED)
 
 if (NOT Qt5Network_FOUND)
   message(STATUS "[class_tests] : QtNetwork module not found!")
@@ -70,6 +70,11 @@ endif()
 
 if (NOT Qt5Core_FOUND)
   message(STATUS "[class_tests] : QtCore module not found!")
+  message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -D QT_QMAKE_EXECUTABLE='<path_to_qmake(.exe)' <src-dir>")
+endif()
+
+if (NOT Qt5Sql_FOUND)
+  message(STATUS "[class_tests] : QtSql module not found!")
   message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -D QT_QMAKE_EXECUTABLE='<path_to_qmake(.exe)' <src-dir>")
 endif()
 

--- a/src/tests/class_tests/smartpeak/source/RawDataProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/RawDataProcessor_test.cpp
@@ -1455,46 +1455,46 @@ TEST(RawDataProcessor, pickMS2Features)
 
   pickFeatures.process(rawDataHandler, params_1, filenames);
 
-  EXPECT_EQ(rawDataHandler.getFeatureMap().size(), 2258);
-  EXPECT_EQ(rawDataHandler.getExperiment().getChromatograms().size(), 2258);
+  EXPECT_EQ(rawDataHandler.getFeatureMap().size(), 2737);
+  EXPECT_EQ(rawDataHandler.getExperiment().getChromatograms().size(), 2737);
 
   const OpenMS::Feature& feature1 = rawDataHandler.getFeatureMap().at(0); // feature_map_
   EXPECT_EQ(feature1.getMetaValue("num_of_masstraces").toString(), "1");
   EXPECT_EQ(feature1.getMetaValue("scan_polarity"), "positive");
   ASSERT_TRUE(feature1.getConvexHulls().size() == 1);
-  EXPECT_NEAR(feature1.getConvexHull().getBoundingBox().minX(), 381.298f, 1e-3);
+  EXPECT_NEAR(feature1.getConvexHull().getBoundingBox().minX(), 488.3000, 1e-3);
   EXPECT_NEAR(feature1.getConvexHull().getBoundingBox().minY(), 79.021f, 1e-3);
   EXPECT_NEAR(feature1.getConvexHull().getBoundingBox().maxX(), 540.557f, 1e-3);
   EXPECT_NEAR(feature1.getConvexHull().getBoundingBox().maxY(), 79.023f, 1e-3);
-  EXPECT_NEAR(static_cast<double>(feature1.getRT()), 453.462, 1e-6);
-  EXPECT_NEAR(static_cast<double>(feature1.getMZ()), 79.022321098842482, 1e-6);
-  EXPECT_NEAR(static_cast<double>(feature1.getIntensity()), 7978.17578125, 1e-6);
+  EXPECT_NEAR(static_cast<double>(feature1.getRT()), 498.752999, 1e-6);
+  EXPECT_NEAR(static_cast<double>(feature1.getMZ()), 79.0221059, 1e-6);
+  EXPECT_NEAR(static_cast<double>(feature1.getIntensity()), 18283.1621093, 1e-6);
 
   const OpenMS::Feature& feature2 = rawDataHandler.getFeatureMap().back();
   EXPECT_EQ(feature2.getMetaValue("num_of_masstraces").toString(), "1");
   ASSERT_TRUE(feature2.getConvexHulls().size() == 1);
-  EXPECT_NEAR(feature2.getConvexHull().getBoundingBox().minX(), 547.524f, 1e-2);
-  EXPECT_NEAR(feature2.getConvexHull().getBoundingBox().minY(), 848.610f, 1e-3);
-  EXPECT_NEAR(feature2.getConvexHull().getBoundingBox().maxX(), 592.812f, 1e-3);
-  EXPECT_NEAR(feature2.getConvexHull().getBoundingBox().maxY(), 848.641f, 1e-3);
-  EXPECT_NEAR(static_cast<double>(feature2.getRT()), 568.428, 1e-6);
-  EXPECT_NEAR(static_cast<double>(feature2.getMZ()), 848.63375701405562, 1e-6);
-  EXPECT_NEAR(static_cast<double>(feature2.getIntensity()), 46520.29296875, 1e-6);
+  EXPECT_NEAR(feature2.getConvexHull().getBoundingBox().minX(), 631.136999f, 1e-2);
+  EXPECT_NEAR(feature2.getConvexHull().getBoundingBox().minY(), 848.624214f, 1e-3);
+  EXPECT_NEAR(feature2.getConvexHull().getBoundingBox().maxX(), 659.0080000f, 1e-3);
+  EXPECT_NEAR(feature2.getConvexHull().getBoundingBox().maxY(), 848.6381134f, 1e-3);
+  EXPECT_NEAR(static_cast<double>(feature2.getRT()), 648.5560000, 1e-6);
+  EXPECT_NEAR(static_cast<double>(feature2.getMZ()), 848.6336890, 1e-6);
+  EXPECT_NEAR(static_cast<double>(feature2.getIntensity()), 14291.36816406, 1e-6);
 
-  EXPECT_EQ(rawDataHandler.getFeatureMapHistory().size(), 2258);
+  EXPECT_EQ(rawDataHandler.getFeatureMapHistory().size(), 2737);
 
   const OpenMS::Feature& hfeature1 = rawDataHandler.getFeatureMapHistory().at(0); // feature_map_history_
   EXPECT_EQ(hfeature1.getMetaValue("num_of_masstraces").toString(), "1");
   EXPECT_EQ(hfeature1.getMetaValue("scan_polarity"), "positive");
-  EXPECT_NEAR(static_cast<double>(hfeature1.getRT()), 453.462, 1e-6);
-  EXPECT_NEAR(static_cast<double>(hfeature1.getMZ()), 79.022321098842482, 1e-6);
-  EXPECT_NEAR(static_cast<double>(hfeature1.getIntensity()), 7978.17578125, 1e-6);
+  EXPECT_NEAR(static_cast<double>(hfeature1.getRT()), 498.752999, 1e-6);
+  EXPECT_NEAR(static_cast<double>(hfeature1.getMZ()), 79.02210591, 1e-6);
+  EXPECT_NEAR(static_cast<double>(hfeature1.getIntensity()), 18283.16210937, 1e-6);
 
   const OpenMS::Feature& hfeature2 = rawDataHandler.getFeatureMapHistory().back();
   EXPECT_EQ(hfeature2.getMetaValue("num_of_masstraces").toString(), "1");
-  EXPECT_NEAR(static_cast<double>(hfeature2.getRT()), 568.428, 1e-6);
-  EXPECT_NEAR(static_cast<double>(hfeature2.getMZ()), 848.63375701405562, 1e-6);
-  EXPECT_NEAR(static_cast<double>(hfeature2.getIntensity()), 46520.29296875, 1e-6);
+  EXPECT_NEAR(static_cast<double>(hfeature2.getRT()), 648.55600000, 1e-6);
+  EXPECT_NEAR(static_cast<double>(hfeature2.getMZ()), 848.6336890331, 1e-6);
+  EXPECT_NEAR(static_cast<double>(hfeature2.getIntensity()), 14291.36816406, 1e-6);
 }
 
 /**


### PR DESCRIPTION
Fixing compilation and unit test issues coming with the latest updates from OpenMS.

- We have now a dependency to QT5::Sql
- After some update in https://github.com/OpenMS/OpenMS/pull/5734 we need to change some values of our unit tests.