### PR TITLE
Removed scan explorer window

### DIFF
--- a/src/examples/source/SmartPeakGUI.cpp
+++ b/src/examples/source/SmartPeakGUI.cpp
@@ -188,7 +188,6 @@ int main(int argc, char** argv)
     "Calibrators");
   auto transitions_explorer_window_ = std::make_shared<ExplorerWidget>("TransitionsExplorerWindow", "Transitions", &event_dispatcher);
   auto features_explorer_window_ = std::make_shared<ExplorerWidget>("FeaturesExplorerWindow", "Features", &event_dispatcher);
-  auto spectrum_explorer_window_ = std::make_shared<ExplorerWidget>("SpectrumExplorerWindow", "Scans", &event_dispatcher);
   auto sequence_main_window_ = std::make_shared<SequenceTableWidget>("SequenceMainWindow", "Sequence",
                                                                       &session_handler_, &application_handler_.sequenceHandler_);
   auto transitions_main_window_ = std::make_shared<GenericTableWidget>("TransitionsMainWindow", "Transitions Table");
@@ -304,8 +303,7 @@ int main(int argc, char** argv)
   split_window.left_windows_ = {
     injections_explorer_window_,
     transitions_explorer_window_,
-    features_explorer_window_,
-    spectrum_explorer_window_
+    features_explorer_window_
   };
 
   std::vector<std::shared_ptr<Widget>> popups = {
@@ -579,7 +577,6 @@ int main(int argc, char** argv)
         if (ImGui::MenuItem("Injections", NULL, &injections_explorer_window_->visible_)) {}
         if (ImGui::MenuItem("Transitions", NULL, &transitions_explorer_window_->visible_)) {}
         if (ImGui::MenuItem("Features", NULL, &features_explorer_window_->visible_)) {}
-        if (ImGui::MenuItem("Scans", NULL, &spectrum_explorer_window_->visible_)) {}
         ImGui::Separator(); // Primary input
         ImGui::MenuItem("Main window (Tables)", NULL, false, false);
         if (ImGui::MenuItem("Sequence", NULL, &sequence_main_window_->visible_)) {}
@@ -874,16 +871,6 @@ int main(int argc, char** argv)
       features_explorer_window_->checked_rows_ = session_handler_.feature_explorer_data.checked_rows;
       features_explorer_window_->checkbox_headers_ = session_handler_.feature_explorer_data.checkbox_headers;
       features_explorer_window_->checkbox_columns_ = &session_handler_.feature_explorer_data.checkbox_body;
-    }
-
-    // spectrum
-    if (spectrum_explorer_window_->visible_)
-    {
-      spectrum_explorer_window_->table_data_.headers_ = session_handler_.getSpectrumExplorerHeader();
-      spectrum_explorer_window_->table_data_.body_ = session_handler_.getSpectrumExplorerBody();
-      spectrum_explorer_window_->checked_rows_ = session_handler_.spectrum_explorer_data.checked_rows;
-      spectrum_explorer_window_->checkbox_headers_ = session_handler_.spectrum_explorer_data.checkbox_headers;
-      spectrum_explorer_window_->checkbox_columns_ = &session_handler_.spectrum_explorer_data.checkbox_body;
     }
 
     // ======================================

--- a/src/smartpeak/include/SmartPeak/core/SessionHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/SessionHandler.h
@@ -249,13 +249,11 @@ namespace SmartPeak
     @param[out] result
     @param[in] range
     @param[in] sample_names
