### PR TITLE
Set focus on the first declared windows in the workflow preset

### DIFF
--- a/src/widgets/include/SmartPeak/ui/SplitWindow.h
+++ b/src/widgets/include/SmartPeak/ui/SplitWindow.h
@@ -60,8 +60,9 @@ namespace SmartPeak
 
   protected:
     void showWindows(const std::vector<std::tuple<std::shared_ptr<Widget>, bool>>&windows);
+    void focusFirstWindow(const std::vector<std::tuple<std::shared_ptr<Widget>, bool>>& windows);
     bool reset_layout_ = true;
     std::map<std::string, std::vector<std::tuple<std::shared_ptr<Widget>, bool>>> current_layout_;
-    std::map<std::string, std::vector<std::tuple<std::shared_ptr<Widget>, bool>>> new_layout;
+    std::map<std::string, std::vector<std::tuple<std::shared_ptr<Widget>, bool>>> new_layout_;
   };
 }


### PR DESCRIPTION
For example, for HPLC_UV_Unkowns,
statistics and transitions will be focused

![image](https://user-images.githubusercontent.com/1705849/215270298-60b75077-740e-43a8-849a-f2e612ccd1a5.png)


