### PR TITLE
Feat/improve calibration curve

### DIFF
--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -874,12 +874,9 @@ int main(int argc, char** argv)
     // calibrators
     if (calibrators_line_plot_->visible_)
     {
-      exceeding_plot_points_ = !session_handler_.setCalibratorsScatterLinePlot(application_handler_.sequenceHandler_);
-      calibrators_line_plot_->setValues(&session_handler_.calibrators_conc_fit_data, &session_handler_.calibrators_feature_fit_data,
-        &session_handler_.calibrators_conc_raw_data, &session_handler_.calibrators_feature_raw_data, &session_handler_.calibrators_series_names,
-        session_handler_.calibrators_x_axis_title, session_handler_.calibrators_y_axis_title, session_handler_.calibrators_conc_min, session_handler_.calibrators_conc_max,
-        session_handler_.calibrators_feature_min, session_handler_.calibrators_feature_max,
-        "CalibratorsMainWindow");
+      SessionHandler::CalibrationData calibration_data;
+      exceeding_plot_points_ = !session_handler_.setCalibratorsScatterLinePlot(application_handler_.sequenceHandler_, calibration_data);
+      calibrators_line_plot_->setValues(calibration_data, "CalibratorsMainWindow");
     }
 
     // ======================================

--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -704,6 +704,7 @@ int main(int argc, char** argv)
         if (ImGui::MenuItem("Reset Window Layout"))
         {
           split_window.reset_layout_ = true;
+          calibrators_line_plot_->reset_layout_ = true;
         }
         ImGui::EndMenu();
       }

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentHandler.h
@@ -112,7 +112,17 @@ public:
     const std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
     getComponentsToConcentrations() const;
 
-private:
+    void setOuterComponentsToConcentrations(
+      const std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> components_to_concentrations
+    );
+
+    std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
+      getOuterComponentsToConcentrations();
+
+    const std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
+      getOuterComponentsToConcentrations() const;
+  
+  private:
     std::string sequence_segment_name_;
     std::vector<size_t> sample_indices_;  ///< The indices of each injection; this could be replaced with `std::shared_ptr<InjectionHandler>` to save the map lookup
     std::vector<OpenMS::AbsoluteQuantitationStandards::runConcentration> standards_concentrations_;
@@ -126,5 +136,6 @@ private:
     std::shared_ptr<OpenMS::MRMFeatureQC> feature_rsd_estimations_ = nullptr;  ///< Percent RSD estimations; shared between all raw data handlers in the sequence segment
     std::shared_ptr<OpenMS::MRMFeatureQC> feature_background_estimations_ = nullptr;  ///< Background interference estimations; shared between all raw data handlers in the sequence segment
     std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> components_to_concentrations_;
+    std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> outer_components_to_concentrations_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentHandler.h
@@ -112,15 +112,15 @@ public:
     const std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
     getComponentsToConcentrations() const;
 
-    void setOuterComponentsToConcentrations(
+    void setOutlierComponentsToConcentrations(
       const std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> components_to_concentrations
     );
 
     std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
-      getOuterComponentsToConcentrations();
+      getOutlierComponentsToConcentrations();
 
     const std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
-      getOuterComponentsToConcentrations() const;
+      getOutlierComponentsToConcentrations() const;
   
   private:
     std::string sequence_segment_name_;
@@ -136,6 +136,6 @@ public:
     std::shared_ptr<OpenMS::MRMFeatureQC> feature_rsd_estimations_ = nullptr;  ///< Percent RSD estimations; shared between all raw data handlers in the sequence segment
     std::shared_ptr<OpenMS::MRMFeatureQC> feature_background_estimations_ = nullptr;  ///< Background interference estimations; shared between all raw data handlers in the sequence segment
     std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> components_to_concentrations_;
-    std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> outer_components_to_concentrations_;
+    std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> outlier_components_to_concentrations_;
   };
 }

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessors/CalculateCalibration.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessors/CalculateCalibration.h
@@ -44,11 +44,6 @@ namespace SmartPeak
       const ParameterSet& params_I,
       Filenames& filenames_I
     ) const override;
-
-    /**
-      Apply the processor only on 1 component
-    */
-    std::optional<std::string> component_name_ = std::nullopt;
   };
 
 }

--- a/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessors/CalculateCalibration.h
+++ b/src/smartpeak/include/SmartPeak/core/SequenceSegmentProcessors/CalculateCalibration.h
@@ -44,6 +44,11 @@ namespace SmartPeak
       const ParameterSet& params_I,
       Filenames& filenames_I
     ) const override;
+
+    /**
+      Apply the processor only on 1 component
+    */
+    std::optional<std::string> component_name_ = std::nullopt;
   };
 
 }

--- a/src/smartpeak/include/SmartPeak/core/SessionHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/SessionHandler.h
@@ -344,6 +344,8 @@ namespace SmartPeak
     {
       std::vector<std::vector<float>> conc_raw_data;
       std::vector<std::vector<float>> feature_raw_data;
+      std::vector<std::vector<float>> outer_conc_raw_data;
+      std::vector<std::vector<float>> outer_feature_raw_data;
       std::vector<std::vector<float>> conc_fit_data;
       std::vector<std::vector<float>> feature_fit_data;
       std::vector<std::string> series_names;
@@ -353,7 +355,7 @@ namespace SmartPeak
       float conc_max;
       float feature_min;
       float feature_max;
-      OpenMS::AbsoluteQuantitationMethod quant_method;
+      std::vector<OpenMS::AbsoluteQuantitationMethod> quant_methods;
     };
 
     /*

--- a/src/smartpeak/include/SmartPeak/core/SessionHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/SessionHandler.h
@@ -336,7 +336,6 @@ namespace SmartPeak
     */
     void getHeatMap(const SequenceHandler& sequence_handler, HeatMapData& result, const std::string& feature_name);
     
-
     /*
     @brief Calibration data structure, result of call to setCalibratorsScatterLinePlot
     */
