### PR TITLE
Fix/openms compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,9 @@ jobs:
           command: |
             cd ~ &&
             git clone --branch develop --depth 1 https://github.com/OpenMS/OpenMS.git &&
-            cd OpenMS && git submodule update --init THIRDPARTY &&
+            cd OpenMS &&
+            git checkout 7f5009cfbabe74c126eece86f86cb9b7a5e4af62 &&
+            git submodule update --init THIRDPARTY &&
             cmake -DBOOST_USE_STATIC=OFF -DHAS_XSERVER=OFF -DWITH_GUI=OFF -DENABLE_TUTORIALS=OFF -DENABLE_DOCS=OFF -DGIT_TRACKING=OFF -DENABLE_UPDATE_CHECK=OFF -DCMAKE_BUILD_TYPE=Release -DPYOPENMS=OFF -DOPENMS_COVERAGE=OFF ~/OpenMS &&
             make -j4 OpenMS
       - run:
@@ -125,6 +127,7 @@ jobs:
             cd ~ &&
             git clone --branch develop --depth 1 https://github.com/OpenMS/OpenMS.git &&
             cd OpenMS
+            git checkout 7f5009cfbabe74c126eece86f86cb9b7a5e4af62
             mkdir contrib_build && cd contrib_build
             curl -C - -O https://abibuilder.informatik.uni-tuebingen.de/archive/openms/contrib/macOS/10.15.4/x64/appleclang-11.0.0/contrib_build.tar.gz
             tar -xzf contrib_build.tar.gz
@@ -238,8 +241,9 @@ jobs:
           name: Cloning OpenMS - develop
           command: |
             cd ~
-            git clone --branch develop --depth 1 https://github.com/OpenMS/OpenMS.git
+            git clone https://github.com/OpenMS/OpenMS.git
             cd ~/OpenMS
+            git checkout 7f5009cfbabe74c126eece86f86cb9b7a5e4af62
       - run:
           name: Building OpenMS
           command: |
@@ -288,7 +292,6 @@ jobs:
             cmake -DUSE_SUPERBUILD=ON -DCMAKE_BUILD_TYPE=Release ~/SmartPeak
             cmake --build .
             cd ~/SmartPeak/smartpeak_release_build
-            dir C:/Users/circleci/SmartPeak/superbuild/Dependencies/Source/sqlite
             cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CXX_EXTENSIONS=OFF -DCXX_STANDARD_REQUIRED=ON -DEIGEN_USE_GPU=OFF -DUSE_SUPERBUILD=OFF -DBoost_NO_SYSTEM_PATHS=ON -DBOOST_USE_STATIC=ON -DBOOST_ROOT="C:/lib/boost/boost_1_73_0" -DBOOST_INCLUDE_DIR="C:/lib/boost/boost_1_73_0" -DBOOST_LIBRARYDIR="C:/lib/boost/boost_1_73_0/lib64-msvc-14.2" -DCMAKE_PREFIX_PATH="C:/Users/circleci/OpenMS/openms_build/;C:/lib/Qt/qt-5.12.9-dynamic-msvc2019-x86_64;C:/lib/sdl2/SDL2-2.0.12" -DEIGEN3_INCLUDE_DIR=C:/Users/circleci/OpenMS/contrib_build/include/eigen3 -DPLOG_INCLUDE_DIR=C:/Users/circleci/SmartPeak/superbuild/Dependencies/Source/plog/include -DIMGUI_DIR=C:/Users/circleci/SmartPeak/superbuild/Dependencies/Source/imgui -DPORTABLEFILEDIALOGS_DIR=C:/Users/circleci/SmartPeak/superbuild/Dependencies/Source/portablefiledialogs -DSQLite3_INCLUDE_DIR=C:/Users/circleci/SmartPeak/superbuild/Dependencies/Source/sqlite -DSQLite3_LIBRARY=C:/Users/circleci/SmartPeak/superbuild/Dependencies/Source/sqlite -DIMPLOT_DIR=C:/Users/circleci/SmartPeak/superbuild/Dependencies/Source/implot -DCMAKE_BUILD_TYPE=Release ~/SmartPeak
             msbuild src/SmartPeak_src.sln /verbosity:normal /maxcpucount /p:Configuration=Release
             msbuild src/smartpeak/SmartPeak.sln /verbosity:normal /maxcpucount /p:Configuration=Release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Cloning and building OpenMS
           command: |
             cd ~ &&
-            git clone --branch develop --depth 1 https://github.com/OpenMS/OpenMS.git &&
+            git clone https://github.com/OpenMS/OpenMS.git &&
             cd OpenMS &&
             git checkout 7f5009cfbabe74c126eece86f86cb9b7a5e4af62 &&
             git submodule update --init THIRDPARTY &&
@@ -125,7 +125,7 @@ jobs:
           name: Cloning and building OpenMS
           command: |
             cd ~ &&
-            git clone --branch develop --depth 1 https://github.com/OpenMS/OpenMS.git &&
+            git clone https://github.com/OpenMS/OpenMS.git &&
             cd OpenMS
             git checkout 7f5009cfbabe74c126eece86f86cb9b7a5e4af62
             mkdir contrib_build && cd contrib_build


### PR DESCRIPTION
Temprary use a specific commit of openms since the build system has been reworked a little bit, SmartPeak needs further work to be able to compile with the new version of openMS.