### PR TITLE
Added option to display only spectrogram data that contains convexhull

### DIFF
--- a/src/smartpeak/include/SmartPeak/core/SessionHandler.h
+++ b/src/smartpeak/include/SmartPeak/core/SessionHandler.h
@@ -297,6 +297,7 @@ namespace SmartPeak
     @param[in] component_group_names
     @param[in] rt
     @param[in] ms_level
+    @param[in] has_convex_hull_only
     */
     void getSpectrumMSMSPlot(const SequenceHandler& sequence_handler,
       GraphVizData& result,
@@ -304,7 +305,8 @@ namespace SmartPeak
       const std::set<std::string>& sample_names,
       const std::set<std::string>& component_group_names,
       const float rt,
-      const int ms_level) const;
+      const int ms_level,
+      const bool has_convex_hull_only) const;
 
     void setFeatureLinePlot();
 

--- a/src/widgets/include/SmartPeak/ui/GraphicDataVizWidget.h
+++ b/src/widgets/include/SmartPeak/ui/GraphicDataVizWidget.h
@@ -64,6 +64,8 @@ namespace SmartPeak
 
     void draw() override;
 
+    virtual void drawHeaderButtons();
+
     /**
       IPropertiesHandler
     */

--- a/src/widgets/include/SmartPeak/ui/SpectraMSMSPlotWidget.h
+++ b/src/widgets/include/SmartPeak/ui/SpectraMSMSPlotWidget.h
@@ -62,6 +62,7 @@ namespace SmartPeak
     */
     virtual void setMarkerPosition(const std::optional<float>& marker_position) override;
     virtual std::optional<float> getMarkerPosition() const override;
+    virtual void drawHeaderButtons() override;
 
     /**
       ISequenceObserver
@@ -74,18 +75,15 @@ namespace SmartPeak
   protected:
     virtual void updateData() override;
 
-  private:
-    int getScanIndexFromRetentionTime(const float& retention_time) const;
-
   protected:
     // input used to create the graph
     std::set<std::string> input_sample_names_;
     std::set<std::string> input_scan_names_;
     std::set<std::string> input_component_group_names_;
-    int input_z_ = 0;
     std::shared_ptr<ChromatogramXICPlotWidget> chromatogram_xic_widget_;
     int ms_level_;
     float current_rt_ = 0.0f;
+    bool has_convex_hull_ = false; // only show items that have convex hull attached
   };
 
 }

--- a/src/widgets/source/ui/GraphicDataVizWidget.cpp
+++ b/src/widgets/source/ui/GraphicDataVizWidget.cpp
@@ -28,6 +28,17 @@
 
 namespace SmartPeak
 {
+  void GraphicDataVizWidget::drawHeaderButtons()
+  {
+    ImGui::Checkbox("Compact View", &compact_view_);
+    ImGui::SameLine();
+    ImGui::Checkbox("Legend", &show_legend_);
+    ImGui::SameLine();
+    if (ImGui::Button("Fit Zoom"))
+    {
+      update_plot_range_ = true;
+    }
+  }
 
   void GraphicDataVizWidget::draw()
   {
@@ -38,15 +49,7 @@ namespace SmartPeak
 
   void GraphicDataVizWidget::drawGraphHeader()
   {
-    float controls_pos_start_y = ImGui::GetCursorPosY();
-    ImGui::Checkbox("Compact View", &compact_view_);
-    ImGui::SameLine();
-    ImGui::Checkbox("Legend", &show_legend_);
-    ImGui::SameLine();
-    if (ImGui::Button("Fit Zoom"))
-    {
-      update_plot_range_ = true;
-    }
+    drawHeaderButtons();
 
     static FilePicker file_picker_;
     


### PR DESCRIPTION
Filtering out the spectra peaks that don't have convex hull attached.
the current algorithm is very simple, and it could be improved in performance but it seems to actually work well enough like this.

![image](https://user-images.githubusercontent.com/1705849/177217793-b255171c-5aef-4aab-82e4-5ccef2493d14.png)

![image](https://user-images.githubusercontent.com/1705849/177217777-773aff8b-dc45-4aba-9897-d089fb426dce.png)