@@ -344,8 +343,8 @@ namespace SmartPeak
     {
       std::vector<std::vector<float>> conc_raw_data;
       std::vector<std::vector<float>> feature_raw_data;
-      std::vector<std::vector<float>> outer_conc_raw_data;
-      std::vector<std::vector<float>> outer_feature_raw_data;
+      std::vector<std::vector<float>> outlier_conc_raw_data;
+      std::vector<std::vector<float>> outlier_feature_raw_data;
       std::vector<std::vector<float>> conc_fit_data;
       std::vector<std::vector<float>> feature_fit_data;
       std::vector<std::string> series_names;

--- a/src/smartpeak/include/SmartPeak/core/SessionHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/SessionHandler.h
@@ -336,6 +336,23 @@ namespace SmartPeak
     */
     void getHeatMap(const SequenceHandler& sequence_handler, HeatMapData& result, const std::string& feature_name);
     
+
+    /*
+    @brief Calibration data structure, result of call to setCalibratorsScatterLinePlot
+    */
+    struct CalibrationData
+    {
+      std::vector<std::vector<float>> calibrators_conc_raw_data, calibrators_feature_raw_data;
+      std::vector<std::vector<float>> calibrators_conc_fit_data, calibrators_feature_fit_data;
+      std::vector<std::string> calibrators_series_names;
+      std::string calibrators_x_axis_title;
+      std::string calibrators_y_axis_title;
+      float calibrators_conc_min;
+      float calibrators_conc_max;
+      float calibrators_feature_min;
+      float calibrators_feature_max;
+    };
+
     /*
     @brief Sets the data used for rendering the calibrators
 
@@ -343,7 +360,7 @@ namespace SmartPeak
 
     @returns true if all points were added and false if points were omitted due to performance
     */
-    bool setCalibratorsScatterLinePlot(const SequenceHandler& sequence_handler);
+    bool setCalibratorsScatterLinePlot(const SequenceHandler& sequence_handler, CalibrationData& result);
 
     Eigen::Tensor<std::string, 1> getInjectionExplorerHeader();
     Eigen::Tensor<std::string, 2> getInjectionExplorerBody();
@@ -403,13 +420,6 @@ namespace SmartPeak
     std::string feat_line_y_axis_title;
     float feat_line_sample_min, feat_line_sample_max, feat_value_min, feat_value_max;
     Eigen::Tensor<std::string, 1> feat_row_labels, feat_col_labels;
-    // data for the calibrators scatter/line plot
-    std::vector<std::vector<float>> calibrators_conc_raw_data, calibrators_feature_raw_data;
-    std::vector<std::vector<float>> calibrators_conc_fit_data, calibrators_feature_fit_data;
-    std::vector<std::string> calibrators_series_names;
-    std::string calibrators_x_axis_title;
-    std::string calibrators_y_axis_title;
-    float calibrators_conc_min , calibrators_conc_max, calibrators_feature_min, calibrators_feature_max;
   private:
     int feature_table_unique_samples_transitions_ = 0; // used to decide when to update the feature table data
     int feature_matrix_unique_transitions_ = 0; // used to decide when to update the feature matrix data

--- a/src/smartpeak/include/SmartPeak/core/SessionHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/SessionHandler.h
@@ -342,17 +342,17 @@ namespace SmartPeak
     */
     struct CalibrationData
     {
-      std::vector<std::vector<float>> calibrators_conc_raw_data;
-      std::vector<std::vector<float>> calibrators_feature_raw_data;
-      std::vector<std::vector<float>> calibrators_conc_fit_data;
-      std::vector<std::vector<float>> calibrators_feature_fit_data;
-      std::vector<std::string> calibrators_series_names;
-      std::string calibrators_x_axis_title;
-      std::string calibrators_y_axis_title;
-      float calibrators_conc_min;
-      float calibrators_conc_max;
-      float calibrators_feature_min;
-      float calibrators_feature_max;
+      std::vector<std::vector<float>> conc_raw_data;
+      std::vector<std::vector<float>> feature_raw_data;
+      std::vector<std::vector<float>> conc_fit_data;
+      std::vector<std::vector<float>> feature_fit_data;
+      std::vector<std::string> series_names;
+      std::string x_axis_title;
+      std::string y_axis_title;
+      float conc_min;
+      float conc_max;
+      float feature_min;
+      float feature_max;
       OpenMS::AbsoluteQuantitationMethod quant_method;
     };
 

--- a/src/smartpeak/include/SmartPeak/core/SessionHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/SessionHandler.h
@@ -342,8 +342,10 @@ namespace SmartPeak
     */
     struct CalibrationData
     {
-      std::vector<std::vector<float>> calibrators_conc_raw_data, calibrators_feature_raw_data;
-      std::vector<std::vector<float>> calibrators_conc_fit_data, calibrators_feature_fit_data;
+      std::vector<std::vector<float>> calibrators_conc_raw_data;
+      std::vector<std::vector<float>> calibrators_feature_raw_data;
+      std::vector<std::vector<float>> calibrators_conc_fit_data;
+      std::vector<std::vector<float>> calibrators_feature_fit_data;
       std::vector<std::string> calibrators_series_names;
       std::string calibrators_x_axis_title;
       std::string calibrators_y_axis_title;
@@ -351,6 +353,7 @@ namespace SmartPeak
       float calibrators_conc_max;
       float calibrators_feature_min;
       float calibrators_feature_max;
+      OpenMS::AbsoluteQuantitationMethod quant_method;
     };
 
     /*

--- a/src/smartpeak/source/core/SequenceSegmentHandler.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentHandler.cpp
@@ -53,6 +53,7 @@ namespace SmartPeak
     if (feature_rsd_estimations_ != nullptr) feature_rsd_estimations_ = std::make_shared<OpenMS::MRMFeatureQC>(OpenMS::MRMFeatureQC());
     if (feature_background_estimations_ != nullptr) feature_background_estimations_ = std::make_shared<OpenMS::MRMFeatureQC>(OpenMS::MRMFeatureQC());
     components_to_concentrations_.clear();
+    outer_components_to_concentrations_.clear();
   }
 
   void SequenceSegmentHandler::setSequenceSegmentName(const std::string& sequence_segment_name)

--- a/src/smartpeak/source/core/SequenceSegmentHandler.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentHandler.cpp
@@ -53,7 +53,7 @@ namespace SmartPeak
     if (feature_rsd_estimations_ != nullptr) feature_rsd_estimations_ = std::make_shared<OpenMS::MRMFeatureQC>(OpenMS::MRMFeatureQC());
     if (feature_background_estimations_ != nullptr) feature_background_estimations_ = std::make_shared<OpenMS::MRMFeatureQC>(OpenMS::MRMFeatureQC());
     components_to_concentrations_.clear();
-    outer_components_to_concentrations_.clear();
+    outlier_components_to_concentrations_.clear();
   }
 
   void SequenceSegmentHandler::setSequenceSegmentName(const std::string& sequence_segment_name)
@@ -345,22 +345,22 @@ namespace SmartPeak
     return components_to_concentrations_;
   }
 
-  void SequenceSegmentHandler::setOuterComponentsToConcentrations(
+  void SequenceSegmentHandler::setOutlierComponentsToConcentrations(
     const std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> components_to_concentrations
   )
   {
-    outer_components_to_concentrations_ = components_to_concentrations;
+    outlier_components_to_concentrations_ = components_to_concentrations;
   }
 
   std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
-    SequenceSegmentHandler::getOuterComponentsToConcentrations()
+    SequenceSegmentHandler::getOutlierComponentsToConcentrations()
   {
-    return outer_components_to_concentrations_;
+    return outlier_components_to_concentrations_;
   }
 
   const std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
-    SequenceSegmentHandler::getOuterComponentsToConcentrations() const
+    SequenceSegmentHandler::getOutlierComponentsToConcentrations() const
   {
-    return outer_components_to_concentrations_;
+    return outlier_components_to_concentrations_;
   }
 }

--- a/src/smartpeak/source/core/SequenceSegmentHandler.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentHandler.cpp
@@ -343,4 +343,23 @@ namespace SmartPeak
   {
     return components_to_concentrations_;
   }
+
+  void SequenceSegmentHandler::setOuterComponentsToConcentrations(
+    const std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> components_to_concentrations
+  )
+  {
+    outer_components_to_concentrations_ = components_to_concentrations;
+  }
+
+  std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
+    SequenceSegmentHandler::getOuterComponentsToConcentrations()
+  {
+    return outer_components_to_concentrations_;
+  }
+
+  const std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
+    SequenceSegmentHandler::getOuterComponentsToConcentrations() const
+  {
+    return outer_components_to_concentrations_;
+  }
 }

--- a/src/smartpeak/source/core/SequenceSegmentProcessors/CalculateCalibration.cpp
+++ b/src/smartpeak/source/core/SequenceSegmentProcessors/CalculateCalibration.cpp
@@ -83,7 +83,7 @@ namespace SmartPeak
 
     absoluteQuantitation.setQuantMethods(sequenceSegmentHandler_IO.getQuantitationMethods());
     std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> components_to_concentrations;
-    std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> outer_components_to_concentrations;
+    std::map<std::string, std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> outlier_components_to_concentrations;
     for (const OpenMS::AbsoluteQuantitationMethod& row : sequenceSegmentHandler_IO.getQuantitationMethods()) {
       // map standards to features
       OpenMS::AbsoluteQuantitationStandards absoluteQuantitationStandards;
@@ -130,7 +130,7 @@ namespace SmartPeak
       }
 
       // Compute outer points
-      std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration> outer_feature_concentrations;
+      std::vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration> outlier_feature_concentrations;
       for (const auto& feature : all_feature_concentrations)
       {
         bool found = false;
@@ -147,17 +147,17 @@ namespace SmartPeak
         }
         if (!found)
         {
-          outer_feature_concentrations.push_back(feature);
+          outlier_feature_concentrations.push_back(feature);
         }
       }
       components_to_concentrations.erase(row.getComponentName());
       components_to_concentrations.insert({row.getComponentName(), feature_concentrations_pruned });
-      outer_components_to_concentrations.erase(row.getComponentName());
-      outer_components_to_concentrations.insert({ row.getComponentName(), outer_feature_concentrations });
+      outlier_components_to_concentrations.erase(row.getComponentName());
+      outlier_components_to_concentrations.insert({ row.getComponentName(), outlier_feature_concentrations });
     }
     // store results
     sequenceSegmentHandler_IO.setComponentsToConcentrations(components_to_concentrations);
-    sequenceSegmentHandler_IO.setOuterComponentsToConcentrations(outer_components_to_concentrations);
+    sequenceSegmentHandler_IO.setOutlierComponentsToConcentrations(outlier_components_to_concentrations);
     sequenceSegmentHandler_IO.getQuantitationMethods() = absoluteQuantitation.getQuantMethods();
     //sequenceSegmentHandler_IO.setQuantitationMethods(absoluteQuantitation.getQuantMethods());
     LOGD << "END optimizeCalibrationCurves";

--- a/src/smartpeak/source/core/SessionHandler.cpp
+++ b/src/smartpeak/source/core/SessionHandler.cpp
@@ -2054,7 +2054,7 @@ namespace SmartPeak
                 (double)quant_method.getTransformationModelParams().getValue("slope") != 1.0&&
                 component_names.count(quant_method.getComponentName()) > 0) // TODO: filter out components that have not been fitted
             { 
-              // Make the line of best fit using the `QuantitationMethods
+              // Make the line of best fit using the `QuantitationMethods`
               std::vector<float> y_fit_data;
               for (const auto& ratio : stand_concs_map.at(quant_method.getComponentName()).first) {
                 // TODO: encapsulate in its own method e.g. sequenceSegmentProcessor

--- a/src/smartpeak/source/core/SessionHandler.cpp
+++ b/src/smartpeak/source/core/SessionHandler.cpp
@@ -2096,24 +2096,24 @@ namespace SmartPeak
               }
               n_points += x_raw_data.size();
               // Extract out the points out of the line of best fit in `ComponentsToConcentrations`
-              std::vector<float> outer_x_raw_data, outer_y_raw_data;
-              for (const auto& point : sequence_segment.getOuterComponentsToConcentrations().at(quant_method.getComponentName())) {
+              std::vector<float> outlier_x_raw_data, outlier_y_raw_data;
+              for (const auto& point : sequence_segment.getOutlierComponentsToConcentrations().at(quant_method.getComponentName())) {
                 auto ratio = float(point.actual_concentration / point.IS_actual_concentration / point.dilution_factor);
-                outer_x_raw_data.push_back(ratio);
+                outlier_x_raw_data.push_back(ratio);
                 float y_datum = absQuant.calculateRatio(point.feature, point.IS_feature, quant_method.getFeatureName());
-                outer_y_raw_data.push_back(y_datum);
+                outlier_y_raw_data.push_back(y_datum);
                 result.feature_min = std::min(y_datum, result.feature_min);
                 result.feature_max = std::max(y_datum, result.feature_max);
                 result.conc_min = std::min(ratio, result.conc_min);
                 result.conc_max = std::max(ratio, result.conc_max);
               }
-              n_points += outer_x_raw_data.size();
+              n_points += outlier_x_raw_data.size();
               // add points
               if (n_points < max_nb_points) {
                 result.conc_raw_data.push_back(x_raw_data);
                 result.feature_raw_data.push_back(y_raw_data);
-                result.outer_conc_raw_data.push_back(outer_x_raw_data);
-                result.outer_feature_raw_data.push_back(outer_y_raw_data);
+                result.outlier_conc_raw_data.push_back(outlier_x_raw_data);
+                result.outlier_feature_raw_data.push_back(outlier_y_raw_data);
                 result.series_names.push_back(quant_method.getComponentName());
               }
               else

--- a/src/smartpeak/source/core/SessionHandler.cpp
+++ b/src/smartpeak/source/core/SessionHandler.cpp
@@ -2007,21 +2007,21 @@ namespace SmartPeak
         if (!selected_transitions(i).empty())
           component_names.insert(selected_transitions(i));
       }
-      if (result.calibrators_conc_fit_data.size() != component_names.size() && result.calibrators_conc_raw_data.size() != component_names.size())
+      if (result.conc_fit_data.size() != component_names.size() && result.conc_raw_data.size() != component_names.size())
       {
         LOGD << "Making the calibrators data for plotting";
         // Update the axis titles and clear the data
-        result.calibrators_x_axis_title = "Concentration (" + sequence_handler.getSequenceSegments().at(0).getQuantitationMethods().at(0).getConcentrationUnits() + ")";
-        result.calibrators_y_axis_title = sequence_handler.getSequenceSegments().at(0).getQuantitationMethods().at(0).getFeatureName() + " (au)";
-        result.calibrators_conc_min = 1e6;
-        result.calibrators_conc_max = 0;
-        result.calibrators_feature_min = 1e6;
-        result.calibrators_feature_max = 0;
-        result.calibrators_conc_fit_data.clear();
-        result.calibrators_feature_fit_data.clear();
-        result.calibrators_conc_raw_data.clear();
-        result.calibrators_feature_raw_data.clear();
-        result.calibrators_series_names.clear();
+        result.x_axis_title = "Concentration (" + sequence_handler.getSequenceSegments().at(0).getQuantitationMethods().at(0).getConcentrationUnits() + ")";
+        result.y_axis_title = sequence_handler.getSequenceSegments().at(0).getQuantitationMethods().at(0).getFeatureName() + " (au)";
+        result.conc_min = 1e6;
+        result.conc_max = 0;
+        result.feature_min = 1e6;
+        result.feature_max = 0;
+        result.conc_fit_data.clear();
+        result.feature_fit_data.clear();
+        result.conc_raw_data.clear();
+        result.feature_raw_data.clear();
+        result.series_names.clear();
         for (const auto& sequence_segment : sequence_handler.getSequenceSegments()) {
           // Extract out raw data used to make the calibrators found in `StandardsConcentrations`
           std::map<std::string, std::pair<std::vector<float>, std::vector<std::string>>> stand_concs_map; // map of x_data and sample_name for a component
@@ -2070,15 +2070,15 @@ namespace SmartPeak
                   calculated_feature_ratio = 0.0;
                 }
                 y_fit_data.push_back(calculated_feature_ratio);
-                result.calibrators_conc_min = std::min(ratio, result.calibrators_conc_min);
-                result.calibrators_conc_max = std::max(ratio, result.calibrators_conc_max);
-                result.calibrators_feature_min = std::min(calculated_feature_ratio, result.calibrators_feature_min);
-                result.calibrators_feature_max = std::max(calculated_feature_ratio, result.calibrators_feature_max);
+                result.conc_min = std::min(ratio, result.conc_min);
+                result.conc_max = std::max(ratio, result.conc_max);
+                result.feature_min = std::min(calculated_feature_ratio, result.feature_min);
+                result.feature_max = std::max(calculated_feature_ratio, result.feature_max);
               }
               n_points += y_fit_data.size();
               if (n_points < max_nb_points) {
-                result.calibrators_conc_fit_data.push_back(stand_concs_map.at(quant_method.getComponentName()).first);
-                result.calibrators_feature_fit_data.push_back(y_fit_data);
+                result.conc_fit_data.push_back(stand_concs_map.at(quant_method.getComponentName()).first);
+                result.feature_fit_data.push_back(y_fit_data);
               }
               else 
               {
@@ -2092,14 +2092,14 @@ namespace SmartPeak
                 x_raw_data.push_back(float(point.actual_concentration / point.IS_actual_concentration / point.dilution_factor));
                 float y_datum = absQuant.calculateRatio(point.feature, point.IS_feature, quant_method.getFeatureName());
                 y_raw_data.push_back(y_datum);
-                result.calibrators_feature_min = std::min(y_datum, result.calibrators_feature_min);
-                result.calibrators_feature_max = std::max(y_datum, result.calibrators_feature_max);
+                result.feature_min = std::min(y_datum, result.feature_min);
+                result.feature_max = std::max(y_datum, result.feature_max);
               }
               n_points += x_raw_data.size();
               if (n_points < max_nb_points) {
-                result.calibrators_conc_raw_data.push_back(x_raw_data);
-                result.calibrators_feature_raw_data.push_back(y_raw_data);
-                result.calibrators_series_names.push_back(quant_method.getComponentName());
+                result.conc_raw_data.push_back(x_raw_data);
+                result.feature_raw_data.push_back(y_raw_data);
+                result.series_names.push_back(quant_method.getComponentName());
               }
               else 
               {
@@ -2110,10 +2110,10 @@ namespace SmartPeak
           }
         }
         // Sort data
-        for (int j = 0; j < result.calibrators_conc_fit_data.size(); ++j)
+        for (int j = 0; j < result.conc_fit_data.size(); ++j)
         {
-          auto& fit_data_x = result.calibrators_conc_fit_data[j];
-          auto& fit_data_y = result.calibrators_feature_fit_data[j];
+          auto& fit_data_x = result.conc_fit_data[j];
+          auto& fit_data_y = result.feature_fit_data[j];
           std::vector<std::pair<float,float>> sorting_vector;
           for (int i = 0; i < fit_data_x.size(); ++i)
           {

--- a/src/tests/class_tests/smartpeak/source/SequenceSegmentHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceSegmentHandler_test.cpp
@@ -422,7 +422,7 @@ TEST(SequenceSegmentHandler, set_get_ComponentsToConcentrations)
   EXPECT_EQ(m3.at(foo)[0].IS_actual_concentration, ac2);
 }
 
-TEST(SequenceSegmentHandler, set_get_OuterComponentsToConcentrations)
+TEST(SequenceSegmentHandler, set_get_OutlierComponentsToConcentrations)
 {
   SequenceSegmentHandler ssh;
   OpenMS::AbsoluteQuantitationStandards::featureConcentration fc;
@@ -437,18 +437,18 @@ TEST(SequenceSegmentHandler, set_get_OuterComponentsToConcentrations)
   ssh.setOuterComponentsToConcentrations(m1);
 
   const map<string, vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
-    m2 = ssh.getOuterComponentsToConcentrations();
+    m2 = ssh.getOutlierComponentsToConcentrations();
   EXPECT_EQ(m2.size(), 1);
   EXPECT_EQ(m2.count(foo), 1);
   EXPECT_EQ(m2.at(foo)[0].actual_concentration, ac1);
 
   const double ac2{ 7.3 };
   fc1[0].IS_actual_concentration = ac2;
-  ssh.getOuterComponentsToConcentrations().erase(foo);
-  ssh.getOuterComponentsToConcentrations().insert({ foo, fc1 });
+  ssh.getOutlierComponentsToConcentrations().erase(foo);
+  ssh.getOutlierComponentsToConcentrations().insert({ foo, fc1 });
 
   map<string, vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
-    m3 = ssh.getOuterComponentsToConcentrations();
+    m3 = ssh.getOutlierComponentsToConcentrations();
   EXPECT_EQ(m3.size(), 1);
   EXPECT_EQ(m3.count(foo), 1);
   EXPECT_EQ(m3.at(foo)[0].actual_concentration, ac1);
@@ -487,14 +487,14 @@ TEST(SequenceSegmentHandler, clear)
   map<string, vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> m1;
   m1.insert({"foo", fc1});
   ssh.setComponentsToConcentrations(m1);
-  ssh.setOuterComponentsToConcentrations(m1);
+  ssh.setOutlierComponentsToConcentrations(m1);
 
   EXPECT_FALSE(ssh.getSequenceSegmentName().empty());
   EXPECT_FALSE(ssh.getSampleIndices().empty());
   EXPECT_FALSE(ssh.getStandardsConcentrations().empty());
   EXPECT_FALSE(ssh.getQuantitationMethods().empty());
   EXPECT_FALSE(ssh.getComponentsToConcentrations().empty());
-  EXPECT_FALSE(ssh.getOuterComponentsToConcentrations().empty());
+  EXPECT_FALSE(ssh.getOutlierComponentsToConcentrations().empty());
   EXPECT_FALSE(ssh.getFeatureFilter().component_qcs.empty());
   EXPECT_FALSE(ssh.getFeatureQC().component_qcs.empty());
   EXPECT_FALSE(ssh.getFeatureRSDFilter().component_qcs.empty());
@@ -511,7 +511,7 @@ TEST(SequenceSegmentHandler, clear)
   EXPECT_TRUE(ssh.getStandardsConcentrations().empty());
   EXPECT_TRUE(ssh.getQuantitationMethods().empty());
   EXPECT_TRUE(ssh.getComponentsToConcentrations().empty());
-  EXPECT_TRUE(ssh.getOuterComponentsToConcentrations().empty());
+  EXPECT_TRUE(ssh.getOutlierComponentsToConcentrations().empty());
   EXPECT_TRUE(ssh.getFeatureFilter().component_qcs.empty());
   EXPECT_TRUE(ssh.getFeatureQC().component_qcs.empty());
   EXPECT_TRUE(ssh.getFeatureRSDFilter().component_qcs.empty());

--- a/src/tests/class_tests/smartpeak/source/SequenceSegmentHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceSegmentHandler_test.cpp
@@ -422,6 +422,39 @@ TEST(SequenceSegmentHandler, set_get_ComponentsToConcentrations)
   EXPECT_EQ(m3.at(foo)[0].IS_actual_concentration, ac2);
 }
 
+TEST(SequenceSegmentHandler, set_get_OuterComponentsToConcentrations)
+{
+  SequenceSegmentHandler ssh;
+  OpenMS::AbsoluteQuantitationStandards::featureConcentration fc;
+  const string foo{ "foo" };
+  const double ac1{ 4.5 };
+  fc.actual_concentration = ac1;
+  vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration> fc1;
+  fc1.push_back(fc);
+  map<string, vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> m1;
+  m1.insert({ foo, fc1 });
+
+  ssh.setOuterComponentsToConcentrations(m1);
+
+  const map<string, vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
+    m2 = ssh.getOuterComponentsToConcentrations();
+  EXPECT_EQ(m2.size(), 1);
+  EXPECT_EQ(m2.count(foo), 1);
+  EXPECT_EQ(m2.at(foo)[0].actual_concentration, ac1);
+
+  const double ac2{ 7.3 };
+  fc1[0].IS_actual_concentration = ac2;
+  ssh.getOuterComponentsToConcentrations().erase(foo);
+  ssh.getOuterComponentsToConcentrations().insert({ foo, fc1 });
+
+  map<string, vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
+    m3 = ssh.getOuterComponentsToConcentrations();
+  EXPECT_EQ(m3.size(), 1);
+  EXPECT_EQ(m3.count(foo), 1);
+  EXPECT_EQ(m3.at(foo)[0].actual_concentration, ac1);
+  EXPECT_EQ(m3.at(foo)[0].IS_actual_concentration, ac2);
+}
+
 TEST(SequenceSegmentHandler, clear)
 {
   SequenceSegmentHandler ssh;
@@ -454,12 +487,14 @@ TEST(SequenceSegmentHandler, clear)
   map<string, vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> m1;
   m1.insert({"foo", fc1});
   ssh.setComponentsToConcentrations(m1);
+  ssh.setOuterComponentsToConcentrations(m1);
 
   EXPECT_FALSE(ssh.getSequenceSegmentName().empty());
   EXPECT_FALSE(ssh.getSampleIndices().empty());
   EXPECT_FALSE(ssh.getStandardsConcentrations().empty());
   EXPECT_FALSE(ssh.getQuantitationMethods().empty());
   EXPECT_FALSE(ssh.getComponentsToConcentrations().empty());
+  EXPECT_FALSE(ssh.getOuterComponentsToConcentrations().empty());
   EXPECT_FALSE(ssh.getFeatureFilter().component_qcs.empty());
   EXPECT_FALSE(ssh.getFeatureQC().component_qcs.empty());
   EXPECT_FALSE(ssh.getFeatureRSDFilter().component_qcs.empty());
@@ -476,6 +511,7 @@ TEST(SequenceSegmentHandler, clear)
   EXPECT_TRUE(ssh.getStandardsConcentrations().empty());
   EXPECT_TRUE(ssh.getQuantitationMethods().empty());
   EXPECT_TRUE(ssh.getComponentsToConcentrations().empty());
+  EXPECT_TRUE(ssh.getOuterComponentsToConcentrations().empty());
   EXPECT_TRUE(ssh.getFeatureFilter().component_qcs.empty());
   EXPECT_TRUE(ssh.getFeatureQC().component_qcs.empty());
   EXPECT_TRUE(ssh.getFeatureRSDFilter().component_qcs.empty());

--- a/src/tests/class_tests/smartpeak/source/SequenceSegmentHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceSegmentHandler_test.cpp
@@ -434,7 +434,7 @@ TEST(SequenceSegmentHandler, set_get_OutlierComponentsToConcentrations)
   map<string, vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>> m1;
   m1.insert({ foo, fc1 });
 
-  ssh.setOuterComponentsToConcentrations(m1);
+  ssh.setOutlierComponentsToConcentrations(m1);
 
   const map<string, vector<OpenMS::AbsoluteQuantitationStandards::featureConcentration>>&
     m2 = ssh.getOutlierComponentsToConcentrations();

--- a/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
@@ -723,6 +723,26 @@ TEST(SequenceSegmentProcessor, processCalculateCalibration)
   EXPECT_NEAR(static_cast<double>(AQMs_rdh[2].getCorrelationCoefficient()), 0.9993200722867581, 1e-6);
   EXPECT_NEAR(static_cast<double>(AQMs_rdh[2].getLLOQ()), 0.04, 1e-6);
   EXPECT_NEAR(static_cast<double>(AQMs_rdh[2].getULOQ()), 200.0, 1e-6);
+
+  const auto& component_to_concentrations = sequenceSegmentHandler.getComponentsToConcentrations();
+  EXPECT_EQ(component_to_concentrations.size(), 3);
+  ASSERT_EQ(component_to_concentrations.count("ser-L.ser-L_1.Light"), 1);
+  const auto& component_to_concentration = component_to_concentrations.at("ser-L.ser-L_1.Light");
+  ASSERT_EQ(component_to_concentration.size(), 11);
+  EXPECT_FLOAT_EQ(component_to_concentration[0].actual_concentration, 0.039999999);
+  EXPECT_EQ(component_to_concentration[0].concentration_units, std::string("uM"));
+  EXPECT_FLOAT_EQ(component_to_concentration[0].dilution_factor, 1);
+  EXPECT_FLOAT_EQ(component_to_concentration[0].IS_actual_concentration, 1);
+
+  const auto& outer_component_to_concentrations = sequenceSegmentHandler.getOuterComponentsToConcentrations();
+  ASSERT_EQ(outer_component_to_concentrations.size(), 3);
+  ASSERT_EQ(outer_component_to_concentrations.count("ser-L.ser-L_1.Light"), 1);
+  const auto& outer_component_to_concentration = outer_component_to_concentrations.at("ser-L.ser-L_1.Light");
+  ASSERT_EQ(outer_component_to_concentration.size(), 3);
+  EXPECT_FLOAT_EQ(outer_component_to_concentration[0].actual_concentration, 0.0099999998);
+  EXPECT_EQ(outer_component_to_concentration[0].concentration_units, std::string("uM"));
+  EXPECT_FLOAT_EQ(outer_component_to_concentration[0].dilution_factor, 1);
+  EXPECT_FLOAT_EQ(outer_component_to_concentration[0].IS_actual_concentration, 1);
 }
 
 /**

--- a/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
@@ -734,15 +734,15 @@ TEST(SequenceSegmentProcessor, processCalculateCalibration)
   EXPECT_FLOAT_EQ(component_to_concentration[0].dilution_factor, 1);
   EXPECT_FLOAT_EQ(component_to_concentration[0].IS_actual_concentration, 1);
 
-  const auto& outer_component_to_concentrations = sequenceSegmentHandler.getOuterComponentsToConcentrations();
-  ASSERT_EQ(outer_component_to_concentrations.size(), 3);
-  ASSERT_EQ(outer_component_to_concentrations.count("ser-L.ser-L_1.Light"), 1);
-  const auto& outer_component_to_concentration = outer_component_to_concentrations.at("ser-L.ser-L_1.Light");
-  ASSERT_EQ(outer_component_to_concentration.size(), 3);
-  EXPECT_FLOAT_EQ(outer_component_to_concentration[0].actual_concentration, 0.0099999998);
-  EXPECT_EQ(outer_component_to_concentration[0].concentration_units, std::string("uM"));
-  EXPECT_FLOAT_EQ(outer_component_to_concentration[0].dilution_factor, 1);
-  EXPECT_FLOAT_EQ(outer_component_to_concentration[0].IS_actual_concentration, 1);
+  const auto& outlier_component_to_concentrations = sequenceSegmentHandler.getOuterComponentsToConcentrations();
+  ASSERT_EQ(outlier_component_to_concentrations.size(), 3);
+  ASSERT_EQ(outlier_component_to_concentrations.count("ser-L.ser-L_1.Light"), 1);
+  const auto& outlier_component_to_concentration = outlier_component_to_concentrations.at("ser-L.ser-L_1.Light");
+  ASSERT_EQ(outlier_component_to_concentration.size(), 3);
+  EXPECT_FLOAT_EQ(outlier_component_to_concentration[0].actual_concentration, 0.0099999998);
+  EXPECT_EQ(outlier_component_to_concentration[0].concentration_units, std::string("uM"));
+  EXPECT_FLOAT_EQ(outlier_component_to_concentration[0].dilution_factor, 1);
+  EXPECT_FLOAT_EQ(outlier_component_to_concentration[0].IS_actual_concentration, 1);
 }
 
 /**

--- a/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SequenceSegmentProcessor_test.cpp
@@ -734,7 +734,7 @@ TEST(SequenceSegmentProcessor, processCalculateCalibration)
   EXPECT_FLOAT_EQ(component_to_concentration[0].dilution_factor, 1);
   EXPECT_FLOAT_EQ(component_to_concentration[0].IS_actual_concentration, 1);
 
-  const auto& outlier_component_to_concentrations = sequenceSegmentHandler.getOuterComponentsToConcentrations();
+  const auto& outlier_component_to_concentrations = sequenceSegmentHandler.getOutlierComponentsToConcentrations();
   ASSERT_EQ(outlier_component_to_concentrations.size(), 3);
   ASSERT_EQ(outlier_component_to_concentrations.count("ser-L.ser-L_1.Light"), 1);
   const auto& outlier_component_to_concentration = outlier_component_to_concentrations.at("ser-L.ser-L_1.Light");

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -722,8 +722,8 @@ TEST(SessionHandler, setCalibratorsScatterLinePlot1)
   EXPECT_EQ(calibrator_data.conc_fit_data.size(), 0);
   EXPECT_EQ(calibrator_data.conc_raw_data.size(), 0);
   EXPECT_EQ(calibrator_data.feature_raw_data.size(), 0);
-  EXPECT_EQ(calibrator_data.outer_conc_raw_data.size(), 0);
-  EXPECT_EQ(calibrator_data.outer_feature_raw_data.size(), 0);
+  EXPECT_EQ(calibrator_data.outlier_conc_raw_data.size(), 0);
+  EXPECT_EQ(calibrator_data.outlier_feature_raw_data.size(), 0);
   EXPECT_EQ(calibrator_data.quant_methods.size(), 0);
   EXPECT_EQ(calibrator_data.series_names.size(), 0);
   EXPECT_EQ(calibrator_data.x_axis_title, std::string(""));

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -719,6 +719,15 @@ TEST(SessionHandler, setCalibratorsScatterLinePlot1)
   SessionHandler session_handler;
   SessionHandler::CalibrationData calibrator_data;
   session_handler.setCalibratorsScatterLinePlot(testData.application_handler.sequenceHandler_, calibrator_data);
+  EXPECT_EQ(calibrator_data.conc_fit_data.size(), 0);
+  EXPECT_EQ(calibrator_data.conc_raw_data.size(), 0);
+  EXPECT_EQ(calibrator_data.feature_raw_data.size(), 0);
+  EXPECT_EQ(calibrator_data.outer_conc_raw_data.size(), 0);
+  EXPECT_EQ(calibrator_data.outer_feature_raw_data.size(), 0);
+  EXPECT_EQ(calibrator_data.quant_methods.size(), 0);
+  EXPECT_EQ(calibrator_data.series_names.size(), 0);
+  EXPECT_EQ(calibrator_data.x_axis_title, std::string(""));
+  EXPECT_EQ(calibrator_data.y_axis_title, std::string(""));
 }
 TEST(SessionHandler, getHeatMap)
 {

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -717,7 +717,8 @@ TEST(SessionHandler, setCalibratorsScatterLinePlot1)
 {
   TestData testData;
   SessionHandler session_handler;
-  session_handler.setCalibratorsScatterLinePlot(testData.application_handler.sequenceHandler_);
+  SessionHandler::CalibrationData calibrator_data;
+  session_handler.setCalibratorsScatterLinePlot(testData.application_handler.sequenceHandler_, calibrator_data);
 }
 TEST(SessionHandler, getHeatMap)
 {

--- a/src/tests/class_tests/smartpeak/source/Widget_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Widget_test.cpp
@@ -34,6 +34,7 @@
 #include <SmartPeak/ui/SessionFilesWidget.h>
 #include <SmartPeak/ui/LoadSessionWizard.h>
 #include <SmartPeak/ui/SetInputOutputWidget.h>
+#include <SmartPeak/ui/CalibratorsPlotWidget.h>
 #include <SmartPeak/core/RawDataProcessors/LoadFeatures.h>
 #include <SmartPeak/core/ApplicationProcessors/SaveSession.h>
 
@@ -878,3 +879,52 @@ TEST(SetInputOutputWidget, cancel)
   EXPECT_EQ(set_input_output_widget_test.on_input_output_cancel_counter, 1);
 }
 
+class CalibratorsPlotWidget_Test :
+  public CalibratorsPlotWidget
+{
+public:
+  CalibratorsPlotWidget_Test() :
+    CalibratorsPlotWidget()
+  {};
+
+public:
+
+  bool& get_reset_zoom_()
+  {
+    return reset_zoom_;
+  }
+
+  const std::vector<std::string>& get_components_()
+  {
+    return components_;
+  }
+
+};
+
+TEST(CalibratorsPlotWidget, setValue)
+{
+  CalibratorsPlotWidget_Test calibrator_widget;
+  EXPECT_EQ(calibrator_widget.get_reset_zoom_(), true);
+
+  SessionHandler::CalibrationData calibrator_data;
+  calibrator_data.series_names = { "on", "two", "three" };
+  calibrator_data.x_axis_title = "x_axis_title";
+  calibrator_data.y_axis_title = "y_axis_title";
+  calibrator_data.conc_min = 1.0f;
+  calibrator_data.conc_max = 100.0f;
+  calibrator_data.feature_min = 10.0f;
+  calibrator_data.feature_max = 1000.0f;
+
+  calibrator_widget.setValues(calibrator_data, "test");
+  EXPECT_EQ(calibrator_widget.get_reset_zoom_(), true);
+
+  // a draw operation would unflag the reset_zoom
+  calibrator_widget.get_reset_zoom_() = false;
+
+  // same data should not involve a zoom reset
+  calibrator_widget.setValues(calibrator_data, "test");
+  EXPECT_EQ(calibrator_widget.get_reset_zoom_(), false);
+
+  auto components = calibrator_widget.get_components_();
+  EXPECT_EQ(components, calibrator_data.series_names);
+};

--- a/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
+++ b/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
@@ -40,13 +40,7 @@ namespace SmartPeak
   {
   public:
     CalibratorsPlotWidget(const std::string title = ""): GenericGraphicWidget(title) {};
-    void setValues(
-      const SessionHandler::CalibrationData& calibration_data,
-      const std::string& plot_title)
-    {
-      calibration_data_ = calibration_data;
-      plot_title_ = plot_title;
-    }
+    void setValues(const SessionHandler::CalibrationData& calibration_data, const std::string& plot_title);
     void draw() override;
 
     bool reset_layout_ = true;
@@ -64,6 +58,7 @@ namespace SmartPeak
     std::vector<std::string> components_;
     std::vector<const char*> component_cstr_;
     int selected_component_ = 0;
+    bool reset_zoom_ = true;
   };
 
 }

--- a/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
+++ b/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
@@ -54,6 +54,7 @@ namespace SmartPeak
     SessionHandler::CalibrationData calibration_data_;
     std::string plot_title_; // used as the ID of the plot as well so this should be unique across the different Widgets
     bool reset_layout_ = true;
+    bool show_legend_ = true;
   };
 
 }

--- a/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
+++ b/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
@@ -53,7 +53,7 @@ namespace SmartPeak
     bool show_legend_ = true;
     bool show_fit_line_ = true;
     bool show_points_ = true;
-    bool show_outer_points_ = true;
+    bool show_outlier_points_ = true;
     std::string current_component_;
     std::vector<std::string> components_;
     std::vector<const char*> component_cstr_;

--- a/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
+++ b/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
@@ -57,6 +57,13 @@ namespace SmartPeak
     SessionHandler::CalibrationData calibration_data_;
     std::string plot_title_; // used as the ID of the plot as well so this should be unique across the different Widgets
     bool show_legend_ = true;
+    bool show_fit_line_ = true;
+    bool show_points_ = true;
+    bool show_outer_points_ = true;
+    std::string current_component_;
+    std::vector<std::string> components_;
+    std::vector<const char*> component_cstr_;
+    int selected_component_ = 0;
   };
 
 }

--- a/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
+++ b/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
@@ -49,8 +49,11 @@ namespace SmartPeak
     }
     void draw() override;
   protected:
+    void displayParameters();
+    void displayPlot();
     SessionHandler::CalibrationData calibration_data_;
     std::string plot_title_; // used as the ID of the plot as well so this should be unique across the different Widgets
+    bool reset_layout_ = true;
   };
 
 }

--- a/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
+++ b/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <SmartPeak/core/SessionHandler.h>
 #include <SmartPeak/ui/Widget.h>
 #include <string>
 #include <utility>
@@ -40,37 +41,15 @@ namespace SmartPeak
   public:
     CalibratorsPlotWidget(const std::string title = ""): GenericGraphicWidget(title) {};
     void setValues(
-      const std::vector<std::vector<float>>* x_fit_data, const std::vector<std::vector<float>>* y_fit_data,
-      const std::vector<std::vector<float>>* x_raw_data, const std::vector<std::vector<float>>* y_raw_data, const std::vector<std::string>* series_names,
-      const std::string& x_axis_title, const std::string& y_axis_title, const float& x_min, const float& x_max, const float& y_min, const float& y_max,
+      const SessionHandler::CalibrationData& calibration_data,
       const std::string& plot_title)
     {
-      x_fit_data_ = x_fit_data;
-      y_fit_data_ = y_fit_data;
-      x_raw_data_ = x_raw_data;
-      y_raw_data_ = y_raw_data;
-      series_names_ = series_names;
-      x_axis_title_ = x_axis_title;
-      y_axis_title_ = y_axis_title;
-      x_min_ = x_min;
-      x_max_ = x_max;
-      y_min_ = y_min;
-      y_max_ = y_max;
+      calibration_data_ = calibration_data;
       plot_title_ = plot_title;
     }
     void draw() override;
   protected:
-    const std::vector<std::vector<float>>* x_fit_data_ = nullptr;
-    const std::vector<std::vector<float>>* y_fit_data_ = nullptr;
-    const std::vector<std::vector<float>>* x_raw_data_ = nullptr;
-    const std::vector<std::vector<float>>* y_raw_data_ = nullptr;
-    const std::vector<std::string>* series_names_ = nullptr;
-    std::string x_axis_title_;
-    std::string y_axis_title_;
-    float x_min_;
-    float x_max_;
-    float y_min_;
-    float y_max_;
+    SessionHandler::CalibrationData calibration_data_;
     std::string plot_title_; // used as the ID of the plot as well so this should be unique across the different Widgets
   };
 

--- a/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
+++ b/src/widgets/include/SmartPeak/ui/CalibratorsPlotWidget.h
@@ -48,12 +48,14 @@ namespace SmartPeak
       plot_title_ = plot_title;
     }
     void draw() override;
+
+    bool reset_layout_ = true;
+
   protected:
     void displayParameters();
     void displayPlot();
     SessionHandler::CalibrationData calibration_data_;
     std::string plot_title_; // used as the ID of the plot as well so this should be unique across the different Widgets
-    bool reset_layout_ = true;
     bool show_legend_ = true;
   };
 

--- a/src/widgets/source/ui/CalibratorsPlotWidget.cpp
+++ b/src/widgets/source/ui/CalibratorsPlotWidget.cpp
@@ -57,10 +57,16 @@ namespace SmartPeak
   void CalibratorsPlotWidget::displayPlot()
   {
     ImGui::Begin("Calibrator Plot");
+    ImGui::Checkbox("Legend", &show_legend_);
     // Main graphic
-    ImPlot::SetNextPlotLimits(calibration_data_.calibrators_conc_min, calibration_data_.calibrators_conc_max, calibration_data_.calibrators_feature_min, calibration_data_.calibrators_feature_max, ImGuiCond_Always);
+    ImPlot::SetNextPlotLimits(calibration_data_.calibrators_conc_min, calibration_data_.calibrators_conc_max, calibration_data_.calibrators_feature_min, calibration_data_.calibrators_feature_max);
     auto window_size = ImGui::GetWindowSize();
-    if (ImPlot::BeginPlot(plot_title_.c_str(), calibration_data_.calibrators_x_axis_title.c_str(), calibration_data_.calibrators_y_axis_title.c_str(), ImVec2(window_size.x - 25, window_size.y - 40))) {
+    ImPlotFlags plotFlags = show_legend_ ? ImPlotFlags_Default | ImPlotFlags_Legend : ImPlotFlags_Default & ~ImPlotFlags_Legend;
+    if (ImPlot::BeginPlot(plot_title_.c_str(), 
+                          calibration_data_.calibrators_x_axis_title.c_str(), 
+                          calibration_data_.calibrators_y_axis_title.c_str(), 
+                          ImVec2(window_size.x - 25, window_size.y - 58),
+                          plotFlags)) {
       for (int i = 0; i < calibration_data_.calibrators_conc_fit_data.size(); ++i) {
         assert(calibration_data_.calibrators_conc_fit_data.at(i).size() == calibration_data_.calibrators_feature_fit_data.at(i).size());
         ImPlot::PushStyleVar(ImPlotStyleVar_LineWeight, ImPlot::GetStyle().LineWeight);

--- a/src/widgets/source/ui/CalibratorsPlotWidget.cpp
+++ b/src/widgets/source/ui/CalibratorsPlotWidget.cpp
@@ -109,7 +109,7 @@ namespace SmartPeak
     ImGui::SameLine();
     ImGui::Checkbox("Points", &show_points_);
     ImGui::SameLine();
-    ImGui::Checkbox("Outer points", &show_outer_points_);
+    ImGui::Checkbox("Outlier points", &show_outlier_points_);
     ImGui::SameLine();
     if (ImGui::Button("Fit Zoom"))
     {
@@ -165,15 +165,15 @@ namespace SmartPeak
                                calibration_data_.conc_raw_data.at(i).size());
         }
       }
-      if (show_outer_points_)
+      if (show_outlier_points_)
       {
         for (int i = 0; i < calibration_data_.conc_raw_data.size(); ++i) {
-          assert(calibration_data_.outer_conc_raw_data.at(i).size() == calibration_data_.outer_feature_raw_data.at(i).size());
+          assert(calibration_data_.outlier_conc_raw_data.at(i).size() == calibration_data_.outlier_feature_raw_data.at(i).size());
           ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Cross);
           ImPlot::PlotScatter((calibration_data_.series_names.at(i)).c_str(),
-                               calibration_data_.outer_conc_raw_data.at(i).data(),
-                               calibration_data_.outer_feature_raw_data.at(i).data(),
-                               calibration_data_.outer_conc_raw_data.at(i).size());
+                               calibration_data_.outlier_conc_raw_data.at(i).data(),
+                               calibration_data_.outlier_feature_raw_data.at(i).data(),
+                               calibration_data_.outlier_conc_raw_data.at(i).size());
         }
       }
       // legend hover management

--- a/src/widgets/source/ui/CalibratorsPlotWidget.cpp
+++ b/src/widgets/source/ui/CalibratorsPlotWidget.cpp
@@ -33,6 +33,31 @@ namespace SmartPeak
       return;
     }
     showQuickHelpToolTip("CalibratorsPlotWidget");
+
+    // Parameters
+    const auto& quantitation_methods = calibration_data_.quant_method;
+    
+    ImGui::LabelText("name", quantitation_methods.getISName().c_str());
+    ImGui::LabelText("component name", quantitation_methods.getComponentName().c_str());
+    
+    ImGui::LabelText("llod", "%f", quantitation_methods.getLLOD());
+    ImGui::LabelText("ulod", "%f", quantitation_methods.getULOD());
+    
+    ImGui::LabelText("lloq", "%f", quantitation_methods.getLLOQ());
+    ImGui::LabelText("uloq", "%f", quantitation_methods.getULOQ());
+    
+    ImGui::LabelText("correlation coefficient", "%f", quantitation_methods.getCorrelationCoefficient());
+    ImGui::LabelText("nb points", "%d", quantitation_methods.getNPoints());
+
+    ImGui::LabelText("transformation model", quantitation_methods.getTransformationModel().c_str());
+
+    const auto& params = quantitation_methods.getTransformationModelParams();
+    for (const auto& param : params)
+    {
+      const auto& value = param.value;
+      ImGui::LabelText(param.name.c_str(), "%s", value.toString().c_str());
+    }
+    
     // Main graphic
     ImPlot::SetNextPlotLimits(calibration_data_.calibrators_conc_min, calibration_data_.calibrators_conc_max, calibration_data_.calibrators_feature_min, calibration_data_.calibrators_feature_max, ImGuiCond_Always);
     auto window_size = ImGui::GetWindowSize();

--- a/src/widgets/source/ui/CalibratorsPlotWidget.cpp
+++ b/src/widgets/source/ui/CalibratorsPlotWidget.cpp
@@ -28,25 +28,25 @@ namespace SmartPeak
 {
   void CalibratorsPlotWidget::draw()
   {
-    if (!x_raw_data_)
+    if (!calibration_data_.calibrators_conc_raw_data.size())
     {
       return;
     }
     showQuickHelpToolTip("CalibratorsPlotWidget");
     // Main graphic
-    ImPlot::SetNextPlotLimits(x_min_, x_max_, y_min_, y_max_, ImGuiCond_Always);
+    ImPlot::SetNextPlotLimits(calibration_data_.calibrators_conc_min, calibration_data_.calibrators_conc_max, calibration_data_.calibrators_feature_min, calibration_data_.calibrators_feature_max, ImGuiCond_Always);
     auto window_size = ImGui::GetWindowSize();
-    if (ImPlot::BeginPlot(plot_title_.c_str(), x_axis_title_.c_str(), y_axis_title_.c_str(), ImVec2(window_size.x - 25, window_size.y - 40))) {
-      for (int i = 0; i < x_fit_data_->size(); ++i) {
-        assert(x_fit_data_->at(i).size() == y_fit_data_->at(i).size());
+    if (ImPlot::BeginPlot(plot_title_.c_str(), calibration_data_.calibrators_x_axis_title.c_str(), calibration_data_.calibrators_y_axis_title.c_str(), ImVec2(window_size.x - 25, window_size.y - 40))) {
+      for (int i = 0; i < calibration_data_.calibrators_conc_fit_data.size(); ++i) {
+        assert(calibration_data_.calibrators_conc_fit_data.at(i).size() == calibration_data_.calibrators_feature_fit_data.at(i).size());
         ImPlot::PushStyleVar(ImPlotStyleVar_LineWeight, ImPlot::GetStyle().LineWeight);
         ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
-        ImPlot::PlotLine((series_names_->at(i) + "-fit").c_str(), x_fit_data_->at(i).data(), y_fit_data_->at(i).data(), x_fit_data_->at(i).size());
+        ImPlot::PlotLine((calibration_data_.calibrators_series_names.at(i) + "-fit").c_str(), calibration_data_.calibrators_conc_fit_data.at(i).data(), calibration_data_.calibrators_feature_fit_data.at(i).data(), calibration_data_.calibrators_conc_fit_data.at(i).size());
       }
-      for (int i = 0; i < x_raw_data_->size(); ++i) {
-        assert(x_raw_data_->at(i).size() == y_raw_data_->at(i).size());
+      for (int i = 0; i < calibration_data_.calibrators_conc_raw_data.size(); ++i) {
+        assert(calibration_data_.calibrators_conc_raw_data.at(i).size() == calibration_data_.calibrators_feature_raw_data.at(i).size());
         ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
-        ImPlot::PlotScatter((series_names_->at(i) + "-pts").c_str(), x_raw_data_->at(i).data(), y_raw_data_->at(i).data(), x_raw_data_->at(i).size());
+        ImPlot::PlotScatter((calibration_data_.calibrators_series_names.at(i) + "-pts").c_str(), calibration_data_.calibrators_conc_raw_data.at(i).data(), calibration_data_.calibrators_feature_raw_data.at(i).data(), calibration_data_.calibrators_conc_raw_data.at(i).size());
       }
       ImPlot::EndPlot();
     }

--- a/src/widgets/source/ui/CalibratorsPlotWidget.cpp
+++ b/src/widgets/source/ui/CalibratorsPlotWidget.cpp
@@ -127,10 +127,13 @@ namespace SmartPeak
     {
       cond = ImGuiCond_Once;
     }
-    ImPlot::SetNextPlotLimits(calibration_data_.conc_min,
-                              calibration_data_.conc_max,
-                              calibration_data_.feature_min,
-                              calibration_data_.feature_max,
+    // add margin around the plot
+    float x_margin = (calibration_data_.conc_max - calibration_data_.conc_min) * 0.05;
+    float y_margin = (calibration_data_.feature_max - calibration_data_.feature_min) * 0.05;
+    ImPlot::SetNextPlotLimits(calibration_data_.conc_min - x_margin,
+                              calibration_data_.conc_max + x_margin,
+                              calibration_data_.feature_min - y_margin,
+                              calibration_data_.feature_max + y_margin,
                               cond);
     auto window_size = ImGui::GetWindowSize();
     ImPlotFlags plotFlags = show_legend_ ? ImPlotFlags_Default | ImPlotFlags_Legend : ImPlotFlags_Default & ~ImPlotFlags_Legend;

--- a/src/widgets/source/ui/CalibratorsPlotWidget.cpp
+++ b/src/widgets/source/ui/CalibratorsPlotWidget.cpp
@@ -26,26 +26,20 @@
 
 namespace SmartPeak
 {
-  void CalibratorsPlotWidget::draw()
+  void CalibratorsPlotWidget::displayParameters()
   {
-    if (!calibration_data_.calibrators_conc_raw_data.size())
-    {
-      return;
-    }
-    showQuickHelpToolTip("CalibratorsPlotWidget");
-
-    // Parameters
+    ImGui::Begin("Calibrator Parameters");
     const auto& quantitation_methods = calibration_data_.quant_method;
-    
+
     ImGui::LabelText("name", quantitation_methods.getISName().c_str());
     ImGui::LabelText("component name", quantitation_methods.getComponentName().c_str());
-    
+
     ImGui::LabelText("llod", "%f", quantitation_methods.getLLOD());
     ImGui::LabelText("ulod", "%f", quantitation_methods.getULOD());
-    
+
     ImGui::LabelText("lloq", "%f", quantitation_methods.getLLOQ());
     ImGui::LabelText("uloq", "%f", quantitation_methods.getULOQ());
-    
+
     ImGui::LabelText("correlation coefficient", "%f", quantitation_methods.getCorrelationCoefficient());
     ImGui::LabelText("nb points", "%d", quantitation_methods.getNPoints());
 
@@ -57,7 +51,12 @@ namespace SmartPeak
       const auto& value = param.value;
       ImGui::LabelText(param.name.c_str(), "%s", value.toString().c_str());
     }
-    
+    ImGui::End();
+  }
+
+  void CalibratorsPlotWidget::displayPlot()
+  {
+    ImGui::Begin("Calibrator Plot");
     // Main graphic
     ImPlot::SetNextPlotLimits(calibration_data_.calibrators_conc_min, calibration_data_.calibrators_conc_max, calibration_data_.calibrators_feature_min, calibration_data_.calibrators_feature_max, ImGuiCond_Always);
     auto window_size = ImGui::GetWindowSize();
@@ -75,5 +74,35 @@ namespace SmartPeak
       }
       ImPlot::EndPlot();
     }
+    ImGui::End();
+  }
+
+  void CalibratorsPlotWidget::draw()
+  {
+    if (!calibration_data_.calibrators_conc_raw_data.size())
+    {
+      return;
+    }
+    showQuickHelpToolTip("CalibratorsPlotWidget");
+
+    // Build default docking
+    ImGuiID dockspace_id = ImGui::GetID("CalibratorsPlotWidgetDockSpace");
+    if (reset_layout_)
+    {
+      ImGuiID left_node;
+      ImGuiID center_node;
+      ImGuiID bottom_node;
+      ImGui::DockBuilderAddNode(dockspace_id, ImGuiDockNodeFlags_DockSpace);
+      ImGui::DockBuilderSetNodeSize(dockspace_id, ImVec2(400,400));
+      ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Left, 0.3, &left_node, &center_node); // The second parameter defines the direction of the split
+      ImGui::DockBuilderDockWindow("Calibrator Parameters", left_node);
+      ImGui::DockBuilderDockWindow("Calibrator Plot", center_node);
+      ImGui::DockBuilderFinish(dockspace_id);
+      reset_layout_ = false;
+    }
+    ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_AutoHideTabBar);
+    
+    displayParameters();
+    displayPlot();
   }
 }

--- a/src/widgets/source/ui/CalibratorsPlotWidget.cpp
+++ b/src/widgets/source/ui/CalibratorsPlotWidget.cpp
@@ -113,24 +113,24 @@ namespace SmartPeak
     ImGui::Begin("Calibrator Plot");
     ImGui::Checkbox("Legend", &show_legend_);
     // Main graphic
-    ImPlot::SetNextPlotLimits(calibration_data_.calibrators_conc_min, calibration_data_.calibrators_conc_max, calibration_data_.calibrators_feature_min, calibration_data_.calibrators_feature_max);
+    ImPlot::SetNextPlotLimits(calibration_data_.conc_min, calibration_data_.conc_max, calibration_data_.feature_min, calibration_data_.feature_max);
     auto window_size = ImGui::GetWindowSize();
     ImPlotFlags plotFlags = show_legend_ ? ImPlotFlags_Default | ImPlotFlags_Legend : ImPlotFlags_Default & ~ImPlotFlags_Legend;
     if (ImPlot::BeginPlot(plot_title_.c_str(), 
-                          calibration_data_.calibrators_x_axis_title.c_str(), 
-                          calibration_data_.calibrators_y_axis_title.c_str(), 
+                          calibration_data_.x_axis_title.c_str(), 
+                          calibration_data_.y_axis_title.c_str(), 
                           ImVec2(window_size.x - 25, window_size.y - 58),
                           plotFlags)) {
-      for (int i = 0; i < calibration_data_.calibrators_conc_fit_data.size(); ++i) {
-        assert(calibration_data_.calibrators_conc_fit_data.at(i).size() == calibration_data_.calibrators_feature_fit_data.at(i).size());
+      for (int i = 0; i < calibration_data_.conc_fit_data.size(); ++i) {
+        assert(calibration_data_.conc_fit_data.at(i).size() == calibration_data_.feature_fit_data.at(i).size());
         ImPlot::PushStyleVar(ImPlotStyleVar_LineWeight, ImPlot::GetStyle().LineWeight);
         ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
-        ImPlot::PlotLine((calibration_data_.calibrators_series_names.at(i) + "-fit").c_str(), calibration_data_.calibrators_conc_fit_data.at(i).data(), calibration_data_.calibrators_feature_fit_data.at(i).data(), calibration_data_.calibrators_conc_fit_data.at(i).size());
+        ImPlot::PlotLine((calibration_data_.series_names.at(i) + "-fit").c_str(), calibration_data_.conc_fit_data.at(i).data(), calibration_data_.feature_fit_data.at(i).data(), calibration_data_.conc_fit_data.at(i).size());
       }
-      for (int i = 0; i < calibration_data_.calibrators_conc_raw_data.size(); ++i) {
-        assert(calibration_data_.calibrators_conc_raw_data.at(i).size() == calibration_data_.calibrators_feature_raw_data.at(i).size());
+      for (int i = 0; i < calibration_data_.conc_raw_data.size(); ++i) {
+        assert(calibration_data_.conc_raw_data.at(i).size() == calibration_data_.feature_raw_data.at(i).size());
         ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
-        ImPlot::PlotScatter((calibration_data_.calibrators_series_names.at(i) + "-pts").c_str(), calibration_data_.calibrators_conc_raw_data.at(i).data(), calibration_data_.calibrators_feature_raw_data.at(i).data(), calibration_data_.calibrators_conc_raw_data.at(i).size());
+        ImPlot::PlotScatter((calibration_data_.series_names.at(i) + "-pts").c_str(), calibration_data_.conc_raw_data.at(i).data(), calibration_data_.feature_raw_data.at(i).data(), calibration_data_.conc_raw_data.at(i).size());
       }
       ImPlot::EndPlot();
     }
@@ -139,7 +139,7 @@ namespace SmartPeak
 
   void CalibratorsPlotWidget::draw()
   {
-    if (!calibration_data_.calibrators_conc_raw_data.size())
+    if (!calibration_data_.conc_raw_data.size())
     {
       return;
     }

--- a/src/widgets/source/ui/CalibratorsPlotWidget.cpp
+++ b/src/widgets/source/ui/CalibratorsPlotWidget.cpp
@@ -37,16 +37,16 @@ namespace SmartPeak
     ImPlot::SetNextPlotLimits(x_min_, x_max_, y_min_, y_max_, ImGuiCond_Always);
     auto window_size = ImGui::GetWindowSize();
     if (ImPlot::BeginPlot(plot_title_.c_str(), x_axis_title_.c_str(), y_axis_title_.c_str(), ImVec2(window_size.x - 25, window_size.y - 40))) {
-      for (int i = 0; i < x_raw_data_->size(); ++i) {
-        assert(x_raw_data_->at(i).size() == y_raw_data_->at(i).size());
-        ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
-        ImPlot::PlotScatter((series_names_->at(i) + "-pts").c_str(), x_raw_data_->at(i).data(), y_raw_data_->at(i).data(), x_raw_data_->at(i).size());
-      }
       for (int i = 0; i < x_fit_data_->size(); ++i) {
         assert(x_fit_data_->at(i).size() == y_fit_data_->at(i).size());
         ImPlot::PushStyleVar(ImPlotStyleVar_LineWeight, ImPlot::GetStyle().LineWeight);
         ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
         ImPlot::PlotLine((series_names_->at(i) + "-fit").c_str(), x_fit_data_->at(i).data(), y_fit_data_->at(i).data(), x_fit_data_->at(i).size());
+      }
+      for (int i = 0; i < x_raw_data_->size(); ++i) {
+        assert(x_raw_data_->at(i).size() == y_raw_data_->at(i).size());
+        ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
+        ImPlot::PlotScatter((series_names_->at(i) + "-pts").c_str(), x_raw_data_->at(i).data(), y_raw_data_->at(i).data(), x_raw_data_->at(i).size());
       }
       ImPlot::EndPlot();
     }

--- a/src/widgets/source/ui/CalibratorsPlotWidget.cpp
+++ b/src/widgets/source/ui/CalibratorsPlotWidget.cpp
@@ -31,25 +31,79 @@ namespace SmartPeak
     ImGui::Begin("Calibrator Parameters");
     const auto& quantitation_methods = calibration_data_.quant_method;
 
-    ImGui::LabelText("name", quantitation_methods.getISName().c_str());
-    ImGui::LabelText("component name", quantitation_methods.getComponentName().c_str());
-
-    ImGui::LabelText("llod", "%f", quantitation_methods.getLLOD());
-    ImGui::LabelText("ulod", "%f", quantitation_methods.getULOD());
-
-    ImGui::LabelText("lloq", "%f", quantitation_methods.getLLOQ());
-    ImGui::LabelText("uloq", "%f", quantitation_methods.getULOQ());
-
-    ImGui::LabelText("correlation coefficient", "%f", quantitation_methods.getCorrelationCoefficient());
-    ImGui::LabelText("nb points", "%d", quantitation_methods.getNPoints());
-
-    ImGui::LabelText("transformation model", quantitation_methods.getTransformationModel().c_str());
-
-    const auto& params = quantitation_methods.getTransformationModelParams();
-    for (const auto& param : params)
+    ImGuiTableFlags table_flags = ImGuiTableFlags_None;
+    if (ImGui::BeginTable("Calibrator Parameters Table", 2, table_flags))
     {
-      const auto& value = param.value;
-      ImGui::LabelText(param.name.c_str(), "%s", value.toString().c_str());
+      /*
+      ImGui::TableSetupColumn("Parameter name");
+      ImGui::TableSetupColumn("Parameter value");
+      ImGui::TableHeadersRow();
+      */
+      ImGui::TableNextRow(); 
+      ImGui::TableSetColumnIndex(0);
+      ImGui::Text("name");
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text(quantitation_methods.getISName().c_str());
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::Text("component name");
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text(quantitation_methods.getComponentName().c_str());
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::Text("llod");
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text("%f", quantitation_methods.getLLOD());
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::Text("ulod");
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text("%f", quantitation_methods.getULOD());
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::Text("lloq");
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text("%f", quantitation_methods.getLLOQ());
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::Text("uloq");
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text("%f", quantitation_methods.getULOQ());
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::Text("correlation coefficient");
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text("%f", quantitation_methods.getCorrelationCoefficient());
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::Text("nb points");
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text("%d", quantitation_methods.getNPoints());
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::Text("transformation model");
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text(quantitation_methods.getTransformationModel().c_str());
+
+      const auto& params = quantitation_methods.getTransformationModelParams();
+      for (const auto& param : params)
+      {
+        const auto& value = param.value;
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::Text(param.name.c_str());
+        ImGui::TableSetColumnIndex(1);
+        ImGui::Text("%s", value.toString().c_str());
+      }
+      ImGui::EndTable();
     }
     ImGui::End();
   }