-    @param[in] component_names
     */
     void getChromatogramTIC(const SequenceHandler& sequence_handler,
       GraphVizData& result,
       const std::pair<float, float>& range,
-      const std::set<std::string>& sample_names,
-      const std::set<std::string>& component_names) const;
+      const std::set<std::string>& sample_names) const;
 
     /*
     @brief Gets the XIC chromatogram data
@@ -281,14 +279,12 @@ namespace SmartPeak
     @param[in] result
     @param[in] range
     @param[in] sample_names
-    @param[in] scan_names
     @param[in] component_group_names
     */
     void getSpectrumScatterPlot(const SequenceHandler& sequence_handler,
                                 GraphVizData& result,
                                 const std::pair<float, float>& range,
                                 const std::set<std::string>& sample_names,
-                                const std::set<std::string>& scan_names,
                                 const std::set<std::string>& component_group_names) const;
 
     /*
@@ -298,7 +294,6 @@ namespace SmartPeak
     @param[in] result
     @param[in] range
     @param[in] sample_names
-    @param[in] scan_names
     @param[in] component_group_names
     @param[in] rt
     @param[in] ms_level
@@ -307,7 +302,6 @@ namespace SmartPeak
       GraphVizData& result,
       const std::pair<float, float>& range,
       const std::set<std::string>& sample_names,
-      const std::set<std::string>& scan_names,
       const std::set<std::string>& component_group_names,
       const float rt,
       const int ms_level) const;

--- a/src/smartpeak/source/core/SessionHandler.cpp
+++ b/src/smartpeak/source/core/SessionHandler.cpp
@@ -1721,8 +1721,7 @@ namespace SmartPeak
   void SessionHandler::getChromatogramTIC(const SequenceHandler& sequence_handler,
     GraphVizData& result,
     const std::pair<float, float>& chrom_time_range,
-    const std::set<std::string>& sample_names,
-    const std::set<std::string>& scan_names) const
+    const std::set<std::string>& sample_names) const
   {
     LOGD << "Making the chromatogram TIC data for plotting";
     // Set the axes titles and min/max defaults
@@ -1737,7 +1736,6 @@ namespace SmartPeak
         const auto ms_level = spectrum.getMSLevel();
         if (ms_level == 1)
         {
-          if (scan_names.count(spectrum.getNativeID()) == 0) continue;
           x_data.push_back(spectrum.getRT());
           y_data.push_back(spectrum.calculateTIC());
         }
@@ -1818,10 +1816,9 @@ namespace SmartPeak
     GraphVizData& result,
     const std::pair<float, float>& range,
     const std::set<std::string>& sample_names,
-    const std::set<std::string>& scan_names,
     const std::set<std::string>& component_group_names) const
   {
-    // Notes: native_id matches the spec NativeID (i.e., scan_names), PeptideRef matches the first annotation identifier
+    // Notes: PeptideRef matches the first annotation identifier
     if (sequence_handler.getSequence().size() > 0 &&
        (sequence_handler.getSequence().at(0).getRawData().getExperiment().getSpectra().size() > 0 ||
        sequence_handler.getSequence().at(0).getRawData().getFeatureMapHistory().size() > 0))
@@ -1833,7 +1830,6 @@ namespace SmartPeak
         if (sample_names.count(injection.getMetaData().getSampleName()) == 0) continue;
         // Extract out the raw data for plotting
         for (const auto& spectra : injection.getRawData().getExperiment().getSpectra()) {
-          if (scan_names.count(spectra.getNativeID()) == 0) continue;
           std::vector<float> x_data, y_data;
           for (auto point = spectra.PosBegin(range.first); point != spectra.PosEnd(range.second); ++point) {
             x_data.push_back(point->getMZ());
@@ -1874,7 +1870,6 @@ namespace SmartPeak
     GraphVizData& result,
     const std::pair<float, float>& range,
     const std::set<std::string>& sample_names,
-    const std::set<std::string>& scan_names,
     const std::set<std::string>& component_group_names,
     const float rt,
     const int ms_level) const
@@ -1895,7 +1890,6 @@ namespace SmartPeak
           if (spectra.getMSLevel() == ms_level)
           {
             result.z_data_area_.push_back(spectra.getRT());
-            if (scan_names.count(spectra.getNativeID()) == 0) continue;
             std::vector<float> x_data, y_data;
             const float rt_threashold = 0.50f;
             if ((!result.points_overflow_) && (abs(spectra.getRT()-rt)< rt_threashold))

--- a/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/SessionHandler_test.cpp
@@ -708,9 +708,8 @@ TEST(SessionHandler, setSpectrumScatterPlot1)
   SessionHandler::GraphVizData result;
   const std::pair<float, float> range = std::make_pair(0, 2000);
   const std::set<std::string> sample_names;
-  const std::set<std::string> scan_names;
   const std::set<std::string> component_group_names;
-  session_handler.getSpectrumScatterPlot(testData.application_handler.sequenceHandler_, result, range, sample_names, scan_names, component_group_names);
+  session_handler.getSpectrumScatterPlot(testData.application_handler.sequenceHandler_, result, range, sample_names, component_group_names);
   EXPECT_FALSE(result.points_overflow_);
 }
 TEST(SessionHandler, setCalibratorsScatterLinePlot1)

--- a/src/widgets/include/SmartPeak/ui/ChromatogramTICPlotWidget.h
+++ b/src/widgets/include/SmartPeak/ui/ChromatogramTICPlotWidget.h
@@ -72,7 +72,6 @@ namespace SmartPeak
   protected:
     // input used to create the graph
     std::set<std::string> input_sample_names_;
-    std::set<std::string> input_scan_names_;
     std::shared_ptr<SpectraMSMSPlotWidget> spectra_msms_plot_widget_;
   };
 }

--- a/src/widgets/include/SmartPeak/ui/GraphicDataVizWidget.h
+++ b/src/widgets/include/SmartPeak/ui/GraphicDataVizWidget.h
@@ -86,7 +86,6 @@ namespace SmartPeak
     // Utility methods
     std::set<std::string> getSelectedSampleNames() const;
     std::set<std::string> getSelectedTransitions() const;
-    std::set<std::string> getSelectedSpectrum() const;
     std::set<std::string> getSelectedTransitionGroups() const;
     std::optional<float>  getNearestPoint(float in_x) const;
 

--- a/src/widgets/source/ui/ChromatogramTICPlotWidget.cpp
+++ b/src/widgets/source/ui/ChromatogramTICPlotWidget.cpp
@@ -36,16 +36,14 @@ namespace SmartPeak
     }
 
     const std::set<std::string> sample_names = getSelectedSampleNames();
-    const std::set<std::string> scan_names = getSelectedSpectrum();
 
     if ((refresh_needed_) || // data changed
-       ((input_scan_names_ != scan_names) || (input_sample_names_ != sample_names))) // user select different items
+       (input_sample_names_ != sample_names)) // user select different items
     {
       // get the whole graph area
-      session_handler_.getChromatogramTIC(sequence_handler_, graph_viz_data_, std::make_pair(0, 1800), sample_names, scan_names);
+      session_handler_.getChromatogramTIC(sequence_handler_, graph_viz_data_, std::make_pair(0, 1800), sample_names);
       updateRanges();
       input_sample_names_ = sample_names;
-      input_scan_names_ = scan_names;
       refresh_needed_ = false;
     }
     graph_viz_data_.y_min_ = 0.0f; // bottom line will start from 0.0

--- a/src/widgets/source/ui/GraphicDataVizWidget.cpp
+++ b/src/widgets/source/ui/GraphicDataVizWidget.cpp
@@ -252,17 +252,6 @@ namespace SmartPeak
     return transitions_names;
   }
 
-  std::set<std::string> GraphicDataVizWidget::getSelectedSpectrum() const
-  {
-    std::set<std::string> scan_names;
-    Eigen::Tensor<std::string, 1> selected_scans = session_handler_.getSelectSpectrumPlot();
-    for (int i = 0; i < selected_scans.size(); ++i) {
-      if (!selected_scans(i).empty())
-        scan_names.insert(selected_scans(i));
-    }
-    return scan_names;
-  }
-
   std::set<std::string> GraphicDataVizWidget::getSelectedTransitionGroups() const
   {
     std::set<std::string> component_group_names;

--- a/src/widgets/source/ui/SpectraMSMSPlotWidget.cpp
+++ b/src/widgets/source/ui/SpectraMSMSPlotWidget.cpp
@@ -37,12 +37,11 @@ namespace SmartPeak
     }
 
     const std::set<std::string> sample_names = getSelectedSampleNames();    
-    const std::set<std::string> scan_names = getSelectedSpectrum();
     const std::set<std::string> component_group_names = getSelectedTransitionGroups();
 
     static const auto init_range = std::make_pair(0, 2000);
     if ((refresh_needed_) || // data changed
-       ((input_sample_names_ != sample_names) || (input_scan_names_ != scan_names) || (input_component_group_names_ != component_group_names)) || // user select different items
+       ((input_sample_names_ != sample_names) || (input_component_group_names_ != component_group_names)) || // user select different items
        (input_z_ != current_z_) // user select different rt
        ) 
     {
@@ -51,10 +50,9 @@ namespace SmartPeak
       {
         current_rt_ = graph_viz_data_.z_data_area_[current_z_];
       }
-      session_handler_.getSpectrumMSMSPlot(sequence_handler_, graph_viz_data_, init_range, sample_names, scan_names, component_group_names, current_rt_, ms_level_);
+      session_handler_.getSpectrumMSMSPlot(sequence_handler_, graph_viz_data_, init_range, sample_names, component_group_names, current_rt_, ms_level_);
       updateRanges();
       input_sample_names_ = sample_names;
-      input_scan_names_ = scan_names;
       input_component_group_names_ = component_group_names;
       current_z_ = getScanIndexFromRetentionTime(current_rt_);
       input_z_ = current_z_;

--- a/src/widgets/source/ui/SpectraPlotWidget.cpp
+++ b/src/widgets/source/ui/SpectraPlotWidget.cpp
@@ -29,17 +29,15 @@ namespace SmartPeak
   void SpectraPlotWidget::updateData()
   {
     const std::set<std::string> sample_names = getSelectedSampleNames();
-    const std::set<std::string> scan_names = getSelectedSpectrum();
     const std::set<std::string> component_group_names = getSelectedTransitionGroups();
 
     if ((refresh_needed_) || // data changed
-       ((input_sample_names_ != sample_names) || (input_scan_names_ != scan_names) || (input_component_group_names_ != component_group_names))) // user select different items
+       ((input_sample_names_ != sample_names) || (input_component_group_names_ != component_group_names))) // user select different items
     {
       // get the whole graph area
-      session_handler_.getSpectrumScatterPlot(sequence_handler_, graph_viz_data_, std::make_pair(0, 2000), sample_names, scan_names, component_group_names);
+      session_handler_.getSpectrumScatterPlot(sequence_handler_, graph_viz_data_, std::make_pair(0, 2000), sample_names, component_group_names);
       updateRanges();
       input_sample_names_ = sample_names;
-      input_scan_names_ = scan_names;
       input_component_group_names_ = component_group_names;
       refresh_needed_ = false;
     }


### PR DESCRIPTION
The scan explorer window actually introduces inconsistency. The user can select scan to plot, but there is no way to determine which sample this scan belongs to. To fix that we would need to add multiple controls that would complicate the user path.
in the end, in 99% of the cases, the user just wants to plot the whole scan. so we just remove that window and consider all scans being selected by the user and to be plotted.

