### PR TITLE
Fix/missing report metadata values

### DIFF
--- a/src/smartpeak/include/SmartPeak/core/Utilities.h
+++ b/src/smartpeak/include/SmartPeak/core/Utilities.h
@@ -111,6 +111,16 @@ public:
     );
 
     /**
+      Convert a OpenMS::DataValue to SmartPeak's CastValue.
+
+      @param[in] openms_datavalue OpenMSDataValue to convert
+      @return SmartPeak's CastValue
+    */
+    static CastValue OpenMSDataValueToCastValue(
+      const OpenMS::DataValue& openms_datavalue
+    );
+
+    /**
       Parse string and return the eval.
 
       The type check is case insensitive.

--- a/src/smartpeak/source/core/SequenceHandler.cpp
+++ b/src/smartpeak/source/core/SequenceHandler.cpp
@@ -24,6 +24,7 @@
 #include <SmartPeak/core/CastValue.h>
 #include <SmartPeak/core/MetaDataHandler.h>
 #include <SmartPeak/core/SequenceHandler.h>
+#include <SmartPeak/core/Utilities.h>
 #include <plog/Log.h>
 
 namespace SmartPeak
@@ -307,14 +308,13 @@ namespace SmartPeak
     } else if (meta_value == "validation") { // The result of the validation
       cast = static_cast<std::string>(subordinate.getMetaValue(meta_value)); // Prioritize the subordinate over the feature
     } else if (subordinate.metaValueExists(meta_value) && !subordinate.getMetaValue(meta_value).isEmpty()) {
-      cast = static_cast<float>(subordinate.getMetaValue(meta_value));
+      cast = Utilities::OpenMSDataValueToCastValue(subordinate.getMetaValue(meta_value));
     } else if (feature.metaValueExists(meta_value) && !feature.getMetaValue(meta_value).isEmpty()) {
-      cast = static_cast<float>(feature.getMetaValue(meta_value));
+      cast = Utilities::OpenMSDataValueToCastValue(feature.getMetaValue(meta_value));
     } else {
       LOGV << "meta_value not found: " << meta_value;
       cast = "";
     }
-
     return cast;
   }
 

--- a/src/smartpeak/source/core/Utilities.cpp
+++ b/src/smartpeak/source/core/Utilities.cpp
@@ -251,6 +251,57 @@ namespace SmartPeak
     }
   }
 
+  CastValue Utilities::OpenMSDataValueToCastValue(
+    const OpenMS::DataValue& openms_datavalue
+  )
+  {
+    CastValue cast;
+    switch (openms_datavalue.valueType())
+    {
+    case OpenMS::DataValue::DataType::INT_VALUE:
+      cast = static_cast<int>(openms_datavalue);
+      break;
+    case OpenMS::DataValue::DataType::DOUBLE_VALUE:
+      cast = static_cast<float>(openms_datavalue);
+      break;
+    case OpenMS::DataValue::DataType::EMPTY_VALUE:
+      cast = static_cast<float>(openms_datavalue);
+      break;
+    case OpenMS::DataValue::DataType::INT_LIST:
+      cast = openms_datavalue.toIntList();
+      break;
+    case OpenMS::DataValue::DataType::DOUBLE_LIST:
+    {
+      auto openms_list = openms_datavalue.toDoubleList();
+      std::vector<float> float_list;
+      for (const auto& v : openms_list)
+      {
+        float_list.push_back(v);
+      }
+      cast = float_list;
+      break;
+    }
+    case OpenMS::DataValue::DataType::STRING_LIST:
+    {
+      auto openms_list = openms_datavalue.toStringList();
+      std::vector<std::string> string_list;
+      for (const auto& v : openms_list)
+      {
+        string_list.push_back(v);
+      }
+      cast = string_list;
+      break;
+    }
+    case OpenMS::DataValue::DataType::STRING_VALUE:
+      cast = static_cast<std::string>(openms_datavalue);
+      break;
+    default:
+      cast = static_cast<float>(openms_datavalue);
+      break;
+    }
+    return cast;
+  }
+
   bool Utilities::isList(const std::string& str, const std::regex& re)
   {
     auto items = Utilities::splitString(str, ',');

--- a/src/smartpeak/source/core/Utilities.cpp
+++ b/src/smartpeak/source/core/Utilities.cpp
@@ -264,9 +264,6 @@ namespace SmartPeak
     case OpenMS::DataValue::DataType::DOUBLE_VALUE:
       cast = static_cast<float>(openms_datavalue);
       break;
-    case OpenMS::DataValue::DataType::EMPTY_VALUE:
-      cast = static_cast<float>(openms_datavalue);
-      break;
     case OpenMS::DataValue::DataType::INT_LIST:
       cast = openms_datavalue.toIntList();
       break;
@@ -296,7 +293,6 @@ namespace SmartPeak
       cast = static_cast<std::string>(openms_datavalue);
       break;
     default:
-      cast = static_cast<float>(openms_datavalue);
       break;
     }
     return cast;

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -687,13 +687,21 @@ namespace SmartPeak
             else 
             {
               CastValue datum = SequenceHandler::getMetaValue(feature, feature, meta_value_name);
-              if (datum.getTag() == CastValue::Type::FLOAT && datum.f_ != 0.0) {
-                // NOTE: to_string() rounds at 1e-6. Therefore, some precision might be lost.
-                row.push_back(std::to_string(datum.f_));
-              }
-              else 
+              if (datum.getTag() == CastValue::Type::FLOAT)
               {
-                row.push_back("");
+                if (datum.f_ != 0.0)
+                {
+                  // NOTE: to_string() rounds at 1e-6. Therefore, some precision might be lost.
+                  row.push_back(std::to_string(datum.f_));
+                }
+                else
+                {
+                  row.push_back("");
+                }
+              }
+              else
+              {
+                row.push_back(std::string(datum));
               }
             }
           }
@@ -752,13 +760,21 @@ namespace SmartPeak
             else 
             {
               CastValue datum = SequenceHandler::getMetaValue(feature, subordinate, meta_value_name);
-              if (datum.getTag() == CastValue::Type::FLOAT && datum.f_ != 0.0) {
-                // NOTE: to_string() rounds at 1e-6. Therefore, some precision might be lost.
-                row.push_back(std::to_string(datum.f_));
-              } 
-              else 
+              if (datum.getTag() == CastValue::Type::FLOAT)
               {
-                row.push_back("");
+                if (datum.f_ != 0.0)
+                {
+                  // NOTE: to_string() rounds at 1e-6. Therefore, some precision might be lost.
+                  row.push_back(std::to_string(datum.f_));
+                }
+                else
+                {
+                  row.push_back("");
+                }
+              }
+              else
+              {
+                row.push_back(std::string(datum));
               }
             }
           }

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -829,13 +829,21 @@ namespace SmartPeak
           for (const std::string& meta_value_name : meta_data)
           {
             CastValue datum = SequenceHandler::getMetaValue(feature, feature, meta_value_name);
-            if (datum.getTag() == CastValue::Type::FLOAT && datum.f_ != 0.0) {
-              // NOTE: to_string() rounds at 1e-6. Therefore, some precision might be lost.
-              row.push_back(std::to_string(datum.f_));
+            if (datum.getTag() == CastValue::Type::FLOAT)
+            {
+              if (datum.f_ != 0.0)
+              {
+                // NOTE: to_string() rounds at 1e-6. Therefore, some precision might be lost.
+                row.push_back(std::to_string(datum.f_));
+              }
+              else
+              {
+                row.push_back("");
+              }
             }
             else
             {
-              row.push_back("");
+              row.push_back(std::string(datum));
             }
           }
           rows_out.push_back(row);
@@ -861,13 +869,21 @@ namespace SmartPeak
           for (const std::string& meta_value_name : meta_data)
           {
             CastValue datum = SequenceHandler::getMetaValue(feature, subordinate, meta_value_name);
-            if (datum.getTag() == CastValue::Type::FLOAT && datum.f_ != 0.0) {
-              // NOTE: to_string() rounds at 1e-6. Therefore, some precision might be lost.
-              row.push_back(std::to_string(datum.f_));
+            if (datum.getTag() == CastValue::Type::FLOAT)
+            {
+              if (datum.f_ != 0.0)
+              {
+                // NOTE: to_string() rounds at 1e-6. Therefore, some precision might be lost.
+                row.push_back(std::to_string(datum.f_));
+              }
+              else
+              {
+                row.push_back("");
+              }
             }
             else
             {
-              row.push_back("");
+              row.push_back(std::string(datum));
             }
           }
           rows_out.push_back(row);

--- a/src/smartpeak/source/io/SequenceParser.cpp
+++ b/src/smartpeak/source/io/SequenceParser.cpp
@@ -1044,6 +1044,12 @@ namespace SmartPeak
               columns.insert(sample_name);
               rows.insert(row_tuple_name);
             }
+            else
+            {
+              data_dict[sample_name].emplace(row_tuple_name, 0.0f);
+              columns.insert(sample_name);
+              rows.insert(row_tuple_name);
+            }
           }
 
           // Case #2 Features and subordinates
@@ -1075,6 +1081,12 @@ namespace SmartPeak
             }
             if (datum.getTag() == CastValue::Type::FLOAT && !std::isnan(datum.f_)) { // Skip NAN (replaced by 0 later)
               data_dict[sample_name].emplace(row_tuple_name, datum.f_);
+              columns.insert(sample_name);
+              rows.insert(row_tuple_name);
+            }
+            else
+            {
+              data_dict[sample_name].emplace(row_tuple_name, 0.0f);
               columns.insert(sample_name);
               rows.insert(row_tuple_name);
             }
@@ -1213,6 +1225,12 @@ namespace SmartPeak
               columns.insert(sample_name);
               rows.insert(row_tuple_name);
             }
+            else
+            {
+              data_dict[sample_name].emplace(row_tuple_name, 0.0f);
+              columns.insert(sample_name);
+              rows.insert(row_tuple_name);
+            }
           }
 
           // Case #2 Features and subordinates
@@ -1238,6 +1256,12 @@ namespace SmartPeak
             }
             if (datum.getTag() == CastValue::Type::FLOAT && !std::isnan(datum.f_)) { // Skip NAN (replaced by 0 later)
               data_dict[sample_name].emplace(row_tuple_name, datum.f_);
+              columns.insert(sample_name);
+              rows.insert(row_tuple_name);
+            }
+            else
+            {
+              data_dict[sample_name].emplace(row_tuple_name, 0.0f);
               columns.insert(sample_name);
               rows.insert(row_tuple_name);
             }

--- a/src/tests/class_tests/smartpeak/source/Utilities_test.cpp
+++ b/src/tests/class_tests/smartpeak/source/Utilities_test.cpp
@@ -833,7 +833,7 @@ TEST(utilities, checkCSVHeader)
   EXPECT_FALSE(Utilities::checkCSVHeader<';'>(filename, "sample_name", "non_existing_column", "sample_group_name"));
 }
 
-TEST(ParametersParser, hasBOMMarker)
+TEST(utilities, hasBOMMarker)
 {
   const string pathname_no_bom = SMARTPEAK_GET_TEST_DATA_PATH("FileReader_parameters.csv");
   EXPECT_FALSE(Utilities::hasBOMMarker(pathname_no_bom));
@@ -855,11 +855,60 @@ TEST(ParametersParser, hasBOMMarker)
 }
 
 
-TEST(Filenames, replaceAll)
+TEST(utilities, replaceAll)
 {
   std::string str = "apple strawberry apple peach ";
   auto result1 = Utilities::replaceAll(str, "apple", "banana");
   EXPECT_EQ(result1, "banana strawberry banana peach ");
   auto result2 = Utilities::replaceAll(str, "not found", "banana");
   EXPECT_EQ(result2, "apple strawberry apple peach ");
+}
+
+TEST(utilities, OpenMSDataValueToCastValue)
+{
+  OpenMS::DataValue v_int(42);
+  auto c_int = Utilities::OpenMSDataValueToCastValue(v_int);
+  EXPECT_EQ(c_int.getTag(), CastValue::Type::INT);
+  EXPECT_EQ(c_int.i_, 42);
+
+  std::vector<int> int_list{ 42, 43, 44 };
+  OpenMS::DataValue v_int_list(int_list);
+  auto c_int_list = Utilities::OpenMSDataValueToCastValue(v_int_list);
+  EXPECT_EQ(c_int_list.getTag(), CastValue::Type::INT_LIST);
+  for (int i=0; i< c_int_list.il_.size(); ++i)
+  {
+    EXPECT_EQ(c_int_list.il_.at(i), int_list.at(i));
+  }
+
+  OpenMS::DataValue v_double(3.14);
+  auto c_double = Utilities::OpenMSDataValueToCastValue(v_double);
+  EXPECT_EQ(c_double.getTag(), CastValue::Type::FLOAT);
+  EXPECT_FLOAT_EQ(c_double.f_, 3.14);
+
+  std::vector<double> double_list{ 3.14, 13.14, 103.14 };
+  OpenMS::DataValue v_double_list(double_list);
+  auto c_double_list = Utilities::OpenMSDataValueToCastValue(double_list);
+  EXPECT_EQ(c_double_list.getTag(), CastValue::Type::FLOAT_LIST);
+  for (int i = 0; i < c_double_list.il_.size(); ++i)
+  {
+    EXPECT_FLOAT_EQ(c_double_list.fl_.at(i), double_list.at(i));
+  }
+
+  OpenMS::DataValue v_string("apple");
+  auto c_string = Utilities::OpenMSDataValueToCastValue(v_string);
+  EXPECT_EQ(c_string.getTag(), CastValue::Type::STRING);
+  EXPECT_EQ(c_string.s_, "apple");
+
+  std::vector<std::string> string_list{ "apple", "banana", "strawberry"};
+  OpenMS::DataValue v_string_list(string_list);
+  auto c_string_list = Utilities::OpenMSDataValueToCastValue(v_string_list);
+  EXPECT_EQ(c_string_list.getTag(), CastValue::Type::STRING_LIST);
+  for (int i = 0; i < c_string_list.sl_.size(); ++i)
+  {
+    EXPECT_EQ(c_string_list.sl_.at(i), string_list.at(i));
+  }
+
+  OpenMS::DataValue v_empty;
+  auto c_empty = Utilities::OpenMSDataValueToCastValue(v_empty);
+  EXPECT_EQ(c_empty.getTag(), CastValue::Type::UNINITIALIZED);
 }


### PR DESCRIPTION
When creating reports, some metadata values are empty like chemical_formula, description, modification ...
we only considered the float conversion of metadata values which in some case contain strings.