@@ -96,13 +150,12 @@ namespace SmartPeak
     if (reset_layout_)
     {
       ImGuiID left_node;
-      ImGuiID center_node;
-      ImGuiID bottom_node;
+      ImGuiID right_node;
       ImGui::DockBuilderAddNode(dockspace_id, ImGuiDockNodeFlags_DockSpace);
-      ImGui::DockBuilderSetNodeSize(dockspace_id, ImVec2(400,400));
-      ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Left, 0.3, &left_node, &center_node); // The second parameter defines the direction of the split
+      ImGui::DockBuilderSetNodeSize(dockspace_id, ImGui::GetCurrentWindow()->Size);
+      ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Left, 0.5f, &left_node, &right_node); // The second parameter defines the direction of the split
       ImGui::DockBuilderDockWindow("Calibrator Parameters", left_node);
-      ImGui::DockBuilderDockWindow("Calibrator Plot", center_node);
+      ImGui::DockBuilderDockWindow("Calibrator Plot", right_node);
       ImGui::DockBuilderFinish(dockspace_id);
       reset_layout_ = false;
     }


### PR DESCRIPTION
Improving the Calibration Plot:

- All points are displayed: the ones that fit the curve (circle) and the ones that don't fit the curve "outer points" (shape : cross)
- Possibility to hide the curve/points/outer points
- Add some margin on top and right
- Use the zooming feature of the Calibration plot
- Add some details about the curve: the parameters used and the one deducted: transformation_model, transformation_model_param_y_weight, ...

![CalibrationCurve](https://user-images.githubusercontent.com/1705849/150533491-5f485122-dc07-427d-80ed-042b188e5e5b.gif)

